### PR TITLE
ci: gate pushes and PRs on build + tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,23 @@
-name: Release
+name: CI
+
+# Integration gate on every push/PR to main: build with warnings denied and
+# run the full test suite. Introduced as phase 1 of the channel/object
+# contract (Omniphony docs/channel-object-contract.md) — the previous
+# `ci.yml` was in fact the tag-triggered Release bundle (now
+# `release.yml`), so branch pushes ran no CI at all.
+#
+# `cargo fmt --check` is intentionally not gated yet: the tree predates
+# rustfmt and a whole-repo reformat would conflict with the in-flight
+# `research/spatial-object-layer` branch. Gate it after that branch lands.
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  build-linux:
+  test-linux:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -25,123 +36,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build (release)
-        run: cargo build --release
+      - name: Build
+        run: cargo build --all-targets
         working-directory: harletty-bridge
         env:
           RUSTFLAGS: -D warnings
 
-      - name: Package (zip)
-        run: |
-          cd harletty-bridge/target/release
-          zip "harletty-bridge-${GITHUB_REF_NAME}-linux-x86_64.zip" libharletty_bridge.so
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: harletty-bridge-linux-x86_64
-          path: harletty-bridge/target/release/harletty-bridge-*-linux-x86_64.zip
-
-  build-windows:
-    runs-on: windows-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-    steps:
-      - name: Checkout harletty-bridge
-        uses: actions/checkout@v4
-        with:
-          path: harletty-bridge
-
-      - name: Checkout Omniphony (path dependencies)
-        uses: actions/checkout@v4
-        with:
-          repository: mgth/Omniphony
-          path: Omniphony
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build (release)
-        run: cargo build --release
+      - name: Test
+        run: cargo test
         working-directory: harletty-bridge
         env:
           RUSTFLAGS: -D warnings
-
-      - name: Package (zip)
-        run: |
-          cd harletty-bridge/target/release
-          Compress-Archive -Path harletty_bridge.dll -DestinationPath "harletty-bridge-${env:GITHUB_REF_NAME}-windows-x86_64.zip"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: harletty-bridge-windows-x86_64
-          path: harletty-bridge/target/release/harletty-bridge-*-windows-x86_64.zip
-
-  build-macos:
-    runs-on: macos-14
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-    steps:
-      - name: Checkout harletty-bridge
-        uses: actions/checkout@v4
-        with:
-          path: harletty-bridge
-
-      - name: Checkout Omniphony (path dependencies)
-        uses: actions/checkout@v4
-        with:
-          repository: mgth/Omniphony
-          path: Omniphony
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build (release)
-        run: cargo build --release
-        working-directory: harletty-bridge
-        env:
-          RUSTFLAGS: -D warnings
-
-      - name: Package (zip)
-        run: |
-          cd harletty-bridge/target/release
-          zip "harletty-bridge-${GITHUB_REF_NAME}-macos-arm64.zip" libharletty_bridge.dylib
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: harletty-bridge-macos-arm64
-          path: harletty-bridge/target/release/harletty-bridge-*-macos-arm64.zip
-
-  release:
-    needs: [build-linux, build-windows, build-macos]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-    steps:
-      - name: Download Linux artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: harletty-bridge-linux-x86_64
-
-      - name: Download Windows artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: harletty-bridge-windows-x86_64
-
-      - name: Download macOS artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: harletty-bridge-macos-arm64
-
-      - name: Create draft release
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          files: |
-            harletty-bridge-*-linux-x86_64.zip
-            harletty-bridge-*-windows-x86_64.zip
-            harletty-bridge-*-macos-arm64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,147 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Checkout harletty-bridge
+        uses: actions/checkout@v4
+        with:
+          path: harletty-bridge
+
+      - name: Checkout Omniphony (path dependencies)
+        uses: actions/checkout@v4
+        with:
+          repository: mgth/Omniphony
+          path: Omniphony
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build (release)
+        run: cargo build --release
+        working-directory: harletty-bridge
+        env:
+          RUSTFLAGS: -D warnings
+
+      - name: Package (zip)
+        run: |
+          cd harletty-bridge/target/release
+          zip "harletty-bridge-${GITHUB_REF_NAME}-linux-x86_64.zip" libharletty_bridge.so
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: harletty-bridge-linux-x86_64
+          path: harletty-bridge/target/release/harletty-bridge-*-linux-x86_64.zip
+
+  build-windows:
+    runs-on: windows-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Checkout harletty-bridge
+        uses: actions/checkout@v4
+        with:
+          path: harletty-bridge
+
+      - name: Checkout Omniphony (path dependencies)
+        uses: actions/checkout@v4
+        with:
+          repository: mgth/Omniphony
+          path: Omniphony
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build (release)
+        run: cargo build --release
+        working-directory: harletty-bridge
+        env:
+          RUSTFLAGS: -D warnings
+
+      - name: Package (zip)
+        run: |
+          cd harletty-bridge/target/release
+          Compress-Archive -Path harletty_bridge.dll -DestinationPath "harletty-bridge-${env:GITHUB_REF_NAME}-windows-x86_64.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: harletty-bridge-windows-x86_64
+          path: harletty-bridge/target/release/harletty-bridge-*-windows-x86_64.zip
+
+  build-macos:
+    runs-on: macos-14
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Checkout harletty-bridge
+        uses: actions/checkout@v4
+        with:
+          path: harletty-bridge
+
+      - name: Checkout Omniphony (path dependencies)
+        uses: actions/checkout@v4
+        with:
+          repository: mgth/Omniphony
+          path: Omniphony
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build (release)
+        run: cargo build --release
+        working-directory: harletty-bridge
+        env:
+          RUSTFLAGS: -D warnings
+
+      - name: Package (zip)
+        run: |
+          cd harletty-bridge/target/release
+          zip "harletty-bridge-${GITHUB_REF_NAME}-macos-arm64.zip" libharletty_bridge.dylib
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: harletty-bridge-macos-arm64
+          path: harletty-bridge/target/release/harletty-bridge-*-macos-arm64.zip
+
+  release:
+    needs: [build-linux, build-windows, build-macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: harletty-bridge-linux-x86_64
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: harletty-bridge-windows-x86_64
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: harletty-bridge-macos-arm64
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: |
+            harletty-bridge-*-linux-x86_64.zip
+            harletty-bridge-*-windows-x86_64.zip
+            harletty-bridge-*-macos-arm64.zip


### PR DESCRIPTION
The previous `ci.yml` was actually the tag-triggered Release bundle, so branch pushes and PRs ran no CI at all — the DTS:X campaign landed nine commits without a single CI run.

- Rename the tag-triggered workflow to `release.yml` (its `name:` was already `Release`).
- Add a real `ci.yml`: Linux build (`--all-targets`, warnings denied) + full test suite on every push/PR to `main`, with the sibling `mgth/Omniphony` checkout for path deps.
- `cargo fmt --check` is deliberately not gated yet: the tree predates rustfmt and a whole-repo reformat would conflict with the in-flight `research/spatial-object-layer` branch. Gate it once that lands.

Part of Omniphony `docs/channel-object-contract.md`, phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)