### PR TITLE
refactor: emit the ABI v2 channel/object contract (phase 2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "abi_stable",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 bridge-perf = []
 
 [dependencies]
-bridge_api = { version = "0.2.0", path = "../Omniphony/omniphony-renderer/bridge_api" }
+bridge_api = { version = "0.3.0", path = "../Omniphony/omniphony-renderer/bridge_api" }
 spdif = { version = "0.1.0", path = "../Omniphony/omniphony-renderer/spdif" }
 sys = { version = "0.1.0", path = "../Omniphony/omniphony-renderer/sys" }
 truehd = { version = "0.5.0", path = "truehd" }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -20,7 +20,6 @@ use crate::eac3_spdif::Eac3SpdifStream;
 use crate::frame_builders::PcmStats;
 use crate::logging::bridge_diag_log;
 use crate::mat::MatStream;
-use crate::metadata::ObjectNameKey;
 use crate::perf::PerfStats;
 use crate::truehd_pipeline::process_extractor_input;
 
@@ -150,7 +149,12 @@ pub(crate) struct AtmosBridge {
     pub(crate) recovering_until_major_sync: bool,
     pub(crate) drc_mode: DrcMode,
     pub(crate) frame_count: u64,
-    pub(crate) object_name_keys_by_id: Vec<Option<ObjectNameKey>>,
+    /// Last object↔channel declaration emitted (sparse re-emission on change
+    /// and after reset). Shared by the TrueHD and E-AC3 metadata paths.
+    pub(crate) declared_object_channels: Option<abi_stable::std_types::RVec<bridge_api::RObjectChannel>>,
+    /// Fixed-channel labels of the active TrueHD spatial presentation
+    /// (bed labels from the OAMD bed assignment, then `Object` fillers).
+    pub(crate) truehd_spatial_labels: Option<abi_stable::std_types::RVec<bridge_api::RChannelLabel>>,
     pub(crate) perf: PerfStats,
 }
 
@@ -223,7 +227,8 @@ impl AtmosBridge {
             recovering_until_major_sync: false,
             drc_mode: DrcMode::Off,
             frame_count: 0,
-            object_name_keys_by_id: Vec::new(),
+            declared_object_channels: None,
+            truehd_spatial_labels: None,
             perf: PerfStats::default(),
         };
 
@@ -287,7 +292,8 @@ impl AtmosBridge {
             .for_each(|p| *p = true);
         self.parser
             .set_required_presentations(&required_presentations);
-        self.object_name_keys_by_id.clear();
+        self.declared_object_channels = None;
+        self.truehd_spatial_labels = None;
         self.recovering_until_major_sync = false;
     }
 
@@ -649,7 +655,7 @@ impl FormatBridge for AtmosBridge {
         self.frame_count > 0 || self.eac3_frame_count > 0 || self.dts_frame_count > 0
     }
 
-    fn is_spatial(&self) -> bool {
+    fn has_objects(&self) -> bool {
         if self.dts_active {
             // DTS core is plain channel-based audio (a 5.1/7.1 bed), not true
             // objects. Whether it is placed at canonical speaker positions
@@ -909,7 +915,7 @@ mod raw_transport_tests {
         // DTS core is plain channel-based audio, not objects: it reports
         // non-spatial and lets the host's channel-render mode place/virtualise
         // the bed (same as AC-3).
-        assert!(!bridge.is_spatial());
+        assert!(!bridge.has_objects());
         assert!(bridge.is_ready());
 
         let f = &result.frames[0];
@@ -940,7 +946,7 @@ mod raw_transport_tests {
         assert!(!result.frames.is_empty(), "no HD frames decoded");
         // DTS (incl. HD) core is channel-based, not objects → non-spatial; the
         // channel-render mode decides how the bed is placed/virtualised.
-        assert!(!bridge.is_spatial());
+        assert!(!bridge.has_objects());
 
         // Find a fully-populated 7.1 frame (some early frames may be 5.1 before
         // the surround-back channels carry signal, but the bed is 8ch once XLL

--- a/src/eac3_pipeline.rs
+++ b/src/eac3_pipeline.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use crate::bridge::AtmosBridge;
 use crate::frame_builders::float_to_pcm_i32;
-use crate::labels::{bed_channel_to_r, eac3_core_bed_indices, eac3_object_output_bed_indices};
+use crate::labels::bed_channel_to_r;
 use crate::metadata::build_eac3_metadata_frame;
 
 const LEGACY_AC3_SAMPLE_COUNT: u32 = 1536;
@@ -550,7 +550,7 @@ fn build_eac3_frame_from_object(
     #[cfg(feature = "bridge-perf")]
     let mut metadata_events = 0usize;
     if bed_object_labels.is_none() {
-        let bed_indices = eac3_object_output_bed_indices(core);
+        let num_bed_channels = usize::from(core.lfe_channel.is_some());
         for (oamd, sample_offset) in &pcm_frame.oamd_payloads {
             let evo_base = base_sample_pos + sample_offset.unwrap_or(0) as u64;
             let oamd_ref: &OamdPayload = oamd;
@@ -558,7 +558,7 @@ fn build_eac3_frame_from_object(
                 oamd_ref,
                 evo_base,
                 base_sample_pos,
-                &bed_indices,
+                num_bed_channels,
                 object_channels,
                 bridge,
             );
@@ -668,7 +668,7 @@ fn build_eac3_object_output_pcm_and_labels(
         // Dynamic objects: positions come from per-frame OAMD events, not labels.
         None => {
             for _ in 0..object_channels {
-                channel_labels.push(RChannelLabel::Unknown);
+                channel_labels.push(RChannelLabel::Object);
             }
         }
     }
@@ -711,12 +711,10 @@ fn build_eac3_frame_from_core(
 
     // Extract metadata from OAMD payloads in the access unit info.
     let mut metadata: RVec<RMetadataFrame> = RVec::new();
-    let bed_indices = eac3_core_bed_indices(core);
     for payload in info.payloads() {
         if let ParsedEmdfPayloadData::Oamd(oamd) = &payload.parsed {
             let evo_base = base_sample_pos + payload.info.sample_offset.unwrap_or(0) as u64;
-            let meta =
-                build_eac3_metadata_frame(oamd, evo_base, base_sample_pos, &bed_indices, 0, bridge);
+            let meta = build_eac3_metadata_frame(oamd, evo_base, base_sample_pos, 0, 0, bridge);
             metadata.push(meta);
         }
     }
@@ -859,7 +857,6 @@ fn decode_ac3_heavy_range_word(word: u8) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::labels::eac3_object_output_bed_indices;
     use eac3::{
         AccessUnitInfo, AudioFrameInfo, AuxParseStatus, BedChannel, BlockDrcInfo, CorePcmFrame,
         EmdfSource, FrameType, JocPayload, OamdPayload, ObjectPcmFrame,
@@ -1089,8 +1086,8 @@ mod tests {
             labels.as_slice(),
             &[
                 RChannelLabel::LFE,
-                RChannelLabel::Unknown,
-                RChannelLabel::Unknown
+                RChannelLabel::Object,
+                RChannelLabel::Object
             ]
         );
         assert_eq!(
@@ -1104,7 +1101,6 @@ mod tests {
                 float_to_pcm_i32(0.82),
             ]
         );
-        assert_eq!(eac3_object_output_bed_indices(&core), vec![3]);
     }
 
     #[test]
@@ -1121,13 +1117,12 @@ mod tests {
 
         assert_eq!(
             labels.as_slice(),
-            &[RChannelLabel::Unknown, RChannelLabel::Unknown]
+            &[RChannelLabel::Object, RChannelLabel::Object]
         );
         assert_eq!(
             pcm.as_slice(),
             &[float_to_pcm_i32(0.31), float_to_pcm_i32(0.41)]
         );
-        assert!(eac3_object_output_bed_indices(&core).is_empty());
     }
 
     /// A 7.1.4 bed-only OAMD payload: 12 bed channels, no dynamic objects.

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,5 +1,4 @@
 use bridge_api::RChannelLabel;
-use eac3::CorePcmFrame;
 use truehd::structs::channel::ChannelLabel;
 
 /// Convert a TrueHD `ChannelLabel` to its ABI-stable counterpart.
@@ -76,64 +75,30 @@ pub(crate) fn bed_channel_to_r(ch: eac3::BedChannel) -> RChannelLabel {
     }
 }
 
-/// Map a `BedChannel` to the speaker ID space used by the bridge.
-pub(crate) fn bed_channel_to_speaker_id(ch: eac3::BedChannel) -> usize {
-    use eac3::BedChannel;
-    match ch {
-        BedChannel::FrontLeft => 0,
-        BedChannel::FrontRight => 1,
-        BedChannel::Center => 2,
-        BedChannel::LowFrequencyEffects => 3,
-        BedChannel::SurroundLeft => 4,
-        BedChannel::SurroundRight => 5,
-        BedChannel::RearCenter => 6,
-        BedChannel::RearLeft => 6,
-        BedChannel::RearRight => 7,
-        BedChannel::TopFrontLeft => 8,
-        BedChannel::TopFrontRight => 9,
-        BedChannel::TopSurroundLeft => 8,
-        BedChannel::TopSurroundRight => 9,
-        BedChannel::TopRearLeft => 8,
-        BedChannel::TopRearRight => 9,
-        BedChannel::WideLeft => 0,
-        BedChannel::WideRight => 1,
-        BedChannel::LowFrequencyEffects2 => 3,
-    }
-}
 
-pub(crate) fn eac3_core_bed_indices(core: &CorePcmFrame) -> Vec<usize> {
-    let mut bed_indices = Vec::with_capacity(core.total_channels());
-    bed_indices.extend(
-        core.fullband_channel_order
-            .iter()
-            .copied()
-            .map(bed_channel_to_speaker_id),
-    );
-    if core.lfe_channel.is_some() {
-        bed_indices.push(bed_channel_to_speaker_id(
-            eac3::BedChannel::LowFrequencyEffects,
-        ));
-    }
-    bed_indices
-}
 
-pub(crate) fn eac3_object_output_bed_indices(core: &CorePcmFrame) -> Vec<usize> {
-    if core.lfe_channel.is_some() {
-        vec![bed_channel_to_speaker_id(
-            eac3::BedChannel::LowFrequencyEffects,
-        )]
-    } else {
-        Vec::new()
-    }
-}
 
-/// Remap a speaker index to the Atmos channel-ID space.
-/// IDs 0-9 are bed channels; 10+ are dynamic objects.
-pub(crate) fn speaker_to_id(speaker_index: usize) -> usize {
+/// Channel label for an OAMD bed-assignment speaker index
+/// (`truehd::structs::oamd::SpeakerLabels` order).
+pub(crate) fn oamd_speaker_to_label(speaker_index: usize) -> RChannelLabel {
     match speaker_index {
-        0..8 => speaker_index,
-        8..10 => speaker_index + 122,
-        10..12 => speaker_index - 2,
-        _ => speaker_index + 120,
+        0 => RChannelLabel::L,
+        1 => RChannelLabel::R,
+        2 => RChannelLabel::C,
+        3 => RChannelLabel::LFE,
+        4 => RChannelLabel::Ls,  // Lss
+        5 => RChannelLabel::Rs,  // Rss
+        6 => RChannelLabel::Lb,  // Lrs
+        7 => RChannelLabel::Rb,  // Rrs
+        8 => RChannelLabel::Tfl, // Lfh (front height)
+        9 => RChannelLabel::Tfr, // Rfh
+        10 => RChannelLabel::Tsl, // Lts (top side)
+        11 => RChannelLabel::Tsr, // Rts
+        12 => RChannelLabel::Tbl, // Lrh (rear height)
+        13 => RChannelLabel::Tbr, // Rrh
+        14 => RChannelLabel::Lw,
+        15 => RChannelLabel::Rw,
+        16 => RChannelLabel::LFE2,
+        _ => RChannelLabel::Unknown,
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -3,91 +3,77 @@ use bridge_api::RMetadataFrame;
 use eac3::OamdPayload;
 #[cfg(feature = "bridge-perf")]
 use std::time::Instant;
-use truehd::structs::oamd::{ObjectAudioMetadataPayload, SpeakerLabels};
+use truehd::structs::oamd::ObjectAudioMetadataPayload;
 
 use crate::bridge::AtmosBridge;
-use crate::labels::speaker_to_id;
 use crate::logging::bridge_diag_log;
-use crate::perf::PerfStats;
+
+/// Sparse-emit an object↔channel declaration: return it only when it differs
+/// from the cached one (or after a cache clear, i.e. pipeline reset).
+pub(crate) fn declare_object_channels(
+    cache: &mut Option<RVec<bridge_api::RObjectChannel>>,
+    current: RVec<bridge_api::RObjectChannel>,
+) -> RVec<bridge_api::RObjectChannel> {
+    if cache.as_deref() == Some(current.as_slice()) {
+        RVec::new()
+    } else {
+        *cache = Some(current.clone());
+        current
+    }
+}
 
 /// Build an [`RMetadataFrame`] from an OAMD payload parsed from E-AC3.
+///
+/// Fixed channels are described by the frame's channel labels; here we emit
+/// the dynamic-object events plus the sparse object↔channel declaration
+/// (objects sit after the `num_bed_channels` fixed channels, in PCM order).
+/// Names are not emitted: the engine derives fixed-channel names from labels
+/// and falls back to `Obj_<id>` for unnamed objects, which matches the
+/// legacy generated names exactly.
 pub(crate) fn build_eac3_metadata_frame(
     oamd: &OamdPayload,
     evo_base: u64,
     frame_sample_pos: u64,
-    bed_indices: &[usize],
+    num_bed_channels: usize,
     object_channel_count: usize,
     bridge: &mut AtmosBridge,
 ) -> RMetadataFrame {
-    let events = extract_eac3_events(oamd, evo_base, bed_indices, object_channel_count);
-    let bed_indices: RVec<usize> = bed_indices.iter().copied().collect();
-
-    let mut name_updates = RVec::new();
-    for &speaker_id in bed_indices.iter() {
-        let id = speaker_id as u32;
-        let key = ObjectNameKey::Bed(speaker_id as u8);
-        if name_key_changed(&mut bridge.object_name_keys_by_id, id, &key) {
-            name_updates.push(bridge_api::RNameUpdate {
-                id,
-                name: object_name_from_key(&key).into(),
-            });
-        }
-    }
+    let events = extract_eac3_events(oamd, evo_base, object_channel_count);
 
     let dynamic_objects = oamd
         .object_count
         .saturating_sub(oamd.bed_or_isf_objects)
         .min(object_channel_count);
-    for dynamic_idx in 0..dynamic_objects {
-        let id = (10 + dynamic_idx) as u32;
-        let key = ObjectNameKey::Dynamic(id as usize);
-        if name_key_changed(&mut bridge.object_name_keys_by_id, id, &key) {
-            name_updates.push(bridge_api::RNameUpdate {
-                id,
-                name: object_name_from_key(&key).into(),
-            });
-        }
-    }
+    let current: RVec<bridge_api::RObjectChannel> = (0..dynamic_objects)
+        .map(|k| bridge_api::RObjectChannel {
+            id: (10 + k) as u32,
+            channel: (num_bed_channels + k) as u32,
+        })
+        .collect();
+    let object_channels = declare_object_channels(&mut bridge.declared_object_channels, current);
 
     RMetadataFrame {
         events,
-        bed_indices,
-        name_updates,
+        object_channels,
+        channel_gains: RVec::new(),
+        name_updates: RVec::new(),
         sample_pos: frame_sample_pos,
         ramp_duration: 0,
     }
 }
 
-/// Convert an E-AC3 OAMD payload into the bridge event list.
-///
-/// Mirrors TrueHD's structure: bed events first (one per PCM bed channel,
-/// `has_pos=false`, `id=speaker_id`), then dynamic events (`id=10+dynamic_idx`).
-/// Studio displays slots ordered by `events[]` index, so the bed events keep
-/// the dynamic slots aligned with their position metadata.
+/// Convert an E-AC3 OAMD payload into the dynamic-object event list
+/// (`id = 10 + dynamic_idx`, matching the object↔channel declaration).
 fn extract_eac3_events(
     oamd: &OamdPayload,
     base_sample_pos: u64,
-    bed_indices: &[usize],
     object_channel_count: usize,
 ) -> RVec<bridge_api::REvent> {
     let dynamic_objects = oamd
         .object_count
         .saturating_sub(oamd.bed_or_isf_objects)
         .min(object_channel_count);
-    let mut events: RVec<bridge_api::REvent> =
-        RVec::with_capacity(bed_indices.len() + dynamic_objects);
-
-    for &speaker_id in bed_indices {
-        events.push(bridge_api::REvent {
-            id: speaker_id as u32,
-            sample_pos: base_sample_pos,
-            has_pos: false,
-            pos: [0.0; 3],
-            gain_db: 0,
-            size: [0.0, 0.0, 0.0],
-            ramp_duration: 0,
-        });
-    }
+    let mut events: RVec<bridge_api::REvent> = RVec::with_capacity(dynamic_objects);
 
     for element in &oamd.elements {
         let eac3::OamdElementKind::Object(ref obj_element) = element.kind else {
@@ -221,14 +207,26 @@ mod tests {
     }
 
     #[test]
-    fn eac3_metadata_names_lfe_bed() {
+    fn eac3_metadata_declares_objects_sparsely() {
         let mut bridge = AtmosBridge::new(false);
+        let mut payload = empty_oamd_payload();
+        payload.object_count = 3;
+        payload.dynamic_objects = 2;
 
-        let meta = build_eac3_metadata_frame(&empty_oamd_payload(), 0, 0, &[3], 0, &mut bridge);
+        // Two dynamic objects after one fixed (LFE) channel: ids 10/11 on
+        // channels 1/2, declared on the first frame only.
+        let meta = build_eac3_metadata_frame(&payload, 0, 0, 1, 2, &mut bridge);
+        let decl: Vec<(u32, u32)> = meta
+            .object_channels
+            .iter()
+            .map(|oc| (oc.id, oc.channel))
+            .collect();
+        assert_eq!(decl, vec![(10, 1), (11, 2)]);
+        assert!(meta.name_updates.is_empty());
 
-        assert_eq!(meta.name_updates.len(), 1);
-        assert_eq!(meta.name_updates[0].id, 3);
-        assert_eq!(meta.name_updates[0].name.as_str(), "LFE");
+        // Unchanged declaration → sparse (empty) re-emission.
+        let again = build_eac3_metadata_frame(&payload, 0, 0, 1, 2, &mut bridge);
+        assert!(again.object_channels.is_empty());
     }
 
     /// Anisotropic OAMD size [w, d, h] is preserved end-to-end without any
@@ -289,7 +287,7 @@ mod tests {
             }],
         };
 
-        let events = extract_eac3_events(&payload, 0, &[], 1);
+        let events = extract_eac3_events(&payload, 0, 1);
         let dynamic = events.iter().find(|e| e.has_pos).expect("dynamic event");
         let expected: [f64; 3] = [0.2_f32 as f64, 0.5_f32 as f64, 0.9_f32 as f64];
         for axis in 0..3 {
@@ -303,98 +301,35 @@ mod tests {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ObjectNameKey {
-    Bed(u8),
-    Isf(usize),
-    Dynamic(usize),
-}
-
-/// Build an [`RMetadataFrame`] from a parsed OAMD payload.
+/// Build an [`RMetadataFrame`] from a TrueHD OAMD payload.
 ///
-/// - `evo_base` = `total_samples + evo_sample_offset` (used for event sample_pos).
-/// - `frame_sample_pos` = `total_samples` (used for OSC timing, no evo offset).
-pub(crate) fn object_name_from_key(key: &ObjectNameKey) -> String {
-    match key {
-        ObjectNameKey::Bed(idx) => SpeakerLabels::from_u8(*idx)
-            .map(|l| format!("{:?}", l))
-            .unwrap_or_else(|| format!("Bed_{}", idx)),
-        ObjectNameKey::Isf(i) => format!("ISF_{}", i),
-        ObjectNameKey::Dynamic(i) => format!("Obj_{}", i),
-    }
-}
-
-#[inline]
-pub(crate) fn name_key_changed(
-    cache: &mut Vec<Option<ObjectNameKey>>,
-    id: u32,
-    key: &ObjectNameKey,
-) -> bool {
-    let idx = id as usize;
-    if idx >= cache.len() {
-        cache.resize(idx + 1, None);
-        cache[idx] = Some(key.clone());
-        return true;
-    }
-    match &cache[idx] {
-        Some(prev) if prev == key => false,
-        _ => {
-            cache[idx] = Some(key.clone());
-            true
-        }
-    }
-}
-
+/// Fixed channels are described by the frame's channel labels; the metadata
+/// carries the dynamic-object events, the sparse object↔channel declaration
+/// and the OAMD bed-gain automation. Names are not emitted: the engine
+/// derives fixed-channel names from labels and falls back to `Obj_<id>`,
+/// matching the legacy generated names.
 pub(crate) fn build_metadata_frame_from_oamd(
     oamd: &ObjectAudioMetadataPayload,
     evo_base: u64,
     frame_sample_pos: u64,
-    name_key_cache: &mut Vec<Option<ObjectNameKey>>,
-    _perf: &mut PerfStats,
+    declared_object_channels: &mut Option<RVec<bridge_api::RObjectChannel>>,
+    #[cfg(feature = "bridge-perf")] perf: &mut crate::perf::BridgePerf,
 ) -> RMetadataFrame {
     #[cfg(feature = "bridge-perf")]
-    let perf = _perf;
-    #[cfg(feature = "bridge-perf")]
     let events_started = Instant::now();
-    let events = extract_events(oamd, evo_base);
+    let extracted = extract_events(oamd, evo_base);
     #[cfg(feature = "bridge-perf")]
     perf.record_build_metadata_events(events_started.elapsed());
 
-    #[cfg(feature = "bridge-perf")]
-    let bed_indices_started = Instant::now();
-    let bed_index_vec: Vec<usize> = oamd
-        .program_assignment
-        .bed_assignment
-        .first()
-        .map(|bed| bed.to_index_vec())
-        .unwrap_or_default();
-    let bed_indices: RVec<usize> = bed_index_vec.iter().map(|&i| speaker_to_id(i)).collect();
-    #[cfg(feature = "bridge-perf")]
-    perf.record_build_metadata_bed_indices(bed_indices_started.elapsed());
-
-    #[cfg(feature = "bridge-perf")]
-    let name_updates_started = Instant::now();
-    let mut name_updates = RVec::new();
-    let num_isf_objects = oamd.program_assignment.num_isf_objects;
-    let num_dynamic_objects = oamd.program_assignment.num_dynamic_objects;
-    for (idx, event) in events.iter().enumerate() {
-        let id = event.id;
-        let key = object_name_key_for_index(
-            idx,
+    let current: RVec<bridge_api::RObjectChannel> = extracted
+        .objects
+        .iter()
+        .map(|&(id, channel)| bridge_api::RObjectChannel {
             id,
-            &bed_index_vec,
-            num_isf_objects,
-            num_dynamic_objects,
-        );
-        if name_key_changed(name_key_cache, id, &key) {
-            name_updates.push(bridge_api::RNameUpdate {
-                id,
-                name: object_name_from_key(&key).into(),
-            });
-        }
-    }
-    #[cfg(feature = "bridge-perf")]
-    perf.record_build_metadata_name_updates(name_updates_started.elapsed());
+            channel: channel as u32,
+        })
+        .collect();
+    let object_channels = declare_object_channels(declared_object_channels, current);
 
     let ramp_duration = oamd
         .object_element
@@ -404,47 +339,42 @@ pub(crate) fn build_metadata_frame_from_oamd(
         .unwrap_or(0);
 
     RMetadataFrame {
-        events,
-        bed_indices,
-        name_updates,
+        events: extracted.events,
+        object_channels,
+        channel_gains: extracted.channel_gains,
+        name_updates: RVec::new(),
         sample_pos: frame_sample_pos,
         ramp_duration,
     }
 }
 
-#[inline]
-fn object_name_key_for_index(
-    object_index: usize,
-    object_id: u32,
-    bed_index_vec: &[usize],
-    num_isf_objects: usize,
-    num_dynamic_objects: usize,
-) -> ObjectNameKey {
-    let bed_count = bed_index_vec.len();
-    if object_index < bed_count {
-        return ObjectNameKey::Bed(bed_index_vec[object_index] as u8);
-    }
-    let isf_start = bed_count;
-    let isf_end = isf_start + num_isf_objects;
-    if object_index < isf_end {
-        return ObjectNameKey::Isf(object_index - isf_start);
-    }
-    let dyn_start = isf_end;
-    let dyn_end = dyn_start + num_dynamic_objects;
-    if object_index < dyn_end {
-        return ObjectNameKey::Dynamic(object_id as usize);
-    }
-    ObjectNameKey::Dynamic(object_id as usize)
+/// Extract spatial events from a TrueHD OAMD frame.
+struct ExtractedTruehdMetadata {
+    /// Dynamic-object events (ids match `objects`).
+    events: RVec<bridge_api::REvent>,
+    /// OAMD gain automation for the bed members, by PCM channel.
+    channel_gains: RVec<bridge_api::RChannelGain>,
+    /// Dynamic-object declaration: (id, PCM channel).
+    objects: Vec<(u32, usize)>,
 }
 
-/// Extract spatial events from a TrueHD OAMD frame.
+impl ExtractedTruehdMetadata {
+    fn empty() -> Self {
+        Self {
+            events: RVec::new(),
+            channel_gains: RVec::new(),
+            objects: Vec::new(),
+        }
+    }
+}
+
 fn extract_events(
     oamd: &ObjectAudioMetadataPayload,
     base_sample_pos: u64,
-) -> RVec<bridge_api::REvent> {
+) -> ExtractedTruehdMetadata {
     let object_count = oamd.object_count;
     let Some(object_element) = &oamd.object_element else {
-        return RVec::new();
+        return ExtractedTruehdMetadata::empty();
     };
 
     if object_element.md_update_info.num_obj_info_blocks != 1 {
@@ -452,21 +382,21 @@ fn extract_events(
             "atmos-bridge: unsupported OAMD with num_obj_info_blocks={} (expected 1); skipping metadata frame",
             object_element.md_update_info.num_obj_info_blocks
         );
-        return RVec::new();
+        return ExtractedTruehdMetadata::empty();
     }
     if oamd.program_assignment.bed_assignment.len() != 1 {
         log::warn!(
             "atmos-bridge: unsupported OAMD with bed_assignment_count={} (expected 1); skipping metadata frame",
             oamd.program_assignment.bed_assignment.len()
         );
-        return RVec::new();
+        return ExtractedTruehdMetadata::empty();
     }
     if oamd.program_assignment.num_isf_objects != 0 {
         log::warn!(
             "atmos-bridge: unsupported OAMD with num_isf_objects={} (expected 0); skipping metadata frame",
             oamd.program_assignment.num_isf_objects
         );
-        return RVec::new();
+        return ExtractedTruehdMetadata::empty();
     }
 
     let sample_offset = object_element.md_update_info.sample_offset as u64;
@@ -482,6 +412,8 @@ fn extract_events(
         .unwrap_or_default();
 
     let mut events: RVec<bridge_api::REvent> = RVec::with_capacity(object_count);
+    let mut channel_gains: RVec<bridge_api::RChannelGain> = RVec::new();
+    let mut objects: Vec<(u32, usize)> = Vec::new();
     let mut missing_object_data = 0usize;
     let mut empty_object_blocks = 0usize;
     let mut bed_index_oob = 0usize;
@@ -497,17 +429,23 @@ fn extract_events(
             continue;
         };
 
-        let id = if object_data.b_object_in_bed_or_isf {
-            let Some(&bed_idx) = bed_index_vec.get(i) else {
+        if object_data.b_object_in_bed_or_isf {
+            // Bed member: its channel is fixed (described by the frame's
+            // labels); OAMD only contributes live gain automation.
+            if bed_index_vec.get(i).is_none() {
                 bed_index_oob += 1;
                 continue;
-            };
-            speaker_to_id(bed_idx) as u32
-        } else {
-            (i + 10 - bed_index_vec.len()) as u32
-        };
-        let (has_pos, pos, size) = if !object_data.b_object_in_bed_or_isf {
-            let render = &object_data.object_render_info;
+            }
+            channel_gains.push(bridge_api::RChannelGain {
+                channel: i as u32,
+                gain_db: object_data.object_basic_info.object_gain,
+            });
+            continue;
+        }
+
+        let id = (i + 10 - bed_index_vec.len()) as u32;
+        let render = &object_data.object_render_info;
+        let (has_pos, pos, size) =
             match pos_vec.get(i).and_then(|raw_blocks| raw_blocks.first()) {
                 Some(raw) if raw.len() >= 3 => (true, [raw[0], raw[1], raw[2]], render.object_size),
                 Some(_) => (false, [0.0; 3], [0.0; 3]),
@@ -515,11 +453,9 @@ fn extract_events(
                     missing_damf_pos += 1;
                     (false, [0.0; 3], [0.0; 3])
                 }
-            }
-        } else {
-            (false, [0.0; 3], [0.0; 3])
-        };
+            };
 
+        objects.push((id, i));
         events.push(bridge_api::REvent {
             id,
             sample_pos,
@@ -558,5 +494,9 @@ fn extract_events(
         );
     }
 
-    events
+    ExtractedTruehdMetadata {
+        events,
+        channel_gains,
+        objects,
+    }
 }

--- a/src/truehd_pipeline.rs
+++ b/src/truehd_pipeline.rs
@@ -10,9 +10,9 @@ use truehd::process::{
 };
 
 use crate::bridge::{AtmosBridge, DrcMode};
-use crate::labels::channel_label_to_r;
+use crate::labels::{channel_label_to_r, oamd_speaker_to_label};
 use crate::logging::{bridge_diag_log, drc_diag_log_enabled, panic_message};
-use crate::metadata::{ObjectNameKey, build_metadata_frame_from_oamd};
+use crate::metadata::build_metadata_frame_from_oamd;
 use crate::perf::PerfStats;
 
 struct DrainContext<'a> {
@@ -28,7 +28,8 @@ struct DrainContext<'a> {
     recovering_until_major_sync: &'a mut bool,
     drc_mode: DrcMode,
     total_samples: &'a mut u64,
-    object_name_keys_by_id: &'a mut Vec<Option<ObjectNameKey>>,
+    declared_object_channels: &'a mut Option<RVec<bridge_api::RObjectChannel>>,
+    spatial_labels: &'a mut Option<RVec<RChannelLabel>>,
     perf: &'a mut PerfStats,
 }
 
@@ -55,7 +56,8 @@ impl DrainContext<'_> {
         *self.current_substream_info = None;
         *self.current_extended_substream_info = None;
         *self.current_dialogue_level = None;
-        self.object_name_keys_by_id.clear();
+        *self.declared_object_channels = None;
+        *self.spatial_labels = None;
         *self.recovering_until_major_sync = true;
     }
 }
@@ -328,33 +330,42 @@ fn build_thd_frame(
     #[cfg(feature = "bridge-perf")]
     ctx.perf.record_build_pcm(pcm_started.elapsed());
 
-    // Channel labels.
-    #[cfg(feature = "bridge-perf")]
-    let labels_started = Instant::now();
-    let channel_labels: RVec<RChannelLabel> = decoded
-        .channel_labels
-        .iter()
-        .map(channel_label_to_r)
-        .collect();
-    #[cfg(feature = "bridge-perf")]
-    ctx.perf.record_build_labels(labels_started.elapsed());
-
     // Metadata: one RMetadataFrame per parsed OAMD payload.
     #[cfg(feature = "bridge-perf")]
     let metadata_started = Instant::now();
     let mut metadata: RVec<RMetadataFrame> = RVec::new();
     if decoded.substream_info_changed {
-        ctx.object_name_keys_by_id.clear();
+        *ctx.declared_object_channels = None;
+        *ctx.spatial_labels = None;
     }
     #[cfg(feature = "bridge-perf")]
     let mut metadata_events = 0usize;
     for oamd in &decoded.oamd {
         let evo_base = base_sample_pos + oamd.evo_sample_offset;
+        // Fixed-channel labels of the spatial presentation: bed labels from
+        // the OAMD bed assignment, then `Object` for the object channels.
+        let bed_labels: RVec<RChannelLabel> = oamd
+            .program_assignment
+            .bed_assignment
+            .first()
+            .map(|bed| bed.to_index_vec())
+            .unwrap_or_default()
+            .iter()
+            .map(|&idx| oamd_speaker_to_label(idx))
+            .collect();
+        let mut labels = bed_labels;
+        while labels.len() < decoded.channel_count {
+            labels.push(RChannelLabel::Object);
+        }
+        if ctx.spatial_labels.as_ref() != Some(&labels) {
+            *ctx.spatial_labels = Some(labels);
+        }
         let meta = build_metadata_frame_from_oamd(
             oamd,
             evo_base,
             base_sample_pos,
-            ctx.object_name_keys_by_id,
+            ctx.declared_object_channels,
+            #[cfg(feature = "bridge-perf")]
             ctx.perf,
         );
         #[cfg(feature = "bridge-perf")]
@@ -368,6 +379,18 @@ fn build_thd_frame(
         ctx.perf.record_build_metadata(metadata_started.elapsed());
         ctx.perf.note_built_frame(metadata.len(), metadata_events);
     }
+
+    // Channel labels.
+    #[cfg(feature = "bridge-perf")]
+    let labels_started = Instant::now();
+    let channel_labels: RVec<RChannelLabel> = match ctx.spatial_labels.as_ref() {
+        // Spatial presentation: authoritative labels come from the OAMD bed
+        // assignment (cached across frames without a payload).
+        Some(labels) => labels.clone(),
+        None => decoded.channel_labels.iter().map(channel_label_to_r).collect(),
+    };
+    #[cfg(feature = "bridge-perf")]
+    ctx.perf.record_build_labels(labels_started.elapsed());
 
     RDecodedFrame {
         sampling_frequency: decoded.sampling_frequency,
@@ -412,7 +435,8 @@ pub(crate) fn process_extractor_input(
             recovering_until_major_sync: &mut bridge.recovering_until_major_sync,
             drc_mode: bridge.drc_mode,
             total_samples: &mut bridge.total_samples,
-            object_name_keys_by_id: &mut bridge.object_name_keys_by_id,
+            declared_object_channels: &mut bridge.declared_object_channels,
+            spatial_labels: &mut bridge.truehd_spatial_labels,
             perf: &mut bridge.perf,
         };
         #[cfg(feature = "bridge-perf")]


### PR DESCRIPTION
Bridge side of the ABI v2 reshape (Omniphony `docs/channel-object-contract.md`, phase 2a). Pair with the Omniphony ABI PR — **merge that one first**: this repo's CI checks out Omniphony `main`, so the CI here stays red until the renderer side lands.

- TrueHD + E-AC-3 metadata describe dynamic objects only: historical event ids kept, explicit sparse `object_channels {id, channel}` declaration, OAMD bed-member gains via `channel_gains`.
- Fixed channels described by `channel_labels`: TrueHD spatial presentations label their bed channels from the OAMD bed assignment (`oamd_speaker_to_label`, exact `SpeakerLabels` mapping) and mark object channels `Object`; same for the E-AC-3 JOC object output (previously `Unknown`).
- `name_updates` no longer emitted (engine label-derived names + `Obj_<id>` fallback reproduce the legacy strings); the whole `ObjectNameKey` plumbing is deleted.
- `is_spatial()` → `has_objects()` (unchanged values).

Behavior notes: OSC source names become canonical (`Ls`/`Lb`/`TSL` vs `Lss`/`Lrs`/`Lts`), and OAMD front-height beds (Lfh/Rfh) are now routable as TFL/TFR instead of silently unroutable.

Tests: full suite green (45); E2E parity harness against the Omniphony side run locally (TrueHD Atmos fixture) — objects decode, render and broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)