### PR TITLE
fix(dts): play DTS-HD HRA via the core instead of failing the track

### DIFF
--- a/dca/src/dcadec/exss.rs
+++ b/dca/src/dcadec/exss.rs
@@ -114,6 +114,13 @@ impl ExssParser {
     pub(crate) fn substream_size(&self) -> usize {
         self.exss_size
     }
+
+    /// True when the (single) audio asset carries an XLL component — i.e. this is
+    /// DTS-HD Master Audio (lossless). False for HRA / lossy-extension streams,
+    /// which have only a core plus an XBR/X96/etc component.
+    pub(crate) fn has_xll(&self) -> bool {
+        self.asset.extension_mask & DCA_EXSS_XLL != 0
+    }
 }
 
 impl ExssParser {
@@ -347,10 +354,15 @@ impl ExssParser {
         let mut offs = a.asset_offset;
         let mut size = a.asset_size as isize;
 
-        // We only retain CORE and XLL component sizes. XBR/XXCH/X96/LBR would sit
-        // between them and shift the XLL offset; reject if present rather than
-        // miscompute. (Ex Machina uses CORE+XLL or XLL-only, no intervening exts.)
-        if a.extension_mask & (DCA_EXSS_XBR | DCA_EXSS_XXCH | DCA_EXSS_X96 | DCA_EXSS_LBR) != 0 {
+        // We only retain CORE and XLL component sizes. When XLL is present, an
+        // intervening XBR/XXCH/X96/LBR component would sit before it and shift the
+        // XLL offset; reject rather than miscompute. When there is NO XLL (e.g.
+        // DTS-HD HRA, which carries CORE + a lossy XBR extension), nothing reads
+        // the XLL offset, so let the EXSS parse succeed — the caller falls back to
+        // the DTS core for these.
+        if a.extension_mask & DCA_EXSS_XLL != 0
+            && a.extension_mask & (DCA_EXSS_XBR | DCA_EXSS_XXCH | DCA_EXSS_X96 | DCA_EXSS_LBR) != 0
+        {
             return Err(ExssError::Unsupported("intervening EXSS extension before XLL"));
         }
 

--- a/dca/src/hd.rs
+++ b/dca/src/hd.rs
@@ -52,6 +52,14 @@ pub fn exss_substream_size(data: &[u8]) -> Option<usize> {
     ExssParser::parse(data).ok().map(|p| p.substream_size())
 }
 
+/// True when the EXSS at `data` carries an XLL (DTS-HD MA, lossless) asset, i.e.
+/// [`HdDecoder`] can reconstruct the lossless bed. DTS-HD HRA and other lossy
+/// extensions parse but expose no XLL asset; callers should decode the DTS core
+/// instead for those.
+pub fn exss_has_xll(data: &[u8]) -> bool {
+    ExssParser::parse(data).map(|p| p.has_xll()).unwrap_or(false)
+}
+
 #[derive(Default)]
 pub struct HdDecoder {
     core: CoreDecoder,

--- a/dca/src/lib.rs
+++ b/dca/src/lib.rs
@@ -23,6 +23,6 @@ pub use parser::{
     AudioMode, FrameInfo, ParseError as HeaderParseError, SYNCWORD_CORE_BE, SYNCWORD_SUBSTREAM,
     parse_header,
 };
-pub use hd::{exss_substream_size, HdDecoder, HdError, HdFrame};
+pub use hd::{exss_has_xll, exss_substream_size, HdDecoder, HdError, HdFrame};
 pub use pcm::{CorePcmFrame, DecodeError, PcmDecoder, PcmPushResult, bed_layout};
 pub use types::BedChannel;

--- a/src/dts_pipeline.rs
+++ b/src/dts_pipeline.rs
@@ -9,7 +9,7 @@
 use abi_stable::std_types::{RString, RVec};
 use bridge_api::{RChannelLabel, RDecodedFrame};
 use bridge_api::RPushResult;
-use dca::{exss_substream_size, parse_header, CorePcmFrame, HdError, HdFrame};
+use dca::{exss_has_xll, exss_substream_size, parse_header, CorePcmFrame, HdError, HdFrame};
 
 use crate::bridge::AtmosBridge;
 use crate::frame_builders::float_to_pcm_i32;
@@ -54,24 +54,48 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
             if rest.len() < fs + es {
                 break;
             }
-            let base = bridge.total_samples;
-            match bridge.dts_hd_decoder.decode(&rest[..fs], &rest[fs..fs + es]) {
-                Ok(hd) => {
-                    let n = hd_samples(&hd);
-                    result.frames.push(build_hd_frame(&hd));
-                    bridge.total_samples += n as u64;
-                    bridge.dts_frame_count += 1;
+            if exss_has_xll(&rest[fs..fs + es]) {
+                let base = bridge.total_samples;
+                match bridge.dts_hd_decoder.decode(&rest[..fs], &rest[fs..fs + es]) {
+                    Ok(hd) => {
+                        let n = hd_samples(&hd);
+                        result.frames.push(build_hd_frame(&hd));
+                        bridge.total_samples += n as u64;
+                        bridge.dts_frame_count += 1;
+                    }
+                    Err(HdError::Pending) => {} // PBR buffering; no frame this packet
+                    Err(e) => {
+                        let msg = format!("dts_hd_decode_error={e:?}");
+                        log::warn!("{msg}");
+                        let _ = base;
+                        if bridge.strict {
+                            result.error_message = RString::from(msg);
+                            bridge.reset_pipeline();
+                            result.did_reset = true;
+                            return;
+                        }
+                    }
                 }
-                Err(HdError::Pending) => {} // PBR buffering; no frame this packet
-                Err(e) => {
-                    let msg = format!("dts_hd_decode_error={e:?}");
-                    log::warn!("{msg}");
-                    let _ = base;
-                    if bridge.strict {
-                        result.error_message = RString::from(msg);
-                        bridge.reset_pipeline();
-                        result.did_reset = true;
-                        return;
+            } else {
+                // No XLL asset: DTS-HD HRA (and other lossy EXSS extensions) layer
+                // only high-frequency detail on top of an ordinary DTS core. We do
+                // not decode that extension, so render the core (5.1) and drop it,
+                // instead of failing the whole track.
+                match bridge.dts_decoder.push_access_unit(&rest[..fs]) {
+                    Ok(push) => {
+                        result.frames.push(build_core_frame(&push.pcm));
+                        bridge.total_samples += push.pcm.samples_per_channel() as u64;
+                        bridge.dts_frame_count += 1;
+                    }
+                    Err(err) => {
+                        let msg = format!("dts_decode_error={err}");
+                        log::warn!("{msg}");
+                        if bridge.strict {
+                            result.error_message = RString::from(msg);
+                            bridge.reset_pipeline();
+                            result.did_reset = true;
+                            return;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
DTS-HD HRA carries an ordinary DTS core plus a lossy XBR extension and **no XLL asset**. `ExssParser::set_exss_offsets` rejected any non-XLL extension outright, so `exss_substream_size` returned `None`, the pipeline stalled (0 frames) and aborted with "sending on a closed channel" — the track was silent / unplayable.

## Fixes
- **`dca` exss**: only reject an intervening XBR/XXCH/X96/LBR component when XLL is actually present (it would shift the XLL offset). With no XLL, nothing reads that offset, so let the EXSS parse succeed.
- **`dca::exss_has_xll()`**: new helper to distinguish MA (XLL) from HRA / lossy-extension streams.
- **`dts_pipeline`**: route no-XLL HD frames to the plain DTS core decoder (5.1), dropping the unsupported lossy extension, instead of failing the track.

## Result
HRA now decodes at DTS core quality (5.1); DTS-HD **MA** still uses the lossless XLL path (verified, no regression). `dca` + `harletty-bridge` test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)