### PR TITLE
feat(dts): DTS:X fixed 7.1.4 as twelve labeled channels

### DIFF
--- a/dca/examples/xll_x_audio.rs
+++ b/dca/examples/xll_x_audio.rs
@@ -1,91 +1,130 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Hypothesis: the DTS:X object payload is residual AUDIO (one mono object per
-// active object, XLL-style residual coding matrixed against the 7.1 bed), not
-// opaque metadata. Decisive cheap test: the bit budget. If it is audio of
-// `nframesamples` samples per object, then
-//     bits_per_sample = (payload_bytes - overhead) * 8 / (n_objects * nsamples)
-// should land in a sane audio-residual range (~1..8 b/sample) and be roughly
-// stable across frames/counts. We also try object counts = byte22 and byte22-3
-// (count 3 == the 48-byte null frame, i.e. likely 0 objects).
+// Decode the four lossless, speaker-unmapped waveforms carried by the XLL-X
+// extension and write them as a 32-bit float, four-channel WAV file.
 //
-// Usage: cargo run -p dca --release --example xll_x_audio -- <in.dts> [max_mb]
+// Usage:
+//   cargo run -p dca --release --example xll_x_audio -- \
+//     <in.dts> <out.wav> [max_mb]
 
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom, Write};
 
 use dca::parser::parse_header;
-use dca::{HdDecoder, exss_substream_size};
+use dca::{exss_substream_size, HdDecoder};
+
+fn write_wav_header(file: &mut std::fs::File, sample_rate: u32, data_bytes: u32) {
+    let channels = 4u16;
+    let bits_per_sample = 32u16;
+    let block_align = channels * bits_per_sample / 8;
+    let byte_rate = sample_rate * block_align as u32;
+
+    file.seek(SeekFrom::Start(0)).expect("seek WAV header");
+    file.write_all(b"RIFF").expect("write WAV header");
+    file.write_all(&(36 + data_bytes).to_le_bytes())
+        .expect("write WAV size");
+    file.write_all(b"WAVEfmt ").expect("write WAV header");
+    file.write_all(&16u32.to_le_bytes())
+        .expect("write fmt size");
+    file.write_all(&3u16.to_le_bytes())
+        .expect("write IEEE-float format");
+    file.write_all(&channels.to_le_bytes())
+        .expect("write channel count");
+    file.write_all(&sample_rate.to_le_bytes())
+        .expect("write sample rate");
+    file.write_all(&byte_rate.to_le_bytes())
+        .expect("write byte rate");
+    file.write_all(&block_align.to_le_bytes())
+        .expect("write block alignment");
+    file.write_all(&bits_per_sample.to_le_bytes())
+        .expect("write sample format");
+    file.write_all(b"data").expect("write data tag");
+    file.write_all(&data_bytes.to_le_bytes())
+        .expect("write data size");
+}
 
 fn main() {
     let mut args = std::env::args().skip(1);
-    let path = args.next().expect("usage: xll_x_audio <in.dts> [max_mb]");
-    let max_mb: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(96);
+    let input_path = args
+        .next()
+        .expect("usage: xll_x_audio <in.dts> <out.wav> [max_mb]");
+    let output_path = args
+        .next()
+        .expect("usage: xll_x_audio <in.dts> <out.wav> [max_mb]");
+    let max_mb: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(256);
 
-    let mut f = std::fs::File::open(&path).expect("open");
+    let mut input = std::fs::File::open(&input_path).expect("open input");
     let mut bytes = vec![0u8; max_mb * 1024 * 1024];
-    let n = f.read(&mut bytes).expect("read");
-    bytes.truncate(n);
+    let read = input.read(&mut bytes).expect("read input");
+    bytes.truncate(read);
 
-    const OVERHEAD: usize = 27; // bytes before object data (syncword+hdr+fields)
-    let mut nsamp_hist = std::collections::BTreeMap::<usize, u32>::new();
-    // bits/sample buckets, per assumed object count, for the count-3 offset model
-    let mut bps_by_obj: std::collections::BTreeMap<usize, Vec<f64>> = std::collections::BTreeMap::new();
-    let mut all_bps: Vec<f64> = Vec::new();
+    let mut output = std::fs::File::create(&output_path).expect("create output");
+    write_wav_header(&mut output, 48_000, 0);
 
-    let mut dec = HdDecoder::new();
-    let mut off = 0usize;
-    let mut frames = 0usize;
-    while off + 18 < bytes.len() && frames < 6000 {
-        let core = match parse_header(&bytes[off..]) {
-            Ok(c) => c,
+    let mut decoder = HdDecoder::new();
+    let mut offset = 0usize;
+    let mut decoded_frames = 0usize;
+    let mut failed_frames = 0usize;
+    let mut data_bytes = 0u64;
+    let mut sample_rate = None;
+
+    while offset + 18 < bytes.len() {
+        let core = match parse_header(&bytes[offset..]) {
+            Ok(header) => header,
             Err(_) => break,
         };
-        let exss_off = off + core.frame_size;
-        if exss_off + 4 > bytes.len() {
+        let exss_offset = offset + core.frame_size;
+        if exss_offset + 4 > bytes.len() {
             break;
         }
-        let exss_len = match exss_substream_size(&bytes[exss_off..]) {
-            Some(l) if exss_off + l <= bytes.len() => l,
+        let exss_len = match exss_substream_size(&bytes[exss_offset..]) {
+            Some(len) if exss_offset + len <= bytes.len() => len,
             _ => break,
         };
-        if let Ok(fr) = dec.decode(&bytes[off..exss_off], &bytes[exss_off..exss_off + exss_len]) {
-            let p = &fr.x_payload;
-            let nsamp = fr.samples.iter().find_map(|o| o.as_ref().map(|v| v.len())).unwrap_or(0);
-            if (fr.x_present || fr.x_imax) && p.len() > OVERHEAD && nsamp > 0 {
-                *nsamp_hist.entry(nsamp).or_insert(0) += 1;
-                let raw = p[22] as usize;
-                let nobj = raw.saturating_sub(3); // hypothesis: count 3 => 0 objects
-                if nobj > 0 {
-                    let obj_bits = (p.len() - OVERHEAD) * 8;
-                    let bps = obj_bits as f64 / (nobj * nsamp) as f64;
-                    bps_by_obj.entry(nobj).or_default().push(bps);
-                    all_bps.push(bps);
+
+        if let Ok(frame) = decoder.decode(
+            &bytes[offset..exss_offset],
+            &bytes[exss_offset..exss_offset + exss_len],
+        ) {
+            if frame.x_samples.len() == 4 {
+                sample_rate.get_or_insert(frame.sample_rate);
+                let samples = frame.x_samples[0].len();
+                if frame
+                    .x_samples
+                    .iter()
+                    .any(|channel| channel.len() != samples)
+                {
+                    panic!("inconsistent XLL-X channel lengths");
                 }
+                let frame_bytes = samples as u64 * 4 * 4;
+                if data_bytes + frame_bytes > u32::MAX as u64 - 36 {
+                    panic!("output exceeds classic RIFF/WAV 4 GiB limit");
+                }
+                for i in 0..samples {
+                    for channel in &frame.x_samples {
+                        output
+                            .write_all(&channel[i].to_le_bytes())
+                            .expect("write PCM");
+                    }
+                }
+                data_bytes += frame_bytes;
+                decoded_frames += 1;
+            } else if frame.x_present {
+                failed_frames += 1;
+                eprintln!(
+                    "XLL-X decode failed at frame {}: {:?}",
+                    decoded_frames + failed_frames,
+                    frame.x_decode_error
+                );
             }
         }
-        off += core.frame_size + exss_len;
-        frames += 1;
+        offset += core.frame_size + exss_len;
     }
 
-    println!("nframesamples (bed) histogram:");
-    for (s, c) in &nsamp_hist {
-        println!("  {s} samples/frame: {c} frames");
-    }
-    let nsamp = nsamp_hist.iter().max_by_key(|(_, c)| **c).map(|(s, _)| *s).unwrap_or(0);
-    println!("\nmodal nframesamples = {nsamp}");
-
-    let med = |v: &mut Vec<f64>| {
-        v.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        if v.is_empty() { 0.0 } else { v[v.len() / 2] }
-    };
-    println!("\nbits/sample under model objects = byte22 - 3, nsamples = {nsamp}:");
-    println!("  nobj    n     min    median     max   (bits/sample)");
-    for (o, v) in bps_by_obj.iter_mut() {
-        let mn = v.iter().cloned().fold(f64::INFINITY, f64::min);
-        let mx = v.iter().cloned().fold(0.0, f64::max);
-        let md = med(v);
-        println!("  {o:>4} {:>6}  {mn:>6.2} {md:>8.2} {mx:>7.2}", v.len());
-    }
-    let md_all = med(&mut all_bps);
-    println!("\noverall median bits/sample = {md_all:.2}  (sane audio residual ≈ 1..8)");
+    let sample_rate = sample_rate.expect("no four-channel XLL-X audio found");
+    write_wav_header(&mut output, sample_rate, data_bytes as u32);
+    output.flush().expect("flush output");
+    println!(
+        "decoded {decoded_frames} frames ({:.3} s) to {output_path}; failures={failed_frames}",
+        data_bytes as f64 / (sample_rate as f64 * 4.0 * 4.0)
+    );
 }

--- a/dca/examples/xll_x_chs.rs
+++ b/dca/examples/xll_x_chs.rs
@@ -1,0 +1,600 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Search the variable part of an XLL-X payload for a plausible bare XLL
+// channel-set header.  DTS-UHD (ETSI TS 103 491) explicitly permits XLL audio
+// chunks containing channel-set header/data without a nested XLL frame sync,
+// so absence of 0x41a29547 alone does not falsify reuse of this grammar.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_x_chs -- <in.dts> [max_mb]
+
+use std::collections::HashMap;
+use std::io::Read;
+
+use dca::parser::parse_header;
+use dca::{exss_substream_size, HdDecoder};
+
+const SEARCH_START: usize = 22 * 8;
+const SEARCH_END_BYTE: usize = 160;
+const CHANNEL_PAIRS: [(usize, usize); 6] = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)];
+
+fn read_bits(data: &[u8], position: &mut usize, width: usize) -> Option<u32> {
+    if width > 32 || *position + width > data.len() * 8 {
+        return None;
+    }
+    let mut value = 0u32;
+    for _ in 0..width {
+        value = (value << 1) | ((data[*position / 8] >> (7 - *position % 8)) & 1) as u32;
+        *position += 1;
+    }
+    Some(value)
+}
+
+#[derive(Debug)]
+struct Candidate {
+    bit_offset: usize,
+    header_size: usize,
+    channels: usize,
+    pcm_resolution: usize,
+    storage_resolution: usize,
+    residual_mask: u32,
+}
+
+fn candidate_at(data: &[u8], bit_offset: usize) -> Option<Candidate> {
+    let mut position = bit_offset;
+    let header_size = read_bits(data, &mut position, 10)? as usize + 1;
+    let channels = read_bits(data, &mut position, 4)? as usize + 1;
+    let residual_mask = read_bits(data, &mut position, channels)?;
+    let pcm_resolution = read_bits(data, &mut position, 5)? as usize + 1;
+    let storage_resolution = read_bits(data, &mut position, 5)? as usize + 1;
+    let frequency_index = read_bits(data, &mut position, 4)?;
+    let frequency_modifier = read_bits(data, &mut position, 2)?;
+    let replacement_set = read_bits(data, &mut position, 2)?;
+
+    let minimum_header_bits = position - bit_offset;
+    let header_fits =
+        header_size * 8 >= minimum_header_bits && bit_offset + header_size * 8 <= data.len() * 8;
+    if !header_fits
+        || !matches!(storage_resolution, 16 | 20 | 24)
+        || pcm_resolution > storage_resolution
+        || frequency_index != 12 // 48 kHz in the DCA EXSS table
+        || frequency_modifier != 0
+        || replacement_set != 0
+    {
+        return None;
+    }
+
+    Some(Candidate {
+        bit_offset,
+        header_size,
+        channels,
+        pcm_resolution,
+        storage_resolution,
+        residual_mask,
+    })
+}
+
+fn crc16_ccitt(data: &[u8]) -> u16 {
+    let mut crc = 0xffffu16;
+    for &byte in data {
+        crc ^= (byte as u16) << 8;
+        for _ in 0..8 {
+            crc = if crc & 0x8000 != 0 {
+                (crc << 1) ^ 0x1021
+            } else {
+                crc << 1
+            };
+        }
+    }
+    crc
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: xll_x_chs <in.dts> [max_mb]");
+    let max_mb: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(64);
+
+    let mut input = std::fs::File::open(&path).expect("open input");
+    let mut bytes = vec![0u8; max_mb * 1024 * 1024];
+    let read = input.read(&mut bytes).expect("read input");
+    bytes.truncate(read);
+
+    let mut decoder = HdDecoder::new();
+    let mut offset = 0usize;
+    let mut frames = 0usize;
+    let mut payloads = 0usize;
+    let mut candidate_frames = 0usize;
+    let mut count_matching_frames = 0usize;
+    let mut all_offsets: HashMap<usize, usize> = HashMap::new();
+    let mut count_matching_offsets: HashMap<usize, usize> = HashMap::new();
+    let mut header_sizes: HashMap<usize, usize> = HashMap::new();
+    let mut exact_offset_frames = 0usize;
+    let mut exact_offset_crc_valid = 0usize;
+    let mut exact_basic_fields: HashMap<(usize, usize, usize, u32), usize> = HashMap::new();
+    let mut first_candidates = Vec::new();
+    let mut decoded_audio_frames = 0usize;
+    let mut descriptor_navigation_frames = 0usize;
+    let mut first_descriptor_fallbacks = Vec::new();
+    let mut decode_errors: HashMap<String, usize> = HashMap::new();
+    let mut navigation_deltas: HashMap<isize, usize> = HashMap::new();
+    let mut trailer_crc_valid = [0usize; 3];
+    let mut trailer_words: HashMap<u16, usize> = HashMap::new();
+    let mut descriptor_tails: HashMap<(usize, Vec<u8>), usize> = HashMap::new();
+    let mut channel_header_tails: HashMap<usize, usize> = HashMap::new();
+    let mut trailing_bits = Vec::new();
+    let mut channel_energy = [0f64; 4];
+    let mut channel_samples = [0usize; 4];
+    let mut frame_rms: [Vec<f64>; 4] = std::array::from_fn(|_| Vec::new());
+    let mut sample_sum = [0f64; 4];
+    let mut sample_cross = [[0f64; 4]; 4];
+    let mut joint_samples = 0usize;
+    let mut frame_pair_correlation: [Vec<f64>; 6] = std::array::from_fn(|_| Vec::new());
+    let mut frame_pair_balance: [Vec<f64>; 6] = std::array::from_fn(|_| Vec::new());
+    let mut constant_frame_values: [Vec<Option<f32>>; 4] = std::array::from_fn(|_| Vec::new());
+    let mut frame_geometry = None;
+    let mut first_layout_bytes = None;
+
+    while offset + 18 < bytes.len() {
+        let core = match parse_header(&bytes[offset..]) {
+            Ok(header) => header,
+            Err(_) => break,
+        };
+        let exss_offset = offset + core.frame_size;
+        if exss_offset + 4 > bytes.len() {
+            break;
+        }
+        let exss_len = match exss_substream_size(&bytes[exss_offset..]) {
+            Some(len) if exss_offset + len <= bytes.len() => len,
+            _ => break,
+        };
+
+        if let Ok(frame) = decoder.decode(
+            &bytes[offset..exss_offset],
+            &bytes[exss_offset..exss_offset + exss_len],
+        ) {
+            *descriptor_tails
+                .entry((
+                    frame.exss_descriptor_tail_bits,
+                    frame.exss_descriptor_tail.clone(),
+                ))
+                .or_default() += 1;
+            if frame.x_present || frame.x_imax {
+                payloads += 1;
+                frame_geometry.get_or_insert((
+                    frame.xll_frame_segments,
+                    frame.xll_segment_samples,
+                    frame.xll_segment_size_bits,
+                    frame.xll_band_crc_present,
+                    frame.xll_scalable_lsbs,
+                ));
+                let payload = &frame.x_payload;
+                if payload.len() > 24 {
+                    let header_size =
+                        (((payload[22] as usize) << 2) | ((payload[23] as usize) >> 6)) + 1;
+                    let navi_start = 22 + header_size;
+                    let navi_bits = frame.xll_frame_segments * frame.xll_segment_size_bits;
+                    let navi_size = navi_bits.div_ceil(8) + 2;
+                    if payload.len() >= navi_start + navi_size {
+                        let mut bit = navi_start * 8;
+                        let mut audio_bytes = 0usize;
+                        for _ in 0..frame.xll_frame_segments {
+                            if let Some(size) =
+                                read_bits(payload, &mut bit, frame.xll_segment_size_bits)
+                            {
+                                audio_bytes += size as usize + 1;
+                            }
+                        }
+                        let predicted_end = navi_start + navi_size + audio_bytes;
+                        let delta = payload.len() as isize - predicted_end as isize;
+                        *navigation_deltas.entry(delta).or_default() += 1;
+                        if delta >= 2 {
+                            let crc_end = predicted_end + 2;
+                            let trailer = u16::from_be_bytes([
+                                payload[predicted_end],
+                                payload[predicted_end + 1],
+                            ]);
+                            *trailer_words.entry(trailer).or_default() += 1;
+                            for (slot, start) in trailer_crc_valid.iter_mut().zip([0usize, 4, 22]) {
+                                if crc16_ccitt(&payload[start..crc_end]) == 0 {
+                                    *slot += 1;
+                                }
+                            }
+                        }
+                    }
+                }
+                if first_layout_bytes.is_none() && payload.len() > 24 {
+                    let header_size =
+                        (((payload[22] as usize) << 2) | ((payload[23] as usize) >> 6)) + 1;
+                    let data_start = 22 + header_size;
+                    first_layout_bytes = Some((
+                        payload.len(),
+                        header_size,
+                        data_start,
+                        payload[data_start..payload.len().min(data_start + 24)].to_vec(),
+                        payload[payload.len().saturating_sub(24)..].to_vec(),
+                    ));
+                }
+                if frame.x_samples.len() == 4 {
+                    *channel_header_tails
+                        .entry(frame.x_header_tail_bits)
+                        .or_default() += 1;
+                    decoded_audio_frames += 1;
+                    descriptor_navigation_frames += usize::from(frame.x_descriptor_navigation_used);
+                    if !frame.x_descriptor_navigation_used && first_descriptor_fallbacks.len() < 8 {
+                        first_descriptor_fallbacks.push((
+                            frames,
+                            frame.x_descriptor_offset,
+                            frame.x_payload_offset,
+                            frame.x_descriptor_size,
+                            frame.x_payload.len(),
+                        ));
+                    }
+                    trailing_bits.push(payload.len() * 8 - frame.x_bits_consumed);
+                    for (channel, samples) in frame.x_samples.iter().enumerate() {
+                        let energy = samples
+                            .iter()
+                            .map(|&sample| (sample as f64).powi(2))
+                            .sum::<f64>();
+                        channel_energy[channel] += energy;
+                        channel_samples[channel] += samples.len();
+                        frame_rms[channel].push((energy / samples.len().max(1) as f64).sqrt());
+                        constant_frame_values[channel].push(samples.first().copied().filter(
+                            |first| {
+                                samples
+                                    .iter()
+                                    .all(|sample| sample.to_bits() == first.to_bits())
+                            },
+                        ));
+                    }
+                    let samples = frame.x_samples[0].len();
+                    if frame
+                        .x_samples
+                        .iter()
+                        .all(|channel| channel.len() == samples)
+                    {
+                        for sample in 0..samples {
+                            let values: [f64; 4] = std::array::from_fn(|channel| {
+                                frame.x_samples[channel][sample] as f64
+                            });
+                            for a in 0..4 {
+                                sample_sum[a] += values[a];
+                                for b in 0..4 {
+                                    sample_cross[a][b] += values[a] * values[b];
+                                }
+                            }
+                        }
+                        joint_samples += samples;
+                        for (pair, &(a, b)) in CHANNEL_PAIRS.iter().enumerate() {
+                            let correlation =
+                                pearson_samples(&frame.x_samples[a], &frame.x_samples[b]);
+                            let rms_a = (frame.x_samples[a]
+                                .iter()
+                                .map(|&value| (value as f64).powi(2))
+                                .sum::<f64>()
+                                / samples.max(1) as f64)
+                                .sqrt();
+                            let rms_b = (frame.x_samples[b]
+                                .iter()
+                                .map(|&value| (value as f64).powi(2))
+                                .sum::<f64>()
+                                / samples.max(1) as f64)
+                                .sqrt();
+                            frame_pair_correlation[pair].push(correlation);
+                            frame_pair_balance[pair].push(rms_b / (rms_a + rms_b));
+                        }
+                    }
+                } else if let Some(error) = &frame.x_decode_error {
+                    *decode_errors.entry(error.to_string()).or_default() += 1;
+                }
+                let expected_channels =
+                    payload.get(22).copied().unwrap_or(3).saturating_sub(3) as usize;
+                let end = (payload.len().min(SEARCH_END_BYTE) * 8).saturating_sub(1);
+                let mut candidates = Vec::new();
+                for bit_offset in SEARCH_START..=end {
+                    if let Some(candidate) = candidate_at(payload, bit_offset) {
+                        candidates.push(candidate);
+                    }
+                }
+                if !candidates.is_empty() {
+                    candidate_frames += 1;
+                }
+                let mut count_match = false;
+                for candidate in candidates {
+                    *all_offsets.entry(candidate.bit_offset).or_default() += 1;
+                    if candidate.bit_offset == SEARCH_START {
+                        exact_offset_frames += 1;
+                        *exact_basic_fields
+                            .entry((
+                                candidate.header_size,
+                                candidate.channels,
+                                candidate.pcm_resolution,
+                                candidate.residual_mask,
+                            ))
+                            .or_default() += 1;
+                        let start = candidate.bit_offset / 8;
+                        let end = start + candidate.header_size;
+                        if candidate.storage_resolution == 24
+                            && end <= payload.len()
+                            && crc16_ccitt(&payload[start..end]) == 0
+                        {
+                            exact_offset_crc_valid += 1;
+                        }
+                    }
+                    if candidate.channels == expected_channels {
+                        count_match = true;
+                        *count_matching_offsets
+                            .entry(candidate.bit_offset)
+                            .or_default() += 1;
+                        *header_sizes.entry(candidate.header_size).or_default() += 1;
+                        if first_candidates.len() < 16 {
+                            first_candidates.push((
+                                frames,
+                                candidate.bit_offset,
+                                candidate.header_size,
+                                candidate.channels,
+                            ));
+                        }
+                    }
+                }
+                if count_match {
+                    count_matching_frames += 1;
+                }
+            }
+            frames += 1;
+        }
+        offset += core.frame_size + exss_len;
+    }
+
+    println!("read {read} bytes from {path}");
+    println!("decoded frames: {frames}; XLL-X payloads: {payloads}");
+    println!(
+        "inherited XLL geometry (segments, samples/segment, size bits, band CRC, scalable LSB): \
+         {frame_geometry:?}"
+    );
+    println!(
+        "first payload (bytes, header bytes, data start, data head, payload tail): \
+         {first_layout_bytes:02x?}"
+    );
+    println!("frames with any basic XLL chset candidate: {candidate_frames}");
+    println!(
+        "candidate at byte 22: {exact_offset_frames}; valid CRC16-CCITT: \
+         {exact_offset_crc_valid}/{exact_offset_frames}"
+    );
+    println!("decoded four-channel audio frames: {decoded_audio_frames}/{payloads}");
+    println!(
+        "frames located through EXSS descriptor navigation: {descriptor_navigation_frames}/{payloads}"
+    );
+    println!(
+        "first descriptor fallbacks (frame, hinted/actual offset, hinted/actual size): \
+         {first_descriptor_fallbacks:?}"
+    );
+    println!("extension decode errors: {decode_errors:?}");
+    let mut navigation_deltas = navigation_deltas.into_iter().collect::<Vec<_>>();
+    navigation_deltas.sort_unstable_by_key(|&(delta, _)| delta);
+    println!("payload bytes after predicted audio end: {navigation_deltas:?}");
+    println!("two-byte trailer CRC valid from offsets 0/4/22: {trailer_crc_valid:?}");
+    let mut trailer_words = trailer_words.into_iter().collect::<Vec<_>>();
+    trailer_words.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "most common two-byte trailers: {:?}",
+        trailer_words.into_iter().take(12).collect::<Vec<_>>()
+    );
+    let mut descriptor_tails = descriptor_tails.into_iter().collect::<Vec<_>>();
+    descriptor_tails.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "EXSS descriptor tails (bits, bytes, frames), {} distinct: {:?}",
+        descriptor_tails.len(),
+        descriptor_tails
+            .into_iter()
+            .take(8)
+            .map(|((bits, bytes), frames)| (bits, bytes, frames))
+            .collect::<Vec<_>>()
+    );
+    println!("unparsed channel-header tail bits (includes CRC16): {channel_header_tails:?}");
+    if !trailing_bits.is_empty() {
+        println!(
+            "trailing bits after sample decode: min={} max={}",
+            trailing_bits.iter().min().unwrap(),
+            trailing_bits.iter().max().unwrap()
+        );
+        let rms: Vec<_> = channel_energy
+            .iter()
+            .zip(channel_samples)
+            .map(|(&energy, samples)| (energy / samples.max(1) as f64).sqrt())
+            .collect();
+        println!("decoded channel RMS: {rms:?}");
+        println!("frame-RMS correlation matrix:");
+        for a in 0..4 {
+            println!(
+                "  {}: {:?}",
+                a,
+                (0..4)
+                    .map(|b| pearson(&frame_rms[a], &frame_rms[b]))
+                    .collect::<Vec<_>>()
+            );
+        }
+        println!("sample correlation matrix:");
+        for a in 0..4 {
+            println!(
+                "  {}: {:?}",
+                a,
+                (0..4)
+                    .map(|b| aggregate_pearson(
+                        sample_sum[a],
+                        sample_sum[b],
+                        sample_cross[a][a],
+                        sample_cross[b][b],
+                        sample_cross[a][b],
+                        joint_samples,
+                    ))
+                    .collect::<Vec<_>>()
+            );
+        }
+        println!("least-squares pair fits (A->B: gain, residual/B RMS):");
+        for a in 0..4 {
+            for b in a + 1..4 {
+                let gain = sample_cross[a][b] / sample_cross[a][a];
+                let residual_energy = (sample_cross[b][b] - gain * sample_cross[a][b]).max(0.0);
+                let residual_ratio = (residual_energy / sample_cross[b][b]).sqrt();
+                println!("  {a}->{b}: {gain:.9}, {residual_ratio:.9}");
+            }
+        }
+        println!("per-frame coherent pairs (|correlation| >= 0.98):");
+        for (pair, &(a, b)) in CHANNEL_PAIRS.iter().enumerate() {
+            let coherent = frame_pair_correlation[pair]
+                .iter()
+                .zip(&frame_pair_balance[pair])
+                .filter_map(|(&correlation, &balance)| {
+                    (correlation.abs() >= 0.98 && balance.is_finite()).then_some(balance)
+                })
+                .collect::<Vec<_>>();
+            let steps = frame_pair_correlation[pair]
+                .windows(2)
+                .zip(frame_pair_balance[pair].windows(2))
+                .filter_map(|(correlations, balances)| {
+                    (correlations[0].abs() >= 0.98
+                        && correlations[1].abs() >= 0.98
+                        && balances[0].is_finite()
+                        && balances[1].is_finite())
+                    .then_some((balances[1] - balances[0]).abs())
+                })
+                .collect::<Vec<_>>();
+            if !coherent.is_empty() {
+                println!(
+                    "  {a}/{b}: {}/{} frames, balance B p10/p50/p90={:.4}/{:.4}/{:.4}, \
+                     step p50/p90={:.5}/{:.5}",
+                    coherent.len(),
+                    frame_pair_correlation[pair].len(),
+                    percentile(&coherent, 0.1),
+                    percentile(&coherent, 0.5),
+                    percentile(&coherent, 0.9),
+                    percentile(&steps, 0.5),
+                    percentile(&steps, 0.9),
+                );
+            }
+        }
+        println!("constant-PCM frames by channel:");
+        for (channel, values) in constant_frame_values.iter().enumerate() {
+            let constant = values.iter().flatten().copied().collect::<Vec<_>>();
+            let distinct = constant
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<std::collections::HashSet<_>>();
+            let first_transitions = values
+                .iter()
+                .enumerate()
+                .filter_map(|(frame, value)| value.map(|value| (frame, value)))
+                .scan(None, |previous: &mut Option<u32>, (frame, value)| {
+                    let bits = value.to_bits();
+                    let changed = previous.is_none_or(|previous| previous != bits);
+                    *previous = Some(bits);
+                    Some(changed.then_some((frame, value * 8_388_608.0)))
+                })
+                .flatten()
+                .take(16)
+                .collect::<Vec<_>>();
+            println!(
+                "  {channel}: {}/{} frames, {} distinct; first transitions as 24-bit PCM: {:?}",
+                constant.len(),
+                values.len(),
+                distinct.len(),
+                first_transitions,
+            );
+        }
+    }
+    println!(
+        "frames with candidate channels == byte22-3: {count_matching_frames} ({:.3}%)",
+        100.0 * count_matching_frames as f64 / payloads.max(1) as f64
+    );
+    let mut offsets: Vec<_> = count_matching_offsets.into_iter().collect();
+    offsets.sort_by(|a, b| b.1.cmp(&a.1));
+    println!("top matching bit offsets as offset:frames:");
+    for (bit_offset, occurrences) in offsets.into_iter().take(16) {
+        println!(
+            "  {bit_offset:>4} (byte {:>3} + bit {}): {occurrences}",
+            bit_offset / 8,
+            bit_offset % 8
+        );
+    }
+    let mut sizes: Vec<_> = header_sizes.into_iter().collect();
+    sizes.sort_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "top matching header sizes: {:?}",
+        &sizes[..sizes.len().min(12)]
+    );
+    let mut basic_fields: Vec<_> = exact_basic_fields.into_iter().collect();
+    basic_fields.sort_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "byte-22 fields as (header bytes, channels, PCM bits, residual mask): {:?}",
+        &basic_fields[..basic_fields.len().min(20)]
+    );
+    println!("first matching candidates (frame, bit, header bytes, channels):");
+    for candidate in first_candidates {
+        println!("  {candidate:?}");
+    }
+
+    let mut any_offsets: Vec<_> = all_offsets.into_iter().collect();
+    any_offsets.sort_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "top offsets regardless of channel count: {:?}",
+        &any_offsets[..any_offsets.len().min(12)]
+    );
+}
+
+fn pearson(a: &[f64], b: &[f64]) -> f64 {
+    let n = a.len().min(b.len());
+    let am = a[..n].iter().sum::<f64>() / n.max(1) as f64;
+    let bm = b[..n].iter().sum::<f64>() / n.max(1) as f64;
+    let mut covariance = 0.0;
+    let mut av = 0.0;
+    let mut bv = 0.0;
+    for (&x, &y) in a[..n].iter().zip(&b[..n]) {
+        covariance += (x - am) * (y - bm);
+        av += (x - am).powi(2);
+        bv += (y - bm).powi(2);
+    }
+    covariance / (av * bv).sqrt()
+}
+
+fn aggregate_pearson(
+    sum_a: f64,
+    sum_b: f64,
+    square_a: f64,
+    square_b: f64,
+    cross: f64,
+    samples: usize,
+) -> f64 {
+    let n = samples.max(1) as f64;
+    let covariance = cross - sum_a * sum_b / n;
+    let variance_a = square_a - sum_a * sum_a / n;
+    let variance_b = square_b - sum_b * sum_b / n;
+    covariance / (variance_a * variance_b).sqrt()
+}
+
+fn pearson_samples(a: &[f32], b: &[f32]) -> f64 {
+    let samples = a.len().min(b.len());
+    let mut sum_a = 0.0;
+    let mut sum_b = 0.0;
+    let mut square_a = 0.0;
+    let mut square_b = 0.0;
+    let mut cross = 0.0;
+    for (&a, &b) in a[..samples].iter().zip(&b[..samples]) {
+        let a = a as f64;
+        let b = b as f64;
+        sum_a += a;
+        sum_b += b;
+        square_a += a * a;
+        square_b += b * b;
+        cross += a * b;
+    }
+    aggregate_pearson(sum_a, sum_b, square_a, square_b, cross, samples)
+}
+
+fn percentile(values: &[f64], quantile: f64) -> f64 {
+    if values.is_empty() {
+        return f64::NAN;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable_by(f64::total_cmp);
+    sorted[((sorted.len() - 1) as f64 * quantile).round() as usize]
+}

--- a/dca/examples/xll_x_mda.rs
+++ b/dca/examples/xll_x_mda.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Test whether the DTS:X XLL-X extension directly embeds the open MDA
+// bitstream syntax from ETSI TS 103 223.  The MDA frame-header local label is
+// encoded as the distinctive 24-bit sequence 0x81, 0x5a, 0xa5.  Search at
+// every bit alignment, and also look for the namespace/asset URI strings used
+// by the normative MDA packet grammar.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_x_mda -- <in.dts> [max_mb]
+
+// This is a falsification probe: no hits rules out byte-for-byte MDA framing,
+// but does not rule out a compact/private serialization of the MDA model.
+
+use std::io::Read;
+
+use dca::parser::parse_header;
+use dca::{exss_substream_size, HdDecoder};
+
+const MDA_FRAME_HEADER: [u8; 3] = [0x81, 0x5a, 0xa5];
+const URI_MARKERS: [&[u8]; 3] = [b"mdaif.org", b"urn:x-mda", b"bitstream:afid:"];
+
+fn bit_at(data: &[u8], bit: usize) -> u8 {
+    (data[bit / 8] >> (7 - bit % 8)) & 1
+}
+
+fn find_bits(data: &[u8], pattern: &[u8]) -> Vec<usize> {
+    let pattern_bits = pattern.len() * 8;
+    if data.len() * 8 < pattern_bits {
+        return Vec::new();
+    }
+
+    let mut hits = Vec::new();
+    for start in 0..=data.len() * 8 - pattern_bits {
+        let matches = (0..pattern_bits).all(|i| bit_at(data, start + i) == bit_at(pattern, i));
+        if matches {
+            hits.push(start);
+        }
+    }
+    hits
+}
+
+fn contains_bytes(data: &[u8], needle: &[u8]) -> bool {
+    data.windows(needle.len()).any(|window| window == needle)
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: xll_x_mda <in.dts> [max_mb]");
+    let max_mb: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(64);
+
+    let mut input = std::fs::File::open(&path).expect("open input");
+    let mut bytes = vec![0u8; max_mb * 1024 * 1024];
+    let read = input.read(&mut bytes).expect("read input");
+    bytes.truncate(read);
+
+    let mut decoder = HdDecoder::new();
+    let mut offset = 0usize;
+    let mut frames = 0usize;
+    let mut payloads = 0usize;
+    let mut payload_bytes = 0usize;
+    let mut signature_hits = 0usize;
+    let mut hit_frames = 0usize;
+    let mut alignment_hits = [0usize; 8];
+    let mut first_hits = Vec::new();
+    let mut uri_hits = [0usize; URI_MARKERS.len()];
+
+    while offset + 18 < bytes.len() {
+        let core = match parse_header(&bytes[offset..]) {
+            Ok(header) => header,
+            Err(_) => break,
+        };
+        let exss_offset = offset + core.frame_size;
+        if exss_offset + 4 > bytes.len() {
+            break;
+        }
+        let exss_len = match exss_substream_size(&bytes[exss_offset..]) {
+            Some(len) if exss_offset + len <= bytes.len() => len,
+            _ => break,
+        };
+
+        if let Ok(frame) = decoder.decode(
+            &bytes[offset..exss_offset],
+            &bytes[exss_offset..exss_offset + exss_len],
+        ) {
+            if frame.x_present || frame.x_imax {
+                let payload = &frame.x_payload;
+                payloads += 1;
+                payload_bytes += payload.len();
+
+                let hits = find_bits(payload, &MDA_FRAME_HEADER);
+                if !hits.is_empty() {
+                    hit_frames += 1;
+                }
+                for bit_offset in hits {
+                    signature_hits += 1;
+                    alignment_hits[bit_offset % 8] += 1;
+                    if first_hits.len() < 16 {
+                        first_hits.push((frames, bit_offset));
+                    }
+                }
+
+                for (i, marker) in URI_MARKERS.iter().enumerate() {
+                    if contains_bytes(payload, marker) {
+                        uri_hits[i] += 1;
+                    }
+                }
+            }
+            frames += 1;
+        }
+
+        offset += core.frame_size + exss_len;
+    }
+
+    // For uniformly random data, the expected number of accidental 24-bit
+    // matches is approximately the number of tested starts divided by 2^24.
+    let expected_random = (payload_bytes.saturating_mul(8)) as f64 / (1u64 << 24) as f64;
+    println!("read {read} bytes from {path}");
+    println!("decoded frames: {frames}; XLL-X payloads: {payloads}");
+    println!("payload bytes scanned: {payload_bytes}");
+    println!(
+        "MDA frame-header signature 81 5a a5: {signature_hits} hits in {hit_frames} frames \
+         (random expectation {expected_random:.3})"
+    );
+    println!("hits by starting bit alignment: {alignment_hits:?}");
+    if !first_hits.is_empty() {
+        println!("first hits as (frame, bit offset): {first_hits:?}");
+    }
+    for (marker, hits) in URI_MARKERS.iter().zip(uri_hits) {
+        println!(
+            "ASCII marker {:?}: {hits} payloads",
+            String::from_utf8_lossy(marker)
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_bits;
+
+    #[test]
+    fn finds_byte_aligned_pattern() {
+        assert_eq!(
+            find_bits(&[0, 0x81, 0x5a, 0xa5, 0], &[0x81, 0x5a, 0xa5]),
+            vec![8]
+        );
+    }
+
+    #[test]
+    fn finds_unaligned_pattern() {
+        // 0x81_5a_a5 shifted right by three bits, with zero padding.
+        assert_eq!(
+            find_bits(&[0x00, 0x10, 0x2b, 0x54, 0xa0], &[0x81, 0x5a, 0xa5]),
+            vec![11]
+        );
+    }
+}

--- a/dca/examples/xll_x_meta.rs
+++ b/dca/examples/xll_x_meta.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Characterize the 64 profile-specific bits in the EXSS asset descriptor of
+// XLL-X streams. Legacy TS 102 114 decoders skip this reserved region.
+//
+// Usage: cargo run -p dca --release --example xll_x_meta -- <in.dts> [max_mb]
+
+use std::collections::{HashMap, HashSet};
+use std::io::Read;
+
+use dca::parser::parse_header;
+use dca::{exss_substream_size, HdDecoder};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: xll_x_meta <in.dts> [max_mb]");
+    let max_mb: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(64);
+
+    let mut input = std::fs::File::open(&path).expect("open input");
+    let mut bytes = vec![0u8; max_mb * 1024 * 1024];
+    let read = input.read(&mut bytes).expect("read input");
+    bytes.truncate(read);
+
+    let mut decoder = HdDecoder::new();
+    let mut offset = 0usize;
+    let mut words = Vec::new();
+    let mut x_payload_offsets = Vec::new();
+    let mut x_payload_sizes = Vec::new();
+    let mut tail_lengths = HashMap::new();
+
+    while offset + 18 < bytes.len() {
+        let core = match parse_header(&bytes[offset..]) {
+            Ok(header) => header,
+            Err(_) => break,
+        };
+        let exss_offset = offset + core.frame_size;
+        if exss_offset + 4 > bytes.len() {
+            break;
+        }
+        let exss_len = match exss_substream_size(&bytes[exss_offset..]) {
+            Some(len) if exss_offset + len <= bytes.len() => len,
+            _ => break,
+        };
+        if let Ok(frame) = decoder.decode(
+            &bytes[offset..exss_offset],
+            &bytes[exss_offset..exss_offset + exss_len],
+        ) {
+            *tail_lengths
+                .entry(frame.exss_descriptor_tail_bits)
+                .or_insert(0usize) += 1;
+            if frame.exss_descriptor_tail.len() >= 8 {
+                words.push(u64::from_be_bytes(
+                    frame.exss_descriptor_tail[..8].try_into().unwrap(),
+                ));
+                x_payload_offsets.push(frame.x_payload_offset);
+                x_payload_sizes.push(frame.x_payload.len());
+            }
+        }
+        offset += core.frame_size + exss_len;
+    }
+
+    println!("read {read} bytes from {path}; tail lengths: {tail_lengths:?}");
+    println!(
+        "captured {} words; {} distinct",
+        words.len(),
+        words.iter().copied().collect::<HashSet<_>>().len()
+    );
+    let navigation_matches = words
+        .iter()
+        .enumerate()
+        .filter(|&(index, &word)| {
+            let offset = ((word >> 45) & 0x7ff) as usize * 4;
+            let size = ((word >> 6) & 0x3ff) as usize * 4 + 24;
+            offset == x_payload_offsets[index] && size == x_payload_sizes[index]
+        })
+        .count();
+    let syntax_matches = words
+        .iter()
+        .filter(|&&word| {
+            let high = (word >> 32) as u32;
+            let low = word as u32;
+            high & !0x00ff_e000 == 0x1800_0000 && low & !0x0000_ffc0 == 0x8a28_0000
+        })
+        .count();
+    println!(
+        "XLL-X navigation syntax matches: {syntax_matches}/{}",
+        words.len()
+    );
+    println!(
+        "XLL-X navigation identity matches: {navigation_matches}/{}",
+        words.len()
+    );
+    let first_mismatches = words
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &word)| {
+            let encoded_offset = ((word >> 45) & 0x7ff) as usize * 4;
+            let encoded_size = ((word >> 6) & 0x3ff) as usize * 4 + 24;
+            let actual_offset = x_payload_offsets[index];
+            let actual_size = x_payload_sizes[index];
+            (encoded_offset != actual_offset || encoded_size != actual_size).then_some((
+                index,
+                encoded_offset,
+                actual_offset,
+                encoded_size,
+                actual_size,
+            ))
+        })
+        .take(12)
+        .collect::<Vec<_>>();
+    println!("first navigation mismatches (frame, encoded/actual offset, encoded/actual size): {first_mismatches:?}");
+    println!("navigation matches by decoded-frame lag (actual index = metadata index + lag):");
+    for lag in -4isize..=4 {
+        let mut matches = 0usize;
+        let mut compared = 0usize;
+        for (index, &word) in words.iter().enumerate() {
+            let actual = index as isize + lag;
+            if !(0..words.len() as isize).contains(&actual) {
+                continue;
+            }
+            let actual = actual as usize;
+            let offset = ((word >> 45) & 0x7ff) as usize * 4;
+            let size = ((word >> 6) & 0x3ff) as usize * 4 + 24;
+            matches +=
+                usize::from(offset == x_payload_offsets[actual] && size == x_payload_sizes[actual]);
+            compared += 1;
+        }
+        println!("  {lag:+}: {matches}/{compared}");
+    }
+    println!("first words (frame, seconds, u64, four u16 lanes, bed/ext bytes):");
+    for (frame, &word) in words.iter().take(32).enumerate() {
+        let lanes = [
+            (word >> 48) as u16,
+            (word >> 32) as u16,
+            (word >> 16) as u16,
+            word as u16,
+        ];
+        println!(
+            "  {frame:>5} {:>9.5}  {word:016x}  {lanes:04x?}  {:>5}/{:>4}",
+            frame as f64 * 512.0 / 48_000.0,
+            x_payload_offsets[frame],
+            x_payload_sizes[frame]
+        );
+    }
+
+    let mut ones = [0usize; 64];
+    let mut toggles = [0usize; 64];
+    for (index, &word) in words.iter().enumerate() {
+        for bit in 0..64 {
+            ones[bit] += ((word >> (63 - bit)) & 1) as usize;
+            if index > 0 {
+                toggles[bit] += (((word ^ words[index - 1]) >> (63 - bit)) & 1) as usize;
+            }
+        }
+    }
+    println!("bit statistics (MSB-first index: ones/toggles):");
+    for bit in 0..64 {
+        if ones[bit] != 0 || toggles[bit] != 0 {
+            println!("  {bit:>2}: {:>6}/{:>6}", ones[bit], toggles[bit]);
+        }
+    }
+
+    println!("signed delta ranges for four 16-bit lanes:");
+    for lane in 0..4 {
+        let shift = 48 - 16 * lane;
+        let mut minimum = i32::MAX;
+        let mut maximum = i32::MIN;
+        let mut zero = 0usize;
+        for pair in words.windows(2) {
+            let previous = ((pair[0] >> shift) & 0xffff) as i32;
+            let current = ((pair[1] >> shift) & 0xffff) as i32;
+            let delta = current - previous;
+            minimum = minimum.min(delta);
+            maximum = maximum.max(delta);
+            zero += usize::from(delta == 0);
+        }
+        println!("  lane {lane}: {minimum}..{maximum}, unchanged {zero}");
+    }
+}

--- a/dca/examples/xll_x_pair.rs
+++ b/dca/examples/xll_x_pair.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Compare two encodes of the same programme (for example two language tracks)
+// frame by frame.  Fields and independently coded object blocks shared by the
+// two tracks are candidates for geometry/metadata or unchanged music/effects;
+// divergent regions are candidates for language-specific object audio.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_x_pair -- <a.dts> <b.dts> [max_mb]
+
+use std::collections::HashMap;
+use std::io::Read;
+
+use dca::parser::parse_header;
+use dca::{exss_substream_size, HdDecoder};
+
+const HEADER_SCAN: usize = 128;
+const DATA_START: usize = 27;
+const MAX_LAG: isize = 512;
+
+struct Capture {
+    payload: Vec<u8>,
+    rms: [f64; 4],
+    descriptor_word: Option<u64>,
+}
+
+fn load_payloads(path: &str, max_mb: usize) -> Vec<Capture> {
+    let mut input = std::fs::File::open(path).expect("open input");
+    let mut bytes = vec![0u8; max_mb * 1024 * 1024];
+    let read = input.read(&mut bytes).expect("read input");
+    bytes.truncate(read);
+
+    let mut decoder = HdDecoder::new();
+    let mut payloads = Vec::new();
+    let mut offset = 0usize;
+    while offset + 18 < bytes.len() {
+        let core = match parse_header(&bytes[offset..]) {
+            Ok(header) => header,
+            Err(_) => break,
+        };
+        let exss_offset = offset + core.frame_size;
+        if exss_offset + 4 > bytes.len() {
+            break;
+        }
+        let exss_len = match exss_substream_size(&bytes[exss_offset..]) {
+            Some(len) if exss_offset + len <= bytes.len() => len,
+            _ => break,
+        };
+        if let Ok(frame) = decoder.decode(
+            &bytes[offset..exss_offset],
+            &bytes[exss_offset..exss_offset + exss_len],
+        ) {
+            if frame.x_present || frame.x_imax {
+                let mut rms = [0.0; 4];
+                for (slot, samples) in rms.iter_mut().zip(&frame.x_samples) {
+                    *slot = (samples
+                        .iter()
+                        .map(|&sample| (sample as f64).powi(2))
+                        .sum::<f64>()
+                        / samples.len().max(1) as f64)
+                        .sqrt();
+                }
+                payloads.push(Capture {
+                    payload: frame.x_payload,
+                    rms,
+                    descriptor_word: frame
+                        .exss_descriptor_tail
+                        .get(..8)
+                        .map(|bytes| u64::from_be_bytes(bytes.try_into().unwrap())),
+                });
+            }
+        }
+        offset += core.frame_size + exss_len;
+    }
+    eprintln!(
+        "{path}: read {read} bytes, captured {} payloads",
+        payloads.len()
+    );
+    payloads
+}
+
+fn aligned_range(a_len: usize, b_len: usize, lag: isize) -> (usize, usize, usize) {
+    let a_start = (-lag).max(0) as usize;
+    let b_start = lag.max(0) as usize;
+    let count = (a_len - a_start).min(b_len - b_start);
+    (a_start, b_start, count)
+}
+
+fn infer_lag(a: &[Capture], b: &[Capture]) -> (isize, f64, usize) {
+    let mut best = (0, f64::NEG_INFINITY, 0);
+    for lag in -MAX_LAG..=MAX_LAG {
+        let (a_start, b_start, count) = aligned_range(a.len(), b.len(), lag);
+        let a_energy = (0..count)
+            .map(|i| a[a_start + i].rms.iter().sum::<f64>())
+            .collect::<Vec<_>>();
+        let b_energy = (0..count)
+            .map(|i| b[b_start + i].rms.iter().sum::<f64>())
+            .collect::<Vec<_>>();
+        let correlation = pearson(&a_energy, &b_energy);
+        if correlation > best.1 || (correlation == best.1 && count > best.2) {
+            best = (lag, correlation, count);
+        }
+    }
+    best
+}
+
+fn pearson(a: &[f64], b: &[f64]) -> f64 {
+    let n = a.len().min(b.len());
+    if n == 0 {
+        return f64::NAN;
+    }
+    let am = a[..n].iter().sum::<f64>() / n as f64;
+    let bm = b[..n].iter().sum::<f64>() / n as f64;
+    let mut covariance = 0.0;
+    let mut av = 0.0;
+    let mut bv = 0.0;
+    for (&x, &y) in a[..n].iter().zip(&b[..n]) {
+        covariance += (x - am) * (y - bm);
+        av += (x - am).powi(2);
+        bv += (y - bm).powi(2);
+    }
+    covariance / (av * bv).sqrt()
+}
+
+fn percentile(values: &mut [usize], numerator: usize, denominator: usize) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    values.sort_unstable();
+    values[(values.len() - 1) * numerator / denominator]
+}
+
+fn common_prefix(a: &[u8], b: &[u8], start: usize) -> usize {
+    let mut n = 0;
+    while start + n < a.len() && start + n < b.len() && a[start + n] == b[start + n] {
+        n += 1;
+    }
+    n
+}
+
+fn common_suffix(a: &[u8], b: &[u8]) -> usize {
+    a.iter()
+        .rev()
+        .zip(b.iter().rev())
+        .take_while(|(x, y)| x == y)
+        .count()
+}
+
+fn u64_at(data: &[u8], offset: usize) -> u64 {
+    u64::from_be_bytes(data[offset..offset + 8].try_into().unwrap())
+}
+
+fn longest_common_run(a: &[u8], b: &[u8], start: usize) -> (usize, isize) {
+    if a.len() < start + 8 || b.len() < start + 8 {
+        return (0, 0);
+    }
+    let mut anchors: HashMap<u64, Vec<usize>> = HashMap::new();
+    for j in start..=b.len() - 8 {
+        let positions = anchors.entry(u64_at(b, j)).or_default();
+        if positions.len() < 4 {
+            positions.push(j);
+        }
+    }
+
+    let mut best = (0usize, 0isize);
+    for i in start..=a.len() - 8 {
+        let Some(candidates) = anchors.get(&u64_at(a, i)) else {
+            continue;
+        };
+        for &j in candidates {
+            let mut left = 0;
+            while left < i - start && left < j - start && a[i - left - 1] == b[j - left - 1] {
+                left += 1;
+            }
+            let mut right = 8;
+            while i + right < a.len() && j + right < b.len() && a[i + right] == b[j + right] {
+                right += 1;
+            }
+            let length = left + right;
+            if length > best.0 {
+                best = (length, j as isize - i as isize);
+            }
+        }
+    }
+    best
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let a_path = args
+        .next()
+        .expect("usage: xll_x_pair <a.dts> <b.dts> [max_mb]");
+    let b_path = args
+        .next()
+        .expect("usage: xll_x_pair <a.dts> <b.dts> [max_mb]");
+    let max_mb: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(64);
+
+    let a = load_payloads(&a_path, max_mb);
+    let b = load_payloads(&b_path, max_mb);
+    let (lag, alignment_correlation, alignment_count) = infer_lag(&a, &b);
+    let (a_start, b_start, count) = aligned_range(a.len(), b.len(), lag);
+    println!(
+        "best alignment: B frame = A frame + {lag}; four-channel RMS correlation \
+         {alignment_correlation:.6} over {alignment_count} frames"
+    );
+
+    let mut per_offset_equal = [0usize; HEADER_SCAN];
+    let mut per_offset_total = [0usize; HEADER_SCAN];
+    let mut exact_payloads = 0usize;
+    let mut equal_data_bytes = 0usize;
+    let mut total_data_bytes = 0usize;
+    let mut prefixes = Vec::with_capacity(count);
+    let mut suffixes = Vec::with_capacity(count);
+    let mut common_runs = Vec::with_capacity(count);
+    let mut run_deltas: HashMap<isize, usize> = HashMap::new();
+    let mut lengths_a = Vec::with_capacity(count);
+    let mut lengths_b = Vec::with_capacity(count);
+
+    for i in 0..count {
+        let pa = &a[a_start + i].payload;
+        let pb = &b[b_start + i].payload;
+        if pa == pb {
+            exact_payloads += 1;
+        }
+        for offset in 0..HEADER_SCAN.min(pa.len()).min(pb.len()) {
+            per_offset_total[offset] += 1;
+            if pa[offset] == pb[offset] {
+                per_offset_equal[offset] += 1;
+            }
+        }
+        for (&x, &y) in pa.iter().skip(DATA_START).zip(pb.iter().skip(DATA_START)) {
+            total_data_bytes += 1;
+            if x == y {
+                equal_data_bytes += 1;
+            }
+        }
+        prefixes.push(common_prefix(pa, pb, 22));
+        suffixes.push(common_suffix(pa, pb));
+        let (run, delta) = longest_common_run(pa, pb, DATA_START);
+        common_runs.push(run);
+        if run >= 16 {
+            *run_deltas.entry(delta).or_default() += 1;
+        }
+        lengths_a.push(pa.len() as f64);
+        lengths_b.push(pb.len() as f64);
+    }
+
+    println!("aligned payloads: {count}; exactly identical: {exact_payloads}");
+    let mut equal_descriptor_words = 0usize;
+    let mut descriptor_a = Vec::new();
+    let mut descriptor_b = Vec::new();
+    for i in 0..count {
+        if let (Some(a_word), Some(b_word)) = (
+            a[a_start + i].descriptor_word,
+            b[b_start + i].descriptor_word,
+        ) {
+            equal_descriptor_words += usize::from(a_word == b_word);
+            descriptor_a.push(((a_word >> 45) & 0xff) as f64);
+            descriptor_b.push(((b_word >> 45) & 0xff) as f64);
+        }
+    }
+    println!(
+        "EXSS reserved 64-bit words identical: {equal_descriptor_words}/{}; first 8-bit field r={:.6}",
+        descriptor_a.len(),
+        pearson(&descriptor_a, &descriptor_b)
+    );
+    for channel in 0..4 {
+        let ea = (0..count)
+            .map(|i| a[a_start + i].rms[channel])
+            .collect::<Vec<_>>();
+        let eb = (0..count)
+            .map(|i| b[b_start + i].rms[channel])
+            .collect::<Vec<_>>();
+        println!(
+            "decoded channel {channel} frame-RMS Pearson r: {:.6}",
+            pearson(&ea, &eb)
+        );
+    }
+    println!(
+        "payload-length Pearson r: {:.4}",
+        pearson(&lengths_a, &lengths_b)
+    );
+    println!(
+        "same-offset data bytes after byte {DATA_START}: {equal_data_bytes}/{total_data_bytes} ({:.3}%)",
+        100.0 * equal_data_bytes as f64 / total_data_bytes.max(1) as f64
+    );
+    println!("\nper-offset equality (first {HEADER_SCAN} bytes):");
+    for offset in 0..HEADER_SCAN {
+        if per_offset_total[offset] == 0 {
+            break;
+        }
+        let fraction = 100.0 * per_offset_equal[offset] as f64 / per_offset_total[offset] as f64;
+        if offset < 32 || fraction >= 5.0 {
+            println!("  byte {offset:>3}: {fraction:>7.3}%");
+        }
+    }
+
+    let mut prefixes_copy = prefixes.clone();
+    let mut suffixes_copy = suffixes.clone();
+    let mut runs_copy = common_runs.clone();
+    println!("\nmatched-run distributions (bytes):");
+    println!(
+        "  prefix from byte 22: p50={} p90={} max={}",
+        percentile(&mut prefixes_copy, 1, 2),
+        percentile(&mut prefixes, 9, 10),
+        prefixes.iter().copied().max().unwrap_or(0)
+    );
+    println!(
+        "  suffix:              p50={} p90={} max={}",
+        percentile(&mut suffixes_copy, 1, 2),
+        percentile(&mut suffixes, 9, 10),
+        suffixes.iter().copied().max().unwrap_or(0)
+    );
+    println!(
+        "  longest run >=8:     p50={} p90={} max={}",
+        percentile(&mut runs_copy, 1, 2),
+        percentile(&mut common_runs, 9, 10),
+        common_runs.iter().copied().max().unwrap_or(0)
+    );
+
+    let mut deltas: Vec<_> = run_deltas.into_iter().collect();
+    deltas.sort_by(|a, b| b.1.cmp(&a.1));
+    println!("most common offsets B-A for matching runs >=16 bytes:");
+    for (delta, occurrences) in deltas.into_iter().take(12) {
+        println!("  {delta:>6}: {occurrences}");
+    }
+}

--- a/dca/src/dcadec/exss.rs
+++ b/dca/src/dcadec/exss.rs
@@ -49,6 +49,42 @@ fn skip(gb: &mut BitReader, n: usize) -> R<()> {
     gb.skip_bits_long(n).ok_or(ExssError::Bitstream)
 }
 #[inline]
+/// Post-navigation asset-descriptor fields observed in later bitstream
+/// revisions. Strictly speculative — see the call site: any `Err` (or an
+/// overrun, checked there) discards the whole read.
+#[allow(clippy::too_many_arguments)]
+fn parse_speculative_descriptor_tail(
+    gb: &mut BitReader,
+    a: &mut ExssAsset,
+    mix_metadata_present: bool,
+    mix_metadata_enabled: bool,
+    nmixoutconfigs: usize,
+    nmixoutchs: &[u32],
+    frame_duration_samples: usize,
+) -> R<()> {
+    if a.one_to_one_map_ch_to_spkr && mix_metadata_enabled && !mix_metadata_present {
+        let one_to_one_mixing = rb1(gb)?;
+        if one_to_one_mixing {
+            let per_channel_scale = rb1(gb)?;
+            for config in 0..nmixoutconfigs {
+                let values = if per_channel_scale {
+                    nmixoutchs[config] as usize
+                } else {
+                    1
+                };
+                skip(gb, 6 * values)?;
+            }
+        }
+    }
+    a.decode_in_secondary = rb1(gb)?;
+    a.drc_rev2_present = rb1(gb)?;
+    if a.drc_rev2_present {
+        skip(gb, 4)?; // DRCversion_Rev2
+        skip(gb, 8 * (frame_duration_samples / 256))?;
+    }
+    Ok(())
+}
+
 fn seek(gb: &mut BitReader, pos: usize) -> R<()> {
     if gb.seek(pos) {
         Ok(())
@@ -94,6 +130,16 @@ pub(crate) struct ExssAsset {
     pub(crate) xll_delay_nframes: u32,
     pub(crate) xll_sync_offset: usize,
     pub(crate) hd_stream_id: u32,
+    /// Unspecified tail of the audio asset descriptor. Newer profiles can put
+    /// metadata here while legacy decoders skip to `nuAssetDescriptFsize`.
+    pub(crate) descriptor_tail: Vec<u8>,
+    pub(crate) descriptor_tail_bits: usize,
+    pub(crate) decode_in_secondary: bool,
+    pub(crate) drc_rev2_present: bool,
+    /// Profile-specific XLL-X navigation: byte offset from the start of the
+    /// logical XLL frame, and full extension size in bytes.
+    pub(crate) xll_x_offset: Option<usize>,
+    pub(crate) xll_x_size: Option<usize>,
 }
 
 #[derive(Default)]
@@ -102,6 +148,7 @@ pub(crate) struct ExssParser {
     exss_size_nbits: usize,
     exss_size: usize,
     static_fields_present: bool,
+    frame_duration_samples: usize,
     mix_metadata_enabled: bool,
     nmixoutconfigs: usize,
     nmixoutchs: [u32; 4],
@@ -124,6 +171,7 @@ impl ExssParser {
 }
 
 impl ExssParser {
+
     /// Parse an EXSS substream (must start at the 0x64582025 syncword).
     pub(crate) fn parse(data: &[u8]) -> R<Self> {
         let mut s = ExssParser::default();
@@ -144,7 +192,7 @@ impl ExssParser {
         s.static_fields_present = rb1(&mut gb)?;
         if s.static_fields_present {
             skip(&mut gb, 2)?; // reference clock code
-            skip(&mut gb, 3)?; // frame duration
+            s.frame_duration_samples = 512 * (rb(&mut gb, 3)? as usize + 1);
             if rb1(&mut gb)? {
                 skip(&mut gb, 36)?; // timecode
             }
@@ -258,7 +306,8 @@ impl ExssParser {
         if drc_present && a.embedded_stereo {
             skip(gb, 8)?;
         }
-        if self.mix_metadata_enabled && rb1(gb)? {
+        let mix_metadata_present = self.mix_metadata_enabled && rb1(gb)?;
+        if mix_metadata_present {
             skip(gb, 1)?; // external mixing flag
             skip(gb, 6)?; // post mixing gain
             if rb(gb, 2)? == 3 {
@@ -346,7 +395,57 @@ impl ExssParser {
             a.hd_stream_id = rb(gb, 3)?;
         }
 
-        seek(gb, descr_pos + descr_size * 8)
+        let descr_end = descr_pos + descr_size * 8;
+        if gb.position() > descr_end {
+            return Err(ExssError::Invalid("asset descriptor fields exceed size"));
+        }
+
+        // Fields added after the decoder navigation block in later revisions
+        // of ETSI TS 102 114. Neither ffmpeg nor libdcadec parses them (both
+        // seek straight to the descriptor end), and their presence is an
+        // observed-corpus heuristic — so the parse is strictly best-effort: on
+        // any failure or overrun the fields are discarded and the reader
+        // rewinds. A mis-read here must NEVER invalidate the asset (a hard
+        // error would stall the whole track: the pipeline treats a failed
+        // EXSS parse as "not enough data yet" and stops consuming input).
+        let tail_fields_start = gb.position();
+        if parse_speculative_descriptor_tail(
+            gb,
+            a,
+            mix_metadata_present,
+            self.mix_metadata_enabled,
+            self.nmixoutconfigs,
+            &self.nmixoutchs,
+            self.frame_duration_samples,
+        )
+        .is_err()
+            || gb.position() > descr_end
+        {
+            a.decode_in_secondary = false;
+            a.drc_rev2_present = false;
+            seek(gb, tail_fields_start)?;
+        }
+
+        // Capture the remaining descriptor tail (reserved/profile-specific
+        // metadata) for XLL assets only — it is where the XLL-X navigation
+        // word lives. Byte-at-a-time: this runs per frame.
+        if a.extension_mask & DCA_EXSS_XLL != 0 {
+            a.descriptor_tail_bits = descr_end - gb.position();
+            a.descriptor_tail = vec![0; a.descriptor_tail_bits.div_ceil(8)];
+            let full_bytes = a.descriptor_tail_bits / 8;
+            for byte in a.descriptor_tail.iter_mut().take(full_bytes) {
+                *byte = rb(gb, 8)? as u8;
+            }
+            let rest_bits = a.descriptor_tail_bits % 8;
+            if rest_bits > 0 {
+                a.descriptor_tail[full_bytes] = (rb(gb, rest_bits)? as u8) << (8 - rest_bits);
+            }
+            if let Some((offset, size)) = parse_xll_x_navigation(&a.descriptor_tail) {
+                a.xll_x_offset = Some(offset);
+                a.xll_x_size = Some(size);
+            }
+        }
+        seek(gb, descr_end)
     }
 
     fn set_exss_offsets(&mut self) -> R<()> {
@@ -363,7 +462,9 @@ impl ExssParser {
         if a.extension_mask & DCA_EXSS_XLL != 0
             && a.extension_mask & (DCA_EXSS_XBR | DCA_EXSS_XXCH | DCA_EXSS_X96 | DCA_EXSS_LBR) != 0
         {
-            return Err(ExssError::Unsupported("intervening EXSS extension before XLL"));
+            return Err(ExssError::Unsupported(
+                "intervening EXSS extension before XLL",
+            ));
         }
 
         if a.extension_mask & DCA_EXSS_CORE != 0 {
@@ -382,6 +483,27 @@ impl ExssParser {
         }
         Ok(())
     }
+}
+
+/// Decode the profile-specific 64-bit XLL-X navigation word carried in the
+/// otherwise reserved asset-descriptor tail.
+///
+/// Observed syntax across the corpus:
+///   8-bit marker, 11-bit `offset / 4`, 13 zero bits,
+///   16-bit marker, 10-bit `(size - 24) / 4`, 6 zero bits.
+fn parse_xll_x_navigation(tail: &[u8]) -> Option<(usize, usize)> {
+    let bytes: [u8; 8] = tail.get(..8)?.try_into().ok()?;
+    let word = u64::from_be_bytes(bytes);
+    let high = (word >> 32) as u32;
+    let low = word as u32;
+    const OFFSET_FIELD_MASK: u32 = 0x00ff_e000;
+    const SIZE_FIELD_MASK: u32 = 0x0000_ffc0;
+    if high & !OFFSET_FIELD_MASK != 0x1800_0000 || low & !SIZE_FIELD_MASK != 0x8a28_0000 {
+        return None;
+    }
+    let offset = ((high & OFFSET_FIELD_MASK) >> 13) as usize * 4;
+    let size = ((low & SIZE_FIELD_MASK) >> 6) as usize * 4 + 24;
+    Some((offset, size))
 }
 
 fn parse_xll_parameters(gb: &mut BitReader, a: &mut ExssAsset, exss_size_nbits: usize) -> R<()> {
@@ -411,11 +533,24 @@ fn parse_lbr_parameters(gb: &mut BitReader) -> R<()> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn parses_xll_x_navigation_word() {
+        // offset 1400 = 350 * 4; size 648 = 156 * 4 + 24.
+        assert_eq!(
+            parse_xll_x_navigation(&0x182b_c000_8a28_2700u64.to_be_bytes()),
+            Some((1400, 648))
+        );
+        // 4188 = 1047 * 4 uses the eleventh offset bit.
+        let large = 0x1882_e000_8a28_3cc0u64.to_be_bytes();
+        assert_eq!(parse_xll_x_navigation(&large), Some((4188, 996)));
+        assert_eq!(parse_xll_x_navigation(&[0; 8]), None);
+    }
+
     // Validate EXSS parsing on the real Ex Machina DTS-HD MA stream (7.1).
     // Skips if the (uncommitted) dump is absent.
     #[test]
     fn parses_real_exss_locates_xll() {
-        const DUMP: &str = "/mnt/local/SSD_B-CT4000/Dumps/Ex.Machina.2014.dtsx.eng.dts";
+        const DUMP: &str = "/mnt/local/SSD_A-CT4000/DTS:X-Dumps/Ex.Machina.2014.dtsx.eng.dts";
         if !std::path::Path::new(DUMP).exists() {
             eprintln!("skipping: 7.1 dump not present");
             return;
@@ -427,7 +562,11 @@ mod tests {
         let core = crate::parser::parse_header(&bytes).expect("core header");
         let pos = core.frame_size;
         let sync = 0x6458_2025u32.to_be_bytes();
-        assert_eq!(&bytes[pos..pos + 4], &sync, "EXSS not right after core frame");
+        assert_eq!(
+            &bytes[pos..pos + 4],
+            &sync,
+            "EXSS not right after core frame"
+        );
         let s = ExssParser::parse(&bytes[pos..]).expect("parse exss");
         let a = &s.asset;
         eprintln!(

--- a/dca/src/dcadec/xll.rs
+++ b/dca/src/dcadec/xll.rs
@@ -18,6 +18,10 @@ use crate::bitstream::BitReader;
 const DCA_XLL_CHANNELS_MAX: usize = 8;
 const DCA_XLL_CHSETS_MAX: usize = 3;
 const DCA_XLL_PRED_ORDER_MAX: usize = 16;
+/// XLL-X (DTS:X spatial extension) end-of-frame syncword.
+const DCA_SYNCWORD_XLL_X: u32 = 0x0200_0850;
+/// XLL-X IMAX-variant syncword (low bit varies across titles).
+const DCA_SYNCWORD_XLL_X_IMAX: u32 = 0xF140_00D0;
 const DCA_SYNCWORD_XLL: u32 = 0x41A2_9547;
 const FF_DCA_DMIXTABLE_OFFSET: usize = 242 - 201; // SIZE - INV_SIZE
 const FF_DCA_DMIXTABLE_SIZE: usize = 242;
@@ -31,6 +35,16 @@ pub(crate) enum XllError {
     Unsupported(&'static str),
 }
 type R<T> = Result<T, XllError>;
+
+/// Allocation-free kind string for a failed XLL-X decode (the audio path
+/// never formats errors per frame; the bridge logs this rate-limited).
+fn xll_x_error_kind(error: &XllError) -> &'static str {
+    match error {
+        XllError::Eagain => "eagain",
+        XllError::Bitstream => "bitstream",
+        XllError::Invalid(what) | XllError::Unsupported(what) => what,
+    }
+}
 
 #[inline]
 fn rb(gb: &mut BitReader, n: usize) -> R<u32> {
@@ -149,19 +163,20 @@ struct XllChSet {
     bitalloc_part_a: [usize; DCA_XLL_CHANNELS_MAX],
     bitalloc_part_b: [usize; DCA_XLL_CHANNELS_MAX],
     nsamples_part_a: [usize; DCA_XLL_CHANNELS_MAX],
+    header_tail_bits: usize,
 }
 
 #[derive(Default)]
 pub(crate) struct XllDecoder {
     frame_size: usize,
     nchsets: usize,
-    nframesegs: usize,
+    pub(crate) nframesegs: usize,
     nsegsamples_log2: usize,
-    nsegsamples: usize,
+    pub(crate) nsegsamples: usize,
     nframesamples: usize,
-    seg_size_nbits: usize,
-    band_crc_present: u32,
-    scalable_lsbs: bool,
+    pub(crate) seg_size_nbits: usize,
+    pub(crate) band_crc_present: u32,
+    pub(crate) scalable_lsbs: bool,
     ch_mask_nbits: usize,
     fixed_lsb_width: usize,
     chset: Vec<XllChSet>,
@@ -189,6 +204,20 @@ pub(crate) struct XllDecoder {
     pub(crate) x_payload: Vec<u8>,
     /// Byte offset of `x_payload` within the XLL frame.
     pub(crate) x_payload_offset: usize,
+    /// Decoded, speaker-unmapped waveforms from the bare XLL channel set in the
+    /// DTS:X extension. These are kept separate from the 7.1 bed because the
+    /// extension does not carry a one-to-one speaker map in its channel-set
+    /// header.
+    pub(crate) x_output: Vec<Vec<i32>>,
+    pub(crate) x_pcm_bit_res: usize,
+    pub(crate) x_bits_consumed: usize,
+    /// Sticky, allocation-free failure kind of the last XLL-X decode attempt
+    /// (cleared on the next successful decode / frame reset).
+    pub(crate) x_decode_error: Option<&'static str>,
+    pub(crate) x_header_tail_bits: usize,
+    x_descriptor_offset: Option<usize>,
+    x_descriptor_size: Option<usize>,
+    pub(crate) x_descriptor_navigation_used: bool,
 }
 
 impl XllDecoder {
@@ -217,6 +246,8 @@ impl XllDecoder {
             self.hd_stream_id = asset.hd_stream_id;
         }
         self.one_to_one = asset.one_to_one_map_ch_to_spkr;
+        self.x_descriptor_offset = asset.xll_x_offset;
+        self.x_descriptor_size = asset.xll_x_size;
         let xll = &data[asset.xll_offset..asset.xll_offset + asset.xll_size];
         if self.pbr_delay > 0 || !self.pbr_buffer.is_empty() {
             self.parse_frame_pbr(xll)?;
@@ -234,7 +265,9 @@ impl XllDecoder {
     fn parse_frame_no_pbr(&mut self, data: &[u8], asset: &ExssAsset) -> R<()> {
         match self.parse_frame(data) {
             Ok(()) => {}
-            Err(XllError::Eagain) if asset.xll_sync_present && asset.xll_sync_offset < data.len() => {
+            Err(XllError::Eagain)
+                if asset.xll_sync_present && asset.xll_sync_offset < data.len() =>
+            {
                 let d = &data[asset.xll_sync_offset..];
                 if asset.xll_delay_nframes > 0 {
                     self.pbr_buffer.clear();
@@ -292,6 +325,7 @@ impl XllDecoder {
         self.parse_navi_table(&mut gb)?;
         self.parse_band_data(&mut gb)?;
         self.detect_x_extension(&mut gb, data);
+        self.decode_x_extension_audio();
         Ok(())
     }
 
@@ -305,24 +339,158 @@ impl XllDecoder {
         self.x_imax_syncword_present = false;
         self.x_payload.clear();
         self.x_payload_offset = 0;
+        self.x_output.clear();
+        self.x_pcm_bit_res = 0;
+        self.x_bits_consumed = 0;
+        self.x_decode_error = None;
+        self.x_header_tail_bits = 0;
+        self.x_descriptor_navigation_used = false;
 
-        let frame_bits = self.frame_size * 8;
+        let frame_end = self.frame_size.min(data.len());
+        let frame_bits = frame_end * 8;
         let aligned = (gb.position() + 31) & !31; // FFALIGN(get_bits_count, 32)
         if frame_bits <= aligned {
             return;
         }
-        gb.align_bits(32);
+        let mut start = aligned / 8;
+
+        // The profile-specific asset-descriptor word provides the XLL-X size
+        // and its DWORD offset. Prefer that navigation when its
+        // markers, bounds and syncword all agree; retain the legacy aligned
+        // band-end probe as a fallback for other profiles.
+        if let (Some(offset), Some(size)) = (self.x_descriptor_offset, self.x_descriptor_size) {
+            if let Some(hinted_start) = frame_end.checked_sub(size) {
+                if hinted_start == offset
+                    && data.get(hinted_start..hinted_start + 4)
+                        == Some(&DCA_SYNCWORD_XLL_X.to_be_bytes())
+                {
+                    start = hinted_start;
+                    self.x_descriptor_navigation_used = true;
+                }
+            }
+        }
+        if !gb.seek(start * 8) {
+            return;
+        }
         match gb.show_bits(32) {
-            Some(0x0200_0850) => self.x_syncword_present = true,
-            Some(sw) if (sw >> 1) == (0xF140_00D0u32 >> 1) => self.x_imax_syncword_present = true,
+            Some(DCA_SYNCWORD_XLL_X) => self.x_syncword_present = true,
+            Some(sw) if (sw >> 1) == (DCA_SYNCWORD_XLL_X_IMAX >> 1) => self.x_imax_syncword_present = true,
             _ => return,
         }
-        let start = gb.position() / 8;
-        let end = self.frame_size.min(data.len());
-        if end > start {
+        if frame_end > start {
             self.x_payload_offset = start;
-            self.x_payload.extend_from_slice(&data[start..end]);
+            self.x_payload.extend_from_slice(&data[start..frame_end]);
         }
+    }
+
+    fn decode_x_extension_audio(&mut self) {
+        if !self.x_syncword_present {
+            return;
+        }
+        let payload = std::mem::take(&mut self.x_payload);
+        let result = self.try_decode_x_extension_audio(&payload);
+        self.x_payload = payload;
+        if let Err(error) = result {
+            self.x_output.clear();
+            self.x_decode_error = Some(xll_x_error_kind(&error));
+        }
+    }
+
+    /// Decode the bare XLL channel set following the 22-byte DTS:X wrapper.
+    ///
+    /// The channel-set header is normative XLL syntax and has its own valid
+    /// CRC16. It deliberately has no one-to-one speaker mapping: the four
+    /// decoded waveforms therefore stay separate from the regular bed output.
+    fn try_decode_x_extension_audio(&mut self, payload: &[u8]) -> R<()> {
+        const X_CHSET_OFFSET: usize = 22;
+        const X_CHANNELS: usize = 4;
+
+        if payload.len() <= X_CHSET_OFFSET {
+            return Err(XllError::Invalid("short XLL-X payload"));
+        }
+        let mut gb = BitReader::with_offset(payload, X_CHSET_OFFSET * 8);
+        let mut chset = XllChSet::default();
+        self.chs_parse_header(&mut gb, &mut chset, true, true)?;
+        if chset.nchannels != X_CHANNELS {
+            return Err(XllError::Invalid("unexpected XLL-X channel count"));
+        }
+        let full_mask = (1u32 << chset.nchannels) - 1;
+        if chset.residual_encode != full_mask {
+            return Err(XllError::Unsupported("XLL-X core-referenced channels"));
+        }
+        self.x_header_tail_bits = chset.header_tail_bits;
+
+        // The bare sub-header is followed by the standard XLL navigation
+        // table: one segment-size entry per inherited frame segment, followed
+        // by byte alignment and CRC16. The segment data then runs up to the
+        // final DWORD padding.
+        let navi_payload_bits = self.nframesegs * self.seg_size_nbits;
+        let navi_size = navi_payload_bits.div_ceil(8) + 2;
+        let navi_start = gb.position() / 8;
+        if payload.len() < navi_start + navi_size {
+            return Err(XllError::Invalid("short XLL-X navigation table"));
+        }
+        let mut navi_reader = BitReader::with_offset(payload, navi_start * 8);
+        let mut navi = Vec::with_capacity(self.nframesegs);
+        for _ in 0..self.nframesegs {
+            navi.push(rb(&mut navi_reader, self.seg_size_nbits)? as usize + 1);
+        }
+        navi_reader.align_bits(8);
+        rb(&mut navi_reader, 16)?;
+        let data_start = navi_start + navi_size;
+        let data_bytes = navi.iter().sum::<usize>();
+        // The extension carries a two-byte trailer after the channel-set data,
+        // then zero to three bytes of DWORD padding.
+        if data_start + data_bytes > payload.len() || payload.len() - (data_start + data_bytes) > 5
+        {
+            return Err(XllError::Invalid("XLL-X navigation size mismatch"));
+        }
+        seek(&mut gb, data_start * 8)?;
+
+        self.chset.push(chset);
+        let chset_index = self.chset.len() - 1;
+        let decode_result = (|| {
+            let channels = self.chset[chset_index].nchannels;
+            self.chset[chset_index].band.msb = vec![vec![0i32; self.nframesamples]; channels];
+            self.chset[chset_index].band.lsb = if self.chset[chset_index].band.lsb_section_size != 0
+            {
+                vec![vec![0i32; self.nframesamples]; channels]
+            } else {
+                Vec::new()
+            };
+
+            let mut band_end = gb.position();
+            for (segment, &segment_bytes) in navi.iter().enumerate() {
+                band_end += segment_bytes * 8;
+                self.chs_parse_band_data(&mut gb, chset_index, segment, band_end)?;
+                seek(&mut gb, band_end)?;
+            }
+            self.chs_filter_band_data(chset_index);
+            if self.scalable_lsbs {
+                self.chs_assemble_msbs_lsbs(chset_index);
+            }
+            Ok(())
+        })();
+        let chset = self.chset.pop().expect("temporary XLL-X channel set");
+        decode_result?;
+
+        let shift = 24usize
+            .checked_sub(chset.pcm_bit_res)
+            .ok_or(XllError::Invalid("XLL-X PCM resolution"))?;
+        self.x_output = chset
+            .band
+            .msb
+            .into_iter()
+            .map(|samples| {
+                samples
+                    .into_iter()
+                    .map(|sample| clip23(sample.wrapping_mul(1 << shift)))
+                    .collect()
+            })
+            .collect();
+        self.x_pcm_bit_res = chset.pcm_bit_res;
+        self.x_bits_consumed = gb.position();
+        Ok(())
     }
 
     fn parse_common_header(&mut self, gb: &mut BitReader) -> R<()> {
@@ -372,7 +540,7 @@ impl XllDecoder {
             let hier_ofs = self.nchannels;
             let mut c = std::mem::take(&mut self.chset[i]);
             c.hier_ofs = hier_ofs;
-            self.chs_parse_header(gb, &mut c, i == 0)?;
+            self.chs_parse_header(gb, &mut c, i == 0, false)?;
             if c.nfreqbands > self.nfreqbands {
                 self.nfreqbands = c.nfreqbands;
             }
@@ -388,7 +556,13 @@ impl XllDecoder {
         Ok(())
     }
 
-    fn chs_parse_header(&mut self, gb: &mut BitReader, c: &mut XllChSet, is_primary: bool) -> R<()> {
+    fn chs_parse_header(
+        &mut self,
+        gb: &mut BitReader,
+        c: &mut XllChSet,
+        is_primary: bool,
+        allow_unmapped: bool,
+    ) -> R<()> {
         let header_pos = gb.position();
         let header_size = rb(gb, 10)? as usize + 1;
         c.nchannels = rb(gb, 4)? as usize + 1;
@@ -417,7 +591,7 @@ impl XllDecoder {
 
         // The channel-set layout depends on the asset's one_to_one_map_ch_to_spkr
         // flag (mirrors FFmpeg dca_xll.c chs_parse_header).
-        if self.one_to_one {
+        if self.one_to_one && !allow_unmapped {
             // Normal one-to-one channel→speaker mapping (multichannel beds).
             c.primary_chset = rb1(gb)?;
             if c.primary_chset != is_primary {
@@ -461,16 +635,26 @@ impl XllDecoder {
             // stereo case is handled: a single 2-channel set with no custom
             // mapping coefficients, fixed to L/R.
             let mapping_coeffs_present = rb1(gb)?;
-            if c.nchannels != 2 || self.nchsets != 1 || mapping_coeffs_present {
-                return Err(XllError::Unsupported("custom XLL channel-to-speaker mapping"));
+            if mapping_coeffs_present
+                || (!allow_unmapped && (c.nchannels != 2 || self.nchsets != 1))
+            {
+                return Err(XllError::Unsupported(
+                    "custom XLL channel-to-speaker mapping",
+                ));
             }
             c.primary_chset = true;
             c.dmix_coeffs_present = false;
             c.dmix_embedded = false;
-            c.hier_chset = false;
-            c.ch_mask = (1 << DCA_SPEAKER_L) | (1 << DCA_SPEAKER_R);
-            c.ch_remap[0] = DCA_SPEAKER_L;
-            c.ch_remap[1] = DCA_SPEAKER_R;
+            c.hier_chset = allow_unmapped;
+            if allow_unmapped {
+                for ch in 0..c.nchannels {
+                    c.ch_remap[ch] = ch;
+                }
+            } else {
+                c.ch_mask = (1 << DCA_SPEAKER_L) | (1 << DCA_SPEAKER_R);
+                c.ch_remap[0] = DCA_SPEAKER_L;
+                c.ch_remap[1] = DCA_SPEAKER_R;
+            }
         }
 
         if c.freq > 96000 {
@@ -571,7 +755,12 @@ impl XllDecoder {
             }
         }
 
-        seek(gb, header_pos + header_size * 8)
+        let header_end = header_pos + header_size * 8;
+        if gb.position() > header_end {
+            return Err(XllError::Invalid("XLL channel-set fields exceed header"));
+        }
+        c.header_tail_bits = header_end - gb.position();
+        seek(gb, header_end)
     }
 
     fn parse_dmix_coeffs(&mut self, gb: &mut BitReader, c: &mut XllChSet) -> R<()> {
@@ -773,7 +962,13 @@ impl XllDecoder {
 
         // LSB portion.
         if c.band.lsb_section_size != 0 {
-            seek(gb, band_data_end - c.band.lsb_section_size * 8)?;
+            let lsb_bits = c
+                .band
+                .lsb_section_size
+                .checked_mul(8)
+                .filter(|&bits| bits <= band_data_end)
+                .ok_or(XllError::Invalid("lsb section exceeds band data"))?;
+            seek(gb, band_data_end - lsb_bits)?;
             for i in 0..nchannels {
                 let w = c.band.nscalablelsbs[i];
                 if w != 0 {
@@ -833,8 +1028,8 @@ impl XllDecoder {
                     // dst = msb[2i+1], src = msb[2i]
                     for n in 0..nsamples {
                         let s = b.msb[i * 2][n];
-                        b.msb[i * 2 + 1][n] =
-                            b.msb[i * 2 + 1][n].wrapping_add((s.wrapping_mul(coeff) + (1 << 2)) >> 3);
+                        b.msb[i * 2 + 1][n] = b.msb[i * 2 + 1][n]
+                            .wrapping_add((s.wrapping_mul(coeff) + (1 << 2)) >> 3);
                     }
                 }
             }
@@ -956,8 +1151,9 @@ impl XllDecoder {
             if self.chset[chs].residual_encode & (1 << ch) != 0 {
                 continue;
             }
-            let spkr = map_core_spkr(core.ch_mask, self.chset[chs].ch_remap[ch])
-                .ok_or(XllError::Invalid("residual references missing core channel"))?;
+            let spkr = map_core_spkr(core.ch_mask, self.chset[chs].ch_remap[ch]).ok_or(
+                XllError::Invalid("residual references missing core channel"),
+            )?;
             let shift = 24 - self.chset[chs].pcm_bit_res + self.chs_get_lsb_width(chs, ch);
             if shift > 24 {
                 return Err(XllError::Invalid("invalid core shift"));
@@ -1033,7 +1229,10 @@ impl XllDecoder {
             for ch in 0..nchannels {
                 let spkr = self.chset[chs].ch_remap[ch];
                 let buf = std::mem::take(&mut self.chset[chs].band.msb[ch]);
-                let scaled: Vec<i32> = buf.iter().map(|&s| clip23(s.wrapping_mul(1 << shift))).collect();
+                let scaled: Vec<i32> = buf
+                    .iter()
+                    .map(|&s| clip23(s.wrapping_mul(1 << shift)))
+                    .collect();
                 self.output[spkr] = Some(scaled);
             }
         }

--- a/dca/src/hd.rs
+++ b/dca/src/hd.rs
@@ -44,6 +44,37 @@ pub struct HdFrame {
     pub x_payload: Vec<u8>,
     /// Byte offset of `x_payload` within the XLL frame.
     pub x_payload_offset: usize,
+    /// Four decoded DTS:X extension waveforms. The XLL channel-set header does
+    /// not assign these channels to speakers, so they are deliberately not
+    /// mixed into `samples` or `output_mask` yet.
+    pub x_samples: Vec<Vec<f32>>,
+    pub x_pcm_bit_res: usize,
+    /// Bit position reached after decoding the four extension waveforms,
+    /// relative to `x_payload`.
+    pub x_bits_consumed: usize,
+    /// Diagnostic failure kind from the optional extension decode
+    /// (allocation-free). A failure here never invalidates the lossless 7.1
+    /// bed.
+    pub x_decode_error: Option<&'static str>,
+    /// Unparsed tail of the extension channel-set header, including byte
+    /// alignment and its mandatory CRC16.
+    pub x_header_tail_bits: usize,
+    /// XLL frame geometry inherited by the extension channel set.
+    pub xll_frame_segments: usize,
+    pub xll_segment_samples: usize,
+    pub xll_segment_size_bits: usize,
+    pub xll_band_crc_present: u32,
+    pub xll_scalable_lsbs: bool,
+    /// Unspecified tail of the EXSS asset descriptor, retained for spatial
+    /// metadata research. Only the first `exss_descriptor_tail_bits` are valid.
+    pub exss_descriptor_tail: Vec<u8>,
+    pub exss_descriptor_tail_bits: usize,
+    /// Parsed profile-specific navigation for the XLL-X block.
+    pub x_descriptor_offset: Option<usize>,
+    pub x_descriptor_size: Option<usize>,
+    /// True when the decoder used the descriptor navigation rather than only
+    /// locating the syncword after the decoded XLL band data.
+    pub x_descriptor_navigation_used: bool,
 }
 
 /// Size in bytes of the EXSS substream starting at `data` (which must begin at
@@ -57,7 +88,9 @@ pub fn exss_substream_size(data: &[u8]) -> Option<usize> {
 /// extensions parse but expose no XLL asset; callers should decode the DTS core
 /// instead for those.
 pub fn exss_has_xll(data: &[u8]) -> bool {
-    ExssParser::parse(data).map(|p| p.has_xll()).unwrap_or(false)
+    ExssParser::parse(data)
+        .map(|p| p.has_xll())
+        .unwrap_or(false)
 }
 
 #[derive(Default)]
@@ -86,11 +119,13 @@ impl HdDecoder {
     pub fn decode(&mut self, core_au: &[u8], exss: &[u8]) -> Result<HdFrame, HdError> {
         // 1) Core (residual base), fixed-point, indexed by speaker.
         let info = parse_header(core_au)?;
-        self.core.decode_frame(&info, core_au).map_err(|_| HdError::Core)?;
+        self.core
+            .decode_frame(&info, core_au)
+            .map_err(|_| HdError::Core)?;
         let core_out = self.synth.synthesize_fixed_by_speaker(&mut self.core);
 
         // 2) EXSS → locate XLL asset.
-        let exssp = ExssParser::parse(exss).map_err(|_| HdError::Exss)?;
+        let mut exssp = ExssParser::parse(exss).map_err(|_| HdError::Exss)?;
 
         // 3) XLL lossless decode, combined with the core residual.
         match self.xll.decode(exss, &exssp.asset, Some(&core_out)) {
@@ -104,7 +139,19 @@ impl HdDecoder {
             .xll
             .output
             .iter()
-            .map(|opt| opt.as_ref().map(|v| v.iter().map(|&s| s as f32 / PCM_SCALE).collect()))
+            .map(|opt| {
+                opt.as_ref()
+                    .map(|v| v.iter().map(|&s| s as f32 / PCM_SCALE).collect())
+            })
+            .collect();
+        let x_samples = std::mem::take(&mut self.xll.x_output)
+            .into_iter()
+            .map(|channel| {
+                channel
+                    .into_iter()
+                    .map(|sample| sample as f32 / PCM_SCALE)
+                    .collect()
+            })
             .collect();
 
         Ok(HdFrame {
@@ -115,6 +162,21 @@ impl HdDecoder {
             x_imax: self.xll.x_imax_syncword_present,
             x_payload: std::mem::take(&mut self.xll.x_payload),
             x_payload_offset: self.xll.x_payload_offset,
+            x_samples,
+            x_pcm_bit_res: self.xll.x_pcm_bit_res,
+            x_bits_consumed: self.xll.x_bits_consumed,
+            x_decode_error: self.xll.x_decode_error.take(),
+            x_header_tail_bits: self.xll.x_header_tail_bits,
+            xll_frame_segments: self.xll.nframesegs,
+            xll_segment_samples: self.xll.nsegsamples,
+            xll_segment_size_bits: self.xll.seg_size_nbits,
+            xll_band_crc_present: self.xll.band_crc_present,
+            xll_scalable_lsbs: self.xll.scalable_lsbs,
+            exss_descriptor_tail: std::mem::take(&mut exssp.asset.descriptor_tail),
+            exss_descriptor_tail_bits: exssp.asset.descriptor_tail_bits,
+            x_descriptor_offset: exssp.asset.xll_x_offset,
+            x_descriptor_size: exssp.asset.xll_x_size,
+            x_descriptor_navigation_used: self.xll.x_descriptor_navigation_used,
         })
     }
 }
@@ -183,7 +245,12 @@ mod tests {
         eprintln!("decoded {frames} XLL frames (pending={pending}), output_mask={active_mask:#x}");
         assert!(frames >= 20, "too few XLL frames decoded ({frames})");
 
-        let nsamp = spk.iter().filter(|v| !v.is_empty()).map(|v| v.len()).min().unwrap();
+        let nsamp = spk
+            .iter()
+            .filter(|v| !v.is_empty())
+            .map(|v| v.len())
+            .min()
+            .unwrap();
         let ref_n = reference.len() / ch;
         let cmp = nsamp.min(ref_n);
         assert!(cmp > 5000, "too little to compare ({cmp})");
@@ -222,7 +289,7 @@ mod tests {
     fn xll_7_1_matches_ffmpeg_lossless() {
         // Ex Machina (2014): 24-bit DTS-HD MA 7.1.
         check_xll_lossless(
-            "/mnt/local/SSD_B-CT4000/Dumps/Ex.Machina.2014.dtsx.eng.dts",
+            "/mnt/local/SSD_A-CT4000/DTS:X-Dumps/Ex.Machina.2014.dtsx.eng.dts",
             "/home/user/dev/spatial-renderer/dumps/dtsx_ref8.f32",
             8,
         );
@@ -237,5 +304,48 @@ mod tests {
             "/home/user/dev/spatial-renderer/dumps/darkcrystal_ref6.f32",
             6,
         );
+    }
+
+    #[test]
+    fn xll_x_decodes_four_unmapped_waveforms() {
+        use std::io::Read;
+
+        const DUMP: &str = "/mnt/local/SSD_A-CT4000/DTS:X-Dumps/Ex.Machina.2014.dtsx.eng.dts";
+        if !std::path::Path::new(DUMP).exists() {
+            eprintln!("skipping: spatial-layer corpus not present ({DUMP})");
+            return;
+        }
+        let mut bytes = Vec::new();
+        std::fs::File::open(DUMP)
+            .unwrap()
+            .take(2 * 1024 * 1024)
+            .read_to_end(&mut bytes)
+            .unwrap();
+
+        let mut decoder = HdDecoder::new();
+        let mut offset = 0usize;
+        let mut frames = 0usize;
+        while frames < 100 && offset + 18 < bytes.len() {
+            let core = parse_header(&bytes[offset..]).unwrap();
+            let exss_offset = offset + core.frame_size;
+            let exss = ExssParser::parse(&bytes[exss_offset..]).unwrap();
+            let exss_size = exss.substream_size();
+            let frame = decoder
+                .decode(
+                    &bytes[offset..exss_offset],
+                    &bytes[exss_offset..exss_offset + exss_size],
+                )
+                .unwrap();
+            assert!(frame.x_present);
+            assert_eq!(frame.x_samples.len(), 4);
+            assert!(frame.x_samples.iter().all(|channel| channel.len() == 512));
+            assert_eq!(frame.x_decode_error, None);
+            assert!(frame.x_descriptor_navigation_used);
+            assert_eq!(frame.x_descriptor_offset, Some(frame.x_payload_offset));
+            assert_eq!(frame.x_descriptor_size, Some(frame.x_payload.len()));
+            frames += 1;
+            offset += core.frame_size + exss_size;
+        }
+        assert_eq!(frames, 100);
     }
 }

--- a/docs/dtsx-objects-campaign.md
+++ b/docs/dtsx-objects-campaign.md
@@ -1,176 +1,396 @@
-# DTS:X object layer — reverse-engineering campaign notes
+# Spatial object layer reverse-engineering notes
 
-Date: 2026-06-02
-Branch: `exp-spatial-decode`
-Status: **investigation complete / blocked on proprietary access.** The 7.1
-lossless bed decodes bit-exactly; the DTS:X object layer is characterised but
-not decodable without the (unpublished) bitstream grammar.
+Date: 2026-07-20 (research campaign) / 2026-07-21 (landing)
 
-## TL;DR
+Status: **landed as twelve labeled fixed channels** — see Omniphony
+`docs/channel-object-contract.md`. The original campaign fabricated an
+`RMetadataFrame` (bed ids + corner-pinned "objects"); that presentation
+layer was rolled back and replaced by the contract model: the bridge emits
+the reconstructed 7.1.4 as labeled fixed channels and the renderer decides
+placement. The reverse-engineering notes below remain the reference for the
+XLL-X payload structure and the embedded height downmix.
 
-- Our streams are **DTS-HD MA + DTS:X "XLL X" extension** (syncword
-  `0x02000850`), *not* DTS-UHD/ACE.
-- ffmpeg / dcadec / libdca decode only the **7.1 lossless bed** (which we now
-  also decode bit-exactly). The DTS:X height/object content lives in a separate
-  blob appended at the end of every XLL frame, which **no open-source decoder
-  parses** and which has **no public specification**.
-- We characterised that blob in full at the byte/bit level and gathered strong
-  evidence for **what** it is: extra **height/object waveforms coded as residual
-  audio matrixed against the 7.1 bed** (the same family DTS uses for 5.1→7.1).
-- We could **not** recover **how** it is coded (the per-object bit grammar):
-  it is a bespoke, non-XLL layout, and the grammar is protected by trade secret
-  (confirmed against patents, open-source, MediaInfo and forums).
-- The only realistic unblock is **ground truth from a licensed encoder/decoder**
-  (DTS:X Encoder Suite to author known-signal test streams; or an AVR→capture to
-  validate the model). Everything else is exhausted.
+## Current result
 
-All work here is diagnostic and **off the audio path** — the DTS-HD MA decoder
-is untouched and still bit-exact.
+The old conclusion that the post-XLL extension used a bespoke, undecodable
+audio grammar was wrong. Its variable block starts with a standard bare XLL
+channel-set header at byte 22. Reusing the existing XLL primitives now decodes
+four extra, speaker-unmapped waveforms in every tested frame.
 
-## Stream facts
+The decoder preserves the regular, backward-compatible 7.1 presentation and
+exposes the new waveforms separately as `HdFrame::x_samples`. At the bridge
+boundary they are provisionally appended as `Tfl`, `Tfr`, `Tbl`, `Tbr`, while
+their exact Q15 -3 dB contribution is subtracted from FL/FR/BL/BR. This produces
+the reconstructed fixed 7.1.4 presentation without double-rendering height
+content onto the lower plane. The reconstruction remains intentionally isolated
+from the lossless decoder.
 
-- Profile `DTS-HD MA + DTS:X`, 48 kHz, 8 ch (7.1), confirmed on **9 films / 10
-  tracks** (corpus below). `nframesamples = 512`.
-- At the end of every XLL frame (dword-aligned, after band data) a blob starts
-  with `DCA_SYNCWORD_XLL_X = 0x02000850`. Present in **100 %** of frames.
-- Variants: corpus is homogeneous — **all `0x02000850`**. No IMAX
-  (`0xF14000D0`) and no `0xF14000D1`/`0xF14000D4` (MediaInfo lists these as other
-  "X?" sub-syncwords). The 1–2 stray IMAX byte-matches per film are chance
-  (1 in ~96 MB).
-- ffmpeg (`dca_xll.c` ~L1060) only dword-aligns, peeks the syncword, sets a
-  profile flag, then seeks to end of frame — **payload never parsed**. MediaInfo
-  (`File_Dts.cpp::Extensions2`) likewise: matches the syncword, labels it `"X?"`,
-  then `Skip_XX(..., "(Unknown)")`.
+Validated on prefixes from all nine currently available tracks:
 
-## Blob structure (byte/bit level)
+- 4,206/4,206 XLL-X frames decoded in the 2 MiB cross-corpus pass;
+- channel-set header CRC valid in every frame;
+- no optional extension decode error;
+- 48 kHz, four channels, full/residual mask `0xf` (independent full-coded
+  signals; no core reconstruction is required);
+- 24-bit storage, with title-dependent source PCM resolutions of 16, 18 or
+  24 bits.
 
-```
-[0:4]   0x02000850                       syncword
-[4:22]  18 bytes, CONSTANT & UNIVERSAL   format/version magic (see below)
-        284bfa71 0d6202fa 02dc1371 0dc8373c f102
-──────────────────────────────────────────────── 22-byte header (byte-aligned)
-[22]    N+3   per-frame object count      N = byte22 - 3 (3 => 0 objects, the
-                                          48-byte null frame); observed 3..14
-[23]    2-bit selector | 0b001111         values 0f/4f/8f/cf
-[24]    per-TITLE constant byte           {ef,df,e3,e7}; LLL eng==fra → tied to
-                                          the mix, not the encoder/language
-[25]    0x7c                              constant marker
-[26]    2-bit field                       values 04..07
-[27:]   variable-length, entropy ~7.98 b/byte   object waveform data
+## Correct XLL-X payload structure
+
+```text
+[0:4]       0x02000850 XLL-X syncword
+[4:22]      18-byte fixed profile wrapper
+[22:...]    standard bare XLL channel-set header, four channels, CRC16
+[header end] standard NAVI: four segment sizes, byte alignment, CRC16
+[NAVI end]  four standard XLL segment-data blocks (512 samples total)
+[audio end] two zero bytes, followed by 0..3 zero bytes for DWORD alignment
 ```
 
-Key cross-title result: the **18-byte header is bit-identical across all 9
-films** (proof it is a *universal format constant*, not a per-title GUID — La La
-Land eng and fra share it). Per-title variation lives only at byte 24.
+For the corpus geometry, the inherited XLL frame has four 128-sample segments
+and 11-bit NAVI sizes. The channel-set header is intentionally not mapped
+one-to-one to speakers. Its otherwise unparsed tail is always only 16..23 bits,
+exactly the CRC16 plus byte alignment; it contains no hidden object metadata.
 
-## Evidence: the objects are residual AUDIO, not position metadata
+The formerly reported `N = byte22 - 3` object count was a false interpretation.
+Byte 22 is the high part of the normative 10-bit `nChSetHeaderFSize` field. All
+bit-budget, per-count and bespoke-Rice conclusions derived from that alleged
+count are obsolete.
 
-Model: each active object = one mono waveform of `nframesamples` (512) samples,
-coded as residual and matrixed against the 7.1 bed. Bit budget
-`(payload - 27)*8 / (N * 512)` lands in an **audio-residual bitrate range and
-tracks content** across titles:
+## Reproducible audio extraction
 
-| Title | median bits/sample |
-|---|---|
-| La La Land (musical) | 0.39 (objects ~silent) |
-| Gladiator (action) | 2.28 |
-| Ex Machina | 4.32 |
-| The Mummy 1999 | 4.30 |
+`xll_x_audio` writes the four decoded waveforms as 32-bit float WAV:
 
-A 10× content-dependent swing in *audio bitrate* is the signature of coded audio;
-positional metadata would cost roughly the same per object regardless of genre.
-This matches the documented DTS:X home model (16 waveforms +2 LFE; 7.1 bed + up
-to ~9 objects; silent waveforms not coded → variable per-frame count).
+```sh
+cargo run -p dca --release --example xll_x_audio -- \
+  input.dts output.wav 256
+```
 
-## What it is NOT (falsified hypotheses)
+The optional final argument limits input to MiB. Classic RIFF output is capped
+below 4 GiB. A smoke test produced a valid 48 kHz, four-channel `pcm_f32le` WAV
+with 960/960 frames and no failures.
 
-- **Not** fixed-size object records: for a fixed N the payload spreads ~10×
-  (count=8: 356–3988 B); records are variable-length (entropy/predictive).
-- **Not** a plain global-k Rice stream: divisibility test ≈ 1/N (chance), F never
-  consistent, under either unary convention, k=0..14, start `base*8 + a*N`.
-- **No nested DCA/XLL framing**: blobs contain no `0x41A29547`(XLL)/CORE/XXCH/
-  X96/XBR syncword.
-- The 18-byte header is **not** an XLL `chs`-header: bit-walk for the signature
-  (storage_bit_res ∈ {16,20,24}, freq = 48 kHz, reserved bits = 0) → 0 hits.
+The paired French/English *La La Land* analysis is also decisive: 564 initial
+silent frames have bit-identical extension payloads, while the decoded
+waveforms then diverge with the two mixes. The block therefore carries real
+audio, not only spatial coordinates.
 
-Conclusion: it reuses the XLL coding *family* (residual audio matrixed against
-the bed) but with a **bespoke bitstream layout** (no sync, non-XLL header). Our
-bit-exact XLL primitives (Rice/linear, LMS prediction, decorrelation, undo
-downmix) cannot be pointed at it directly.
+## Spatial metadata investigation
 
-## External research (all dead ends for the bitstream grammar)
+No time-varying coordinates remain inside the XLL-X payload after accounting
+for the standard channel-set header, NAVI, audio segments and zero padding.
+The 18-byte profile wrapper is constant across frames and titles. Direct
+bit-aligned searches also found no MDA frame signature or MDA URI markers, so
+this is not a byte-for-byte MDA packet encapsulation.
 
-- **Format**: it is the DTS-HD MA "XLL X" extension, **not** DTS-UHD. So
-  **ETSI TS 103 491** (DTS-UHD/ACE) does not describe it.
-- **Patents** (DTS/Xperi) confirm the architecture but contain **no bitstream
-  syntax** — they are deliberately codec-agnostic:
-  - US9779739B2 *Residual encoding in an object-based audio system* — total mix
-    `C = A + ΣBi`, objects coded separately, base recovered by subtraction
-    `A' = C' − ΣBi'`. Confirms the residual/matrix architecture; no syntax.
-  - US9552819B2 *Multiplet-based matrix mixing…* — parametric spatial matrixing
-    (multiplets, ICPD, pan angle/radius) for height; no syntax.
-  - US20170098452 (DME + height objects), US9721575B2 (base vs extension
-    objects) — architecture only.
-  - Verdict: DTS protects the XLL X syntax by **trade secret**, not patent.
-    Chasing patents for a bit table is a structural dead end.
-- **Open source**: ffmpeg, dcadec (foo86), libdca, Const-me all stop at the bed.
-  No GitHub project parses the post-`0x02000850` payload. No forum (doom9 /
-  hydrogenaudio / MakeMKV / AVS) documents it at the bit level.
-- **MediaInfo**: detects and labels `"X?"`, payload is `(Unknown)` — the author
-  knows where the blob is, not what's in it.
+The EXSS audio-asset descriptor contains a 64-bit profile-specific word per
+frame. Corpus analysis now identifies it as XLL-X navigation, not DRC or
+spatial coordinates. Its observed bit layout is:
 
-We are at the public state of the art: nobody has published more than what is
-measured here.
+- 8-bit marker `0x18`;
+- 11-bit XLL-X payload offset divided by four, followed by 13 zero bits;
+- 16-bit marker `0x8a28`;
+- 10-bit `(payload size - 24) / 4`, followed by 6 zero bits.
 
-## The only realistic unblock: ground truth
+The decoded offset and size exactly match the XLL-X block located after the
+regular XLL band data: 93,243/93,243 frames across 64 MiB from each of the nine
+available streams. `xll_x_meta` checks this identity over the corpus. The
+decoder now prefers these values to locate the block, while validating its
+bounds and syncword and retaining the legacy aligned band-end probe as a
+fallback. This makes extension extraction more robust, but supplies neither a
+gain curve nor an object trajectory.
 
-To go from *what* to *how* we need a known bitstream↔PCM pair:
+Before analysis of the Object Emulator control clip, the remaining spatial
+question was whether the four waveforms were:
 
-1. **DTS:X Encoder Suite / Creator (keystone).** Author a stream with a single
-   object carrying a known impulse/sine at a fixed position; confront against the
-   produced bitstream → unambiguous, bidirectional calibration. Access is
-   licensed/NDA via Xperi — pursue via a pro channel.
-2. **AVR/processor (DTS:X Pro) → multichannel capture (TASCAM).** A commercial
-   film's rendered 7.1.4 = bed + objects mixed (not cleanly invertible), but the
-   **height channels ≈ rendered object audio**, enough to *validate* the model
-   (e.g. byte22=3 ⇒ silent height; high N ⇒ active height) without an NDA.
-   Requires DTS:X Pro hardware.
+1. fixed height feeds (most economical explanation);
+2. a four-component sound-field representation;
+3. four object waveforms whose static mapping is defined by the constant
+   profile wrapper or by metadata outside the elementary audio payload.
 
-No public DTS:X conformance vectors exist (FATE covers only the bed).
+The public DTS-UHD syntax is only an analogy, but it is an important warning:
+it carries object metadata separately from bare XLL audio chunks, and one
+object may reference multiple consecutive waveforms. Four decoded waveforms
+therefore do not imply four objects.
 
-## What ships now, regardless
+The controlled tests below resolve this corpus in favour of fixed TFL, TFR,
+TBL and TBR feeds embedded into a backward-compatible 7.1 downmix. Labeling
+them as independently recoverable moving objects would still be premature.
 
-- **7.1 lossless bed** — bit-exact DTS-HD MA decode (unchanged, validated).
-- **Per-frame object count** (`N = byte22 − 3`) — a reliable, cheap "immersive
-  intensity" signal that the renderer could use to drive an algorithmic
-  height/upmix. (Not yet wired into the bridge.)
+### Atypical channel-coherence cases
 
-## Tooling & references (commits on `exp-spatial-decode`)
+Sample-level measurements over the first 64 MiB of each stream identify three
+particularly useful counterexamples to four independent height feeds:
 
-Diagnostic examples in `dca/examples/` (read a raw `.dts`, decode via
-`HdDecoder`, analyse the captured `HdFrame::x_payload`):
+- *Apollo 13*: channels 2 and 3 are exactly silent for 7,501 frames (about
+  80 seconds), leaving only two active extension waveforms;
+- *La La Land* English: channels 2 and 3 are sample-identical in aggregate and
+  exactly zero after the shared 564-frame introduction, for the rest of the
+  13,223-frame prefix (about 141 seconds);
+- *The Mummy* (1999): channels 0/3 and 1/2 have sample correlations of 0.9981
+  and 0.9975. A single gain-scaled copy explains each target with only 6.1%
+  and 7.0% residual RMS respectively.
 
-- `xll_x_probe.rs` — presence, size histogram, byte entropy, per-byte
-  cardinality, fixed-prefix detection, payload↔energy correlation, per-count
-  floor, CSV.
-- `xll_x_audio.rs` — bits/sample budget (audio-hypothesis test).
-- `xll_x_rice.rs` — global-k Rice hypothesis (negative).
-- `xll_x_scan.rs` — nested-syncword scan (negative).
+These observations do not prove object coding: fixed speaker feeds can share
+or duplicate content. A first time-local coherence test finds the two *Mummy*
+pairs in 6,388/6,582 and 6,362/6,582 frames respectively. Their normalized
+second-channel gain occupies narrow 10th-to-90th percentile ranges of
+0.5063..0.5189 and 0.4412..0.4599. This favours static duplicated stems over a
+moving pan in that prefix. The silent *La La Land* feeds carry zero PCM, not a
+frame-wise DC control value.
 
-Capture path: `XllDecoder::detect_x_extension` (in `src/dcadec/xll.rs`) mirrors
-ffmpeg's syncword detection and additionally retains the raw payload; surfaced on
-`HdFrame::{x_present, x_imax, x_payload, x_payload_offset}` (in `src/hd.rs`).
-This runs after band-data decode and does not affect PCM output.
+The next test is frequency-local rather than whole-frame: isolate coherent
+components with a short-time covariance or source-separation pass, estimate
+each component's four-channel gain vector, normalize it, and track whether the
+vector moves smoothly. Under the provisional corner-speaker interpretation,
+the normalized gains give a rendered upper-plane barycentre. Stable gains
+would instead support fixed channels or static multichannel stems. This can
+recover only a rendered direction, not necessarily the original object
+coordinates, distance or spread.
 
-Commits: `925e0b8` (capture), `35ead79` (fixed header + correlation), `b8d5398`
-(bit-level header + count field), `bdd8852` (record-structure test), `4bbdb6d`
-(audio evidence), `715999b` (Rice negative), `736ff87` (framing/header
-negatives), `dd15aa6` (corpus path).
+The paired *La La Land* language tracks provide a control: spatial gain
+trajectories belonging to shared music and effects should agree despite the
+different dialogue mix. A second useful comparison is coherence between the
+four extension waveforms and the 7.1 bed; strong shared components would be
+consistent with a pre-rendered 12-channel bus, while independent components
+would better support separately carried object waveforms.
+
+### DTS:X Object Emulator control
+
+The public DTS-authored *DTS:X Object Emulator* test clip is a much stronger
+control than a feature-film soundtrack because its picture explicitly shows a
+moving source, labels the signal as using 3D coordinates, and then illustrates
+several playback layouts. It does not print numerical azimuth, elevation or
+radius values; the visible source position can only be used as a screen-space
+proxy in shots where the camera is fixed. The clip linked by the official Kodi
+sample catalogue is 95 seconds long and `ffprobe` identifies its audio as a
+48 kHz, 7.1 DTS-HD MA + DTS:X stream.
+
+The complete elementary stream has the same representation as the film corpus:
+
+- 8,902/8,902 frames decode as the regular 7.1 bed plus exactly four full-coded
+  XLL-X waveforms;
+- the bare channel-set CRC is valid in every frame;
+- the XLL-X payload is completely consumed by header, navigation, lossless
+  audio and zero alignment;
+- no MDA URI or non-random MDA frame signature is present;
+- the varying EXSS descriptor bits again encode XLL-X offset and size, not
+  coordinates.
+
+The 7.1.4 portion of the demo also supplies a direct ordering clue. Over the
+49–70 second motion sequence, frame-energy correlation between each extension
+waveform and the regular bed is strongest for these pairs:
+
+| Extension | Bed reference | RMS-envelope correlation | Provisional position |
+| --- | --- | ---: | --- |
+| X0 | FL | 0.916 | top front left |
+| X1 | FR | 0.890 | top front right |
+| X2 | BL | 0.835 | top back left |
+| X3 | BR | 0.733 | top back right |
+
+Sample correlations for the same pairs are respectively 0.937, 0.917, 0.847
+and 0.754. The visible source moves continuously while coherent copies are
+gain-panned between the corresponding lower and upper feeds. No independently
+transmitted coordinate curve is needed to reproduce this particular stream.
+
+An additional controlled analysis makes the fixed-presentation interpretation
+substantially stronger. The picture successively labels its illustrated output
+layouts as 7.1.4, 5.1.2, 2.1, 5.1, 7.1 and 7.1.4. Although the elementary audio
+stream remains in the same 7.1 plus four-XLL-X container throughout, its actual
+decoded channel activity follows those labels:
+
+- during the 5.1.2 section, rear bed channels BL/BR and extension waveforms
+  X2/X3 are exactly zero while X0/X1 remain active;
+- during the 2.1, 5.1 and 7.1 sections, all four extension waveforms are
+  exactly zero;
+- all four extension waveforms become active again in the final 7.1.4 section.
+
+The demonstration therefore contains a sequence of layout-specific renders in
+a fixed 7.1.4 transport presentation. If X0..X3 were a layout-independent
+four-component object basis, changing the illustrated playback layout would
+not require two or all four transport components to become bit-identically
+zero in precisely this way.
+
+The moving-object audio is also almost ideal for a blind gain-vector test. In
+150 ms windows from the first 7.1.4 section, the median share of signal energy
+explained by the first covariance eigenvector is 0.9884: it is essentially one
+mono waveform distributed by changing gains. Among 247 reliable windows:
+
+- negative height-gain energy is only `4.4e-8` of total height-gain energy;
+- the median number of active height outputs is two out of four at a -26 dB
+  threshold;
+- 74.9% of windows use no more than two height outputs;
+- every possible raw-FOA W candidate drops out entirely in some positions; the
+  best candidate, X0, has a normalized coefficient variation of 0.786 and is
+  below 0.05 in 29.1% of the reliable windows.
+
+This rejects a direct W/X/Y/Z interpretation. Raw first-order ambisonics needs
+an omnidirectional W component whose normalized gain remains non-zero and
+constant for a single moving point source; it also does not naturally produce
+these non-negative, piecewise-sparse corner gains.
+
+A projective test also rejects an unknown fixed real 4x4 rematrix around raw
+FOA. A point-source vector `[W, X, Y, Z]` lies on the quadratic cone
+`W^2 = X^2 + Y^2 + Z^2`, whose matrix has signature (1,3). By Sylvester's law
+of inertia, an invertible real rematrix may rotate or scale that cone but cannot
+change its signature. The best homogeneous quadratic fitted on four fifths of
+the measured height-gain vectors and evaluated on the held-out fifth has:
+
+- eigenvalues `-0.514, -0.492, +0.494, +0.500`, hence signature (2,2);
+- a held-out normalized RMS residual of 0.0145;
+- almost exactly the simpler relation `X1*X2 = X0*X3`, with RMS residual
+  0.0129 over all reliable windows.
+
+That last relation is the expected separability constraint for four corner
+gains `[left*front, right*front, left*back, right*back]`. It is a much more
+specific match for two-dimensional speaker panning than for a hidden linear
+FOA basis.
+
+As an independent A/V synchronization check, a simple bright-object tracker
+finds 46 positions in the fixed-camera 5.1.2 shot. Screen X correlates at 0.671
+with decoded right-minus-left energy, while screen Y correlates at -0.667 with
+the decoded height-energy fraction (negative is expected because smaller image
+Y is higher on screen). The moderate rather than perfect values are expected
+from perspective projection, glow/occlusion errors and the use of screen-space
+coordinates instead of the undisclosed 3D animation coordinates. They are
+nevertheless strong enough to confirm that the visible trajectory and decoded
+speaker gains are synchronized.
+
+### Embedded 7.1 compatibility downmix
+
+The regular 7.1 presentation is not the final lower speaker plane when XLL-X is
+decoded. It contains a backward-compatible copy of each height feed mixed into
+the corresponding lower corner at -3 dB. The Object Emulator exposes this
+particularly clearly because it contains isolated single-source pans.
+
+The dominant lower/height gain ratio is `23170 / 32768 = 0.707092285`. This is
+not merely close to `1/sqrt(2)`: `23170` is the exact Q15 -3 dB coefficient in
+the DTS downmix table already used by the regular XLL decoder. Across reliable
+100/150 ms windows, subtracting that contribution makes the corresponding
+lower gain nearly zero in 80.7% of FL/X0 windows, 92.1% of FR/X1, 68.2% of
+BL/X2 and 65.5% of BR/X3. The remaining positive gain is consistent with an
+intentional simultaneous lower-plane component as the source moves between
+speakers.
+
+The fixed-point result is more decisive. In windows where the visible source
+is at an upper speaker, applying the same rounded multiply used by XLL,
+`bed - rmul15(height, 23170)`, leaves only:
+
+| Pair | residual / bed RMS | residual RMS | maximum residual |
+| --- | ---: | ---: | ---: |
+| FR - X1 | `1.06e-6` | 1.01 PCM LSB | 4 LSB |
+| BL - X2 | `1.17e-6` | 0.78 PCM LSB | 2 LSB |
+| BR - X3 | `8.80e-7` | 0.78 PCM LSB | 2 LSB |
+
+The trajectory does not include an equally isolated TFL interval; its best
+FL-X0 window still leaves only 0.236% of the bed RMS. This establishes the
+likely reconstruction matrix:
+
+```text
+FL = bed.FL - rmul15(TFL, 23170)    TFL = X0
+FR = bed.FR - rmul15(TFR, 23170)    TFR = X1
+BL = bed.BL - rmul15(TBL, 23170)    TBL = X2
+BR = bed.BR - rmul15(TBR, 23170)    TBR = X3
+```
+
+A legacy 7.1 decoder ignores XLL-X and therefore retains all height content in
+the compatible bed. A 7.1.4 decoder must undo those four contributions before
+adding the height feeds. The bridge now performs this reconstruction; its
+previous append-only behavior left a -3 dB floor ghost of height-only sounds.
+
+These tests disprove a fixed invertible 4x4 rematrix to raw FOA, but cannot
+disprove a nonlinear or signal-adaptive direction estimator applied by a
+receiver to the four height feeds. Such processing would be an upmixer
+operating on an already rendered speaker presentation, however. Without side
+information it cannot uniquely recover more than four arbitrary,
+simultaneously overlapping original object waveforms or their authoring
+trajectories.
+
+This is the strongest evidence so far that the current `Tfl/Tfr/Tbl/Tbr`
+mapping is correct and that this legacy optical-disc profile normally stores a
+pre-rendered fixed 7.1.4 presentation. It also resolves an apparent marketing
+contradiction: a mix may originate as 3D objects with coordinates while the
+consumer encode carries the result rendered to twelve fixed feeds.
+
+It does not prove that the profile can never append genuine dynamic objects.
+DTS stated at launch that an embedded object can be extracted, and independent
+technical reports identify the US Blu-ray of *Ip Man 3* as an unusual
+`7.1.4 + five dynamic objects` encode. A second forum source calls it the
+first DTS:X Blu-ray not locked to 7.1.4. These are useful acquisition leads,
+not primary-source proof. A dump from that exact US disc, or from the reported
+`7.1.4 + one object` *Independence Day* encode, is now the highest-value
+comparison: it should contain a structural element absent from both the nine
+films and the Object Emulator if the reports are accurate.
+
+Relevant public links:
+
+- Kodi test catalogue and Object Emulator link:
+  <https://kodi.wiki/view/Samples#HD/object-based_Audio_Test_Clips>
+- DTS patent application describing both a 7.1-channel presentation plus four
+  separate height inputs and an alternate 11.1-channel representation:
+  <https://patents.google.com/patent/US20170098452A1/en>
+- DTS launch statement distinguishing content rendered from channels from
+  objects that are actually embedded and extractable:
+  <https://dts.com/insights/welcome-to-dtsx-open-immersive-and-flexible-object-based-audio-coming-to-cinema-and-home/>
+- report of five dynamic objects on the US *Ip Man 3* disc:
+  <https://www.avforums.com/threads/lyngdorf-discussion.1580956/page-592>
+- independent recollection that *Ip Man 3* was the first non-locked DTS:X
+  Blu-ray:
+  <https://forum.blu-ray.com/showthread.php?p=20520575>
+
+By contrast, DTS's *Ex Machina* announcement says that DTS:X moves sound
+objects through mixer-selected locations, but it does not state that this
+specific disc retains time-varying object metadata. The local *Ex Machina*
+bitstream has the same fixed four-waveform structure, so that press wording is
+not sufficient evidence of dynamic objects in the title:
+<https://dts.com/insights/lionsgates-ex-machina-blu-ray-disc-is-first-to-feature-dtsx-audio/>.
+
+## Public specifications used
+
+- ETSI TS 102 114 V1.6.1 describes the regular EXSS and XLL syntax reused by
+  the discovered channel set:
+  <https://www.etsi.org/deliver/etsi_ts/102100_102199/102114/01.06.01_60/ts_102114v010601p.pdf>
+- ETSI TS 103 491 describes DTS-UHD object navigation and bare XLL audio chunks.
+  It is not the format carried here, but it supplied a useful structural model:
+  <https://www.etsi.org/deliver/etsi_ts/103400_103499/103491/01.01.01_60/ts_103491v010101p.pdf>
+- ETSI TS 103 223 describes MDA packet and coordinate syntax used for the
+  negative signature/URI tests:
+  <https://www.etsi.org/deliver/etsi_ts/103200_103299/103223/01.01.01_60/ts_103223v010101p.pdf>
+
+Current FFmpeg still only detects the `0x02000850` syncword and skips to the end
+of the XLL frame; it does not parse this channel set.
+
+## Tools
+
+- `xll_x_audio.rs`: decode the four waveforms to WAV;
+- `xll_x_chs.rs`: prove/characterize the bare XLL channel set and CRC;
+- `xll_x_meta.rs`: analyze the reserved 64-bit EXSS descriptor field;
+- `xll_x_pair.rs`: compare aligned language variants;
+- `xll_x_mda.rs`: bit-aligned MDA signature and URI scan;
+- `analyze-dtsx-object-emulator.py`: rank-one gain, raw-FOA, layout activity
+  and optional picture/audio trajectory tests for the public control clip;
+- older `xll_x_probe`, `xll_x_rice` and `xll_x_scan` diagnostics remain useful
+  as historical/raw-payload tools, but their object-count hypothesis is
+  obsolete.
+
+Run the control analysis after extracting the regular bed and XLL-X WAVs:
+
+```sh
+python3 scripts/analyze-dtsx-object-emulator.py \
+  --bed /tmp/dtsx-object-emulator-bed.wav \
+  --height /tmp/dtsx-object-emulator-x.wav \
+  --video /tmp/dtsx-object-emulator.mkv
+```
 
 ## Corpus
 
-Full DTS:X tracks (`-c copy`, X extension included) at
-`/mnt/local/SSD_B-CT4000/Dumps/`:
-Ex.Machina.2014, Apollo.13.1995, Carlitos.Way.1993, Gladiator.2000,
-Harry.Potter.DH1.2010, La.La.Land.2016 (eng + fra), The.Mummy.1999,
-The.Mummy.Returns.2001, The.Mummy.2008 — all `DTS-HD MA + DTS:X`, 48 kHz, 8 ch.
+Re-extracted elementary streams are in:
+
+```text
+/mnt/local/SSD_A-CT4000/DTS:X-Dumps/
+```
+
+Available: *Apollo 13*, *Carlito's Way*, *Ex Machina*, *Gladiator*, *La La
+Land* (English and French), *The Mummy* (1999), *The Mummy Returns*, and *The
+Mummy* (2008). `ffprobe` identifies every track as `DTS-HD MA + DTS:X`, 48 kHz,
+8-channel bed. The previously used *Harry Potter and the Deathly Hallows: Part
+1* source was not found and has not been re-extracted.

--- a/scripts/analyze-dtsx-object-emulator.py
+++ b/scripts/analyze-dtsx-object-emulator.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Classify the four XLL-X waveforms in the DTS:X Object Emulator clip.
+
+The test uses the public clip as a controlled, mostly single-source pan.  It
+does not assume that the decoded XLL-X channels are speakers: their gain
+vectors are estimated from the common waveform with a rank-one covariance
+decomposition, then checked for speaker-feed and raw FOA signatures.
+
+Optional video analysis tracks the bright object in the fixed-camera 5.1.2
+section.  It verifies A/V alignment by comparing screen position with the
+decoded left/right and floor/height energy balances.  Screen coordinates are
+only proxies; the clip does not print numerical azimuth/elevation values.
+
+Dependencies: numpy, scipy, and (with --video) opencv-python.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from scipy.io import wavfile
+
+
+CHANNELS = ("FL", "FR", "FC", "LFE", "BL", "BR", "SL", "SR", "X0", "X1", "X2", "X3")
+HEIGHT = np.array((8, 9, 10, 11))
+LEFT = np.array((0, 4, 6, 8, 10))
+RIGHT = np.array((1, 5, 7, 9, 11))
+FLOOR = np.array((0, 1, 2, 4, 5, 6, 7))
+HEIGHT_DOWNMIX_Q15 = 23170
+HEIGHT_DOWNMIX_GAIN = HEIGHT_DOWNMIX_Q15 / 32768.0
+HEIGHT_BED_PAIRS = ((0, 8), (1, 9), (4, 10), (5, 11))
+
+
+@dataclass(frozen=True)
+class LayoutInterval:
+    name: str
+    start: float
+    end: float
+    absent: tuple[int, ...]
+
+
+# These conservative ranges avoid the animated transitions between layouts.
+LAYOUTS = (
+    LayoutInterval("7.1.4 (first)", 46.0, 61.5, ()),
+    LayoutInterval("5.1.2", 64.0, 69.0, (4, 5, 10, 11)),
+    LayoutInterval("2.1", 72.5, 75.0, (2, 4, 5, 6, 7, 8, 9, 10, 11)),
+    LayoutInterval("5.1", 77.0, 79.5, (4, 5, 8, 9, 10, 11)),
+    LayoutInterval("7.1", 82.0, 84.5, (8, 9, 10, 11)),
+    LayoutInterval("7.1.4 (last)", 86.0, 89.0, ()),
+)
+
+
+def load_audio(bed_path: Path, height_path: Path) -> tuple[int, np.ndarray]:
+    bed_rate, bed = wavfile.read(bed_path, mmap=True)
+    height_rate, height = wavfile.read(height_path, mmap=True)
+    if bed_rate != height_rate:
+        raise ValueError(f"sample-rate mismatch: {bed_rate} != {height_rate}")
+    if bed.ndim != 2 or bed.shape[1] != 8:
+        raise ValueError(f"expected an eight-channel bed, got {bed.shape}")
+    if height.ndim != 2 or height.shape[1] != 4:
+        raise ValueError(f"expected four XLL-X channels, got {height.shape}")
+    if bed.shape[0] != height.shape[0]:
+        raise ValueError(f"sample-count mismatch: {bed.shape[0]} != {height.shape[0]}")
+    return bed_rate, np.concatenate((bed, height), axis=1)
+
+
+def interval(audio: np.ndarray, rate: int, start: float, end: float) -> np.ndarray:
+    return np.asarray(audio[int(start * rate) : int(end * rate)], dtype=np.float64)
+
+
+def rms(samples: np.ndarray) -> np.ndarray:
+    return np.sqrt(np.mean(np.square(samples), axis=0))
+
+
+def relative_db(values: np.ndarray) -> np.ndarray:
+    peak = float(np.max(values))
+    if peak == 0.0:
+        return np.full_like(values, -np.inf)
+    with np.errstate(divide="ignore"):
+        return 20.0 * np.log10(values / peak)
+
+
+def print_layout_activity(audio: np.ndarray, rate: int) -> None:
+    print("Layout-controlled channel activity")
+    print("----------------------------------")
+    for item in LAYOUTS:
+        levels = rms(interval(audio, rate, item.start, item.end))
+        db = relative_db(levels)
+        heights = " ".join(
+            f"{CHANNELS[index]}={db[index]:6.1f} dB" if np.isfinite(db[index]) else f"{CHANNELS[index]}=  -inf"
+            for index in HEIGHT
+        )
+        if item.absent:
+            inactive = levels[np.array(item.absent)]
+            inactive_db = relative_db(np.append(levels.max(), inactive))[1:]
+            leakage = float(np.max(inactive_db))
+            leak_text = f"; strongest forbidden output={leakage:.1f} dB" if np.isfinite(leakage) else "; forbidden outputs are exactly zero"
+        else:
+            leak_text = ""
+        print(f"{item.name:15s} {heights}{leak_text}")
+    print()
+
+
+def windowed_rms(audio: np.ndarray, rate: int, start: float, end: float, width: float, hop: float) -> np.ndarray:
+    size = int(width * rate)
+    rows = []
+    for time in np.arange(start, end - width, hop):
+        rows.append(rms(interval(audio, rate, float(time), float(time) + width)))
+    return np.asarray(rows)
+
+
+def print_pair_correlations(audio: np.ndarray, rate: int) -> None:
+    envelopes = windowed_rms(audio, rate, 46.0, 69.0, 0.1, 0.05)
+    print("Lower/upper RMS-envelope correlations")
+    print("-------------------------------------")
+    for lower, upper in ((0, 8), (1, 9), (4, 10), (5, 11)):
+        correlation = float(np.corrcoef(envelopes[:, lower], envelopes[:, upper])[0, 1])
+        print(f"{CHANNELS[upper]} vs {CHANNELS[lower]}: {correlation:.3f}")
+    print()
+
+
+def rank_one_gains(
+    audio: np.ndarray,
+    rate: int,
+    start: float = 46.0,
+    end: float = 61.5,
+    width: float = 0.15,
+    hop: float = 0.05,
+) -> tuple[np.ndarray, np.ndarray]:
+    gains = []
+    shares = []
+    for time in np.arange(start, end - width, hop):
+        samples = interval(audio, rate, float(time), float(time) + width)
+        samples -= np.mean(samples, axis=0)
+        covariance = samples.T @ samples
+        eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+        total = float(np.sum(eigenvalues))
+        if total <= 0.0:
+            continue
+        share = float(eigenvalues[-1] / total)
+        gain = eigenvectors[:, -1]
+        # A speaker pan should have common polarity.  Resolve the arbitrary PCA
+        # sign in the direction that maximizes that hypothesis, then measure
+        # whatever negative energy remains.
+        if np.sum(gain) < 0.0:
+            gain = -gain
+        gains.append(gain)
+        shares.append(share)
+    return np.asarray(gains), np.asarray(shares)
+
+
+def quadratic_features(vectors: np.ndarray) -> np.ndarray:
+    x0, x1, x2, x3 = vectors.T
+    return np.column_stack(
+        (
+            x0 * x0,
+            x1 * x1,
+            x2 * x2,
+            x3 * x3,
+            2.0 * x0 * x1,
+            2.0 * x0 * x2,
+            2.0 * x0 * x3,
+            2.0 * x1 * x2,
+            2.0 * x1 * x3,
+            2.0 * x2 * x3,
+        )
+    )
+
+
+def quadratic_matrix(coefficients: np.ndarray) -> np.ndarray:
+    return np.array(
+        (
+            (coefficients[0], coefficients[4], coefficients[5], coefficients[6]),
+            (coefficients[4], coefficients[1], coefficients[7], coefficients[8]),
+            (coefficients[5], coefficients[7], coefficients[2], coefficients[9]),
+            (coefficients[6], coefficients[8], coefficients[9], coefficients[3]),
+        )
+    )
+
+
+def print_fixed_rematrix_test(height: np.ndarray) -> None:
+    features = quadratic_features(height)
+    indices = np.arange(height.shape[0])
+    training = indices % 5 != 0
+    testing = ~training
+    _, _, right_vectors = np.linalg.svd(features[training], full_matrices=False)
+    coefficients = right_vectors[-1]
+    matrix = quadratic_matrix(coefficients)
+    coefficients /= np.linalg.norm(matrix, ord="fro")
+    matrix = quadratic_matrix(coefficients)
+    eigenvalues = np.linalg.eigvalsh(matrix)
+    holdout_residual = float(np.sqrt(np.mean(np.square(features[testing] @ coefficients))))
+
+    # Four-corner separable panning has gains [L*F, R*F, L*B, R*B], hence
+    # X1*X2 - X0*X3 == 0.  This is a (2,2)-signature quadratic surface.
+    corner_relation = height[:, 1] * height[:, 2] - height[:, 0] * height[:, 3]
+    corner_residual = float(np.sqrt(np.mean(np.square(corner_relation))))
+
+    negative = int(np.sum(eigenvalues < -1e-6))
+    positive = int(np.sum(eigenvalues > 1e-6))
+    print("Unknown fixed 4x4 rematrix test")
+    print("--------------------------------")
+    print("FOA point-source gains lie on a quadratic cone with signature (1,3).")
+    print("A real invertible 4x4 rematrix must preserve that signature.")
+    print("fitted cone eigenvalues: " + " ".join(f"{value:+.3f}" for value in eigenvalues))
+    print(f"fitted signature: ({negative},{positive}); holdout RMS residual={holdout_residual:.4f}")
+    print(f"four-corner relation X1*X2=X0*X3 RMS residual: {corner_residual:.4f}")
+    print("Result: no fixed real 4x4 transform can turn this gain surface into raw FOA.")
+    print()
+
+
+def q15_downmix(samples: np.ndarray) -> np.ndarray:
+    pcm = np.rint(samples * 8_388_608.0).astype(np.int64)
+    return (pcm * HEIGHT_DOWNMIX_Q15 + (1 << 14)) >> 15
+
+
+def print_embedded_downmix_test(
+    audio: np.ndarray, rate: int, gains: np.ndarray, shares: np.ndarray
+) -> None:
+    selected = gains[shares >= 0.95]
+    print("Backward-compatible 7.1 height-downmix test")
+    print("--------------------------------------------")
+    print(
+        f"candidate coefficient: {HEIGHT_DOWNMIX_Q15}/32768 = "
+        f"{HEIGHT_DOWNMIX_GAIN:.9f} (-3 dB DTS table value)"
+    )
+    for lower, upper in HEIGHT_BED_PAIRS:
+        usable = selected[:, upper] > 0.03
+        ratio = selected[usable, lower] / selected[usable, upper]
+        unfolded = selected[usable, lower] - HEIGHT_DOWNMIX_GAIN * selected[usable, upper]
+        near_zero = float(np.mean(np.abs(unfolded) < 0.02))
+        print(
+            f"{CHANNELS[lower]}/{CHANNELS[upper]}: median ratio={np.median(ratio):.9f}; "
+            f"unfolded gain near zero in {near_zero:.1%} of usable windows"
+        )
+
+    print("Best 100 ms fixed-point reconstruction windows (bed - rmul15(height, 23170)):")
+    for lower, upper in HEIGHT_BED_PAIRS:
+        best = None
+        for time in np.arange(46.0, 68.9, 0.025):
+            samples = interval(audio, rate, float(time), float(time) + 0.1)
+            bed = np.rint(samples[:, lower] * 8_388_608.0).astype(np.int64)
+            height = q15_downmix(samples[:, upper])
+            bed_rms = float(np.sqrt(np.mean(np.square(bed.astype(np.float64)))))
+            height_rms = float(np.sqrt(np.mean(np.square(height.astype(np.float64)))))
+            if bed_rms < 10_000.0 or height_rms < 10_000.0:
+                continue
+            residual = bed - height
+            residual_rms = float(np.sqrt(np.mean(np.square(residual.astype(np.float64)))))
+            candidate = (
+                residual_rms / bed_rms,
+                float(time),
+                residual_rms,
+                int(np.max(np.abs(residual))),
+            )
+            best = candidate if best is None or candidate < best else best
+        if best is None:
+            continue
+        relative, time, residual_rms, maximum = best
+        print(
+            f"  {CHANNELS[lower]}-{CHANNELS[upper]}: t={time:.3f}s, residual/bed={relative:.3e}, "
+            f"residual RMS={residual_rms:.2f} LSB, max={maximum} LSB"
+        )
+    print("Result: the regular 7.1 contains a -3 dB copy of each height feed.")
+    print()
+
+
+def print_gain_model(audio: np.ndarray, rate: int) -> None:
+    gains, shares = rank_one_gains(audio, rate)
+    selected = gains[shares >= 0.95]
+    height = selected[:, HEIGHT]
+    height_share = np.linalg.norm(height, axis=1) / np.linalg.norm(selected, axis=1)
+    height = height[height_share >= 0.10]
+    height /= np.linalg.norm(height, axis=1, keepdims=True)
+
+    negative_energy = float(np.sum(np.square(np.minimum(height, 0.0))) / np.sum(np.square(height)))
+    active = np.sum(np.abs(height) >= 0.05, axis=1)
+
+    print("Single-source gain-vector test (first 7.1.4 section)")
+    print("---------------------------------------------------")
+    print(f"usable windows: {height.shape[0]} / {gains.shape[0]}")
+    print(f"median rank-one covariance share: {np.median(shares):.4f}")
+    print(f"negative height-gain energy: {negative_energy:.3e}")
+    print(f"median active height outputs at -26 dB: {np.median(active):.0f} / 4")
+    print(f"windows with at most two active height outputs: {np.mean(active <= 2):.1%}")
+    print()
+
+    print("Raw first-order ambisonic (FOA) sanity check")
+    print("---------------------------------------------")
+    print("A raw FOA W component has constant non-zero magnitude after gain-vector normalization.")
+    best = None
+    for channel in range(4):
+        values = np.abs(height[:, channel])
+        variation = float(np.std(values) / np.mean(values))
+        dropout = float(np.mean(values < 0.05))
+        candidate = (variation, dropout, channel)
+        best = candidate if best is None or candidate < best else best
+        print(f"X{channel}: coefficient of variation={variation:.3f}, dropout={dropout:.1%}")
+    assert best is not None
+    print(
+        f"best W candidate is X{best[2]}, but varies by {best[0]:.3f} and drops out in {best[1]:.1%} of windows"
+    )
+    print("Result: the four decoded waveforms are not raw W/X/Y/Z components.")
+    print()
+    print_fixed_rematrix_test(height)
+    print_embedded_downmix_test(audio, rate, gains, shares)
+
+
+def detect_bright_object(frame: np.ndarray) -> tuple[float, float] | None:
+    import cv2
+
+    hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+    hue = hsv[:, :, 0]
+    saturation = hsv[:, :, 1]
+    value = hsv[:, :, 2]
+    warm_or_white = ((saturation < 180) & ((hue < 45) | (hue > 170))) | ((hue < 40) & (saturation > 40))
+    mask = ((value > 245) & warm_or_white).astype(np.uint8) * 255
+    mask[:100, :] = 0
+    mask[800:, :] = 0
+    mask[:, :100] = 0
+    mask[:, 1820:] = 0
+
+    count, _, stats, centroids = cv2.connectedComponentsWithStats(mask)
+    candidates = []
+    for index in range(1, count):
+        _, _, width, height, area = (int(value) for value in stats[index])
+        aspect = min(width, height) / max(width, height)
+        center_x, center_y = centroids[index]
+        if not (80 <= area <= 1300 and 7 <= width <= 70 and 7 <= height <= 70 and aspect >= 0.45):
+            continue
+        # Reject small pieces of the fixed television logo in this shot.
+        if 930 < center_x < 1020 and 440 < center_y < 510:
+            continue
+        candidates.append((area * aspect, center_x, center_y))
+    if not candidates:
+        return None
+    _, center_x, center_y = max(candidates)
+    return float(center_x), float(center_y)
+
+
+def print_video_alignment(video_path: Path, audio: np.ndarray, rate: int, audio_start: float) -> None:
+    import cv2
+
+    capture = cv2.VideoCapture(str(video_path))
+    screen_x = []
+    screen_y = []
+    horizontal_balance = []
+    height_fraction = []
+    for video_time in np.arange(64.0, 69.0, 0.1):
+        capture.set(cv2.CAP_PROP_POS_MSEC, float(video_time * 1000.0))
+        ok, frame = capture.read()
+        if not ok:
+            continue
+        point = detect_bright_object(frame)
+        if point is None:
+            continue
+        audio_time = float(video_time - audio_start)
+        samples = interval(audio, rate, audio_time - 0.05, audio_time + 0.05)
+        levels = rms(samples)
+        power = np.square(levels)
+        left = float(np.sum(power[LEFT]))
+        right = float(np.sum(power[RIGHT]))
+        top = float(np.sum(power[HEIGHT]))
+        floor = float(np.sum(power[FLOOR]))
+        screen_x.append(point[0])
+        screen_y.append(point[1])
+        horizontal_balance.append((right - left) / (right + left + 1e-30))
+        height_fraction.append(top / (top + floor + 1e-30))
+    capture.release()
+
+    print("Fixed-camera 5.1.2 picture/audio alignment")
+    print("------------------------------------------")
+    if len(screen_x) < 10:
+        print(f"only {len(screen_x)} object positions detected; no reliable result")
+        print()
+        return
+    horizontal_correlation = float(np.corrcoef(screen_x, horizontal_balance)[0, 1])
+    vertical_correlation = float(np.corrcoef(screen_y, height_fraction)[0, 1])
+    print(f"tracked video positions: {len(screen_x)}")
+    print(f"screen X vs decoded right-minus-left energy: r={horizontal_correlation:.3f}")
+    print(f"screen Y vs decoded height-energy fraction: r={vertical_correlation:.3f}")
+    print("(The expected vertical sign is negative because smaller screen Y means higher.)")
+    print()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bed", type=Path, required=True, help="decoded eight-channel bed WAV")
+    parser.add_argument("--height", type=Path, required=True, help="decoded four-channel XLL-X WAV")
+    parser.add_argument("--video", type=Path, help="optional Object Emulator MKV for picture/audio alignment")
+    parser.add_argument(
+        "--audio-start",
+        type=float,
+        default=0.053,
+        help="audio start time in the MKV relative to video, in seconds (default: 0.053)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    rate, audio = load_audio(args.bed, args.height)
+    print(f"audio: {audio.shape[0]} samples, {audio.shape[1]} channels, {rate} Hz")
+    print()
+    print_layout_activity(audio, rate)
+    print_pair_correlations(audio, rate)
+    print_gain_model(audio, rate)
+    if args.video is not None:
+        print_video_alignment(args.video, audio, rate, args.audio_start)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -134,6 +134,10 @@ pub(crate) struct AtmosBridge {
     /// DTS-HD Master Audio lossless (5.1/7.1) decoder.
     pub(crate) dts_hd_decoder: dca::HdDecoder,
     pub(crate) dts_frame_count: u64,
+    /// Latches once a valid XLL-X height quartet has been emitted: fallback
+    /// frames then keep the 12-channel shape (composite bed + silent heights)
+    /// instead of renegotiating to 8 channels. Cleared with the pipeline.
+    pub(crate) dts_height_locked: bool,
     /// True when the most recent `push_packet` used the DTS path.
     pub(crate) dts_active: bool,
     // ── Shared ───────────────────────────────────────────────────────
@@ -217,6 +221,7 @@ impl AtmosBridge {
             dts_decoder: dca::PcmDecoder::new(),
             dts_hd_decoder: dca::HdDecoder::new(),
             dts_frame_count: 0,
+            dts_height_locked: false,
             dts_active: false,
             presentation,
             strict,
@@ -272,6 +277,7 @@ impl AtmosBridge {
         self.dts_decoder.reset();
         self.dts_hd_decoder.reset();
         self.dts_frame_count = 0;
+        self.dts_height_locked = false;
         self.dts_active = false;
         // Re-sniff after reset, but keep any host-declared codec.
         self.raw_codec = None;
@@ -930,10 +936,10 @@ mod raw_transport_tests {
     // End-to-end DTS-HD MA: feed the raw 7.1 dump and check it emits 8-channel
     // lossless bed frames. Skips when the (uncommitted) dump is absent.
     #[test]
-    fn dtshd_raw_transport_emits_7_1_bed() {
-        const DUMP: &str = "/mnt/local/SSD_B-CT4000/Dumps/Ex.Machina.2014.dtsx.eng.dts";
+    fn dtshd_raw_transport_emits_labeled_7_1_4_channels() {
+        const DUMP: &str = "/mnt/local/SSD_A-CT4000/DTS:X-Dumps/Ex.Machina.2014.dtsx.eng.dts";
         if !std::path::Path::new(DUMP).exists() {
-            eprintln!("skipping: 7.1 dump not present");
+            eprintln!("skipping: DTS:X dump not present");
             return;
         }
         // Feed ~2 MB — enough for many frames past the silent intro.
@@ -944,22 +950,22 @@ mod raw_transport_tests {
         let result = bridge.push_packet(RSlice::from_slice(chunk), RInputTransport::Raw, 0);
         assert!(result.error_message.is_empty(), "{}", result.error_message);
         assert!(!result.frames.is_empty(), "no HD frames decoded");
-        // DTS (incl. HD) core is channel-based, not objects → non-spatial; the
-        // channel-render mode decides how the bed is placed/virtualised.
+        // A DTS:X fixed 7.1.4 presentation is twelve labeled fixed channels —
+        // no dynamic objects, no fabricated metadata: the renderer decides
+        // placement (docs/channel-object-contract.md).
         assert!(!bridge.has_objects());
 
-        // Find a fully-populated 7.1 frame (some early frames may be 5.1 before
-        // the surround-back channels carry signal, but the bed is 8ch once XLL
-        // emits the full hierarchy).
+        // Once the XLL-X quartet locks, frames carry the fixed 7.1.4 shape.
         let f = result
             .frames
             .iter()
-            .find(|f| f.channel_count == 8)
-            .expect("expected an 8-channel 7.1 frame");
+            .find(|f| f.channel_count == 12)
+            .expect("expected a 12-channel 7.1.4 frame");
         assert_eq!(f.sampling_frequency, 48_000);
+        assert!(f.metadata.is_empty(), "fixed presentation must carry no metadata");
         use bridge_api::RChannelLabel::*;
         let labels: Vec<_> = f.channel_labels.iter().copied().collect();
-        // Active speakers ascending: C,L,R,Ls,Rs,LFE,Lsr,Rsr.
-        assert_eq!(labels, vec![C, L, R, Ls, Rs, LFE, Lb, Rb]);
+        // Active speakers ascending (C,L,R,Ls,Rs,LFE,Lsr,Rsr) + the height quartet.
+        assert_eq!(labels, vec![C, L, R, Ls, Rs, LFE, Lb, Rb, Tfl, Tfr, Tbl, Tbr]);
     }
 }

--- a/src/dts_pipeline.rs
+++ b/src/dts_pipeline.rs
@@ -3,12 +3,14 @@
 // DTS (DCA) raw transport pipeline. Demuxes the `[core][exss]` byte stream and
 // routes each frame to either the DTS-HD MA lossless decoder (5.1/7.1, when an
 // EXSS substream follows the core) or the plain DTS core decoder (5.1). Every
-// decoded channel is emitted as a bed channel, placed at its canonical speaker
-// by the renderer (the layout is the "fixed object disposition").
+// decoded core channel is emitted as a bed channel, placed at its canonical
+// speaker by the renderer. XLL-X's four additional waveforms are mapped as
+// fixed objects at the four 7.1.4 height positions after undoing their -3 dB
+// contribution to the backward-compatible 7.1 bed.
 
 use abi_stable::std_types::{RString, RVec};
-use bridge_api::{RChannelLabel, RDecodedFrame};
 use bridge_api::RPushResult;
+use bridge_api::{RChannelLabel, RDecodedFrame};
 use dca::{exss_has_xll, exss_substream_size, parse_header, CorePcmFrame, HdError, HdFrame};
 
 use crate::bridge::AtmosBridge;
@@ -17,6 +19,15 @@ use crate::labels::dca_bed_channel_to_r;
 
 const CORE_SYNC: [u8; 4] = 0x7FFE_8001u32.to_be_bytes();
 const SUBSTREAM_SYNC: [u8; 4] = 0x6458_2025u32.to_be_bytes();
+const XLL_X_HEIGHT_LABELS: [RChannelLabel; 4] = [
+    RChannelLabel::Tfl,
+    RChannelLabel::Tfr,
+    RChannelLabel::Tbl,
+    RChannelLabel::Tbr,
+];
+// Exact Q15 -3 dB coefficient used by the DTS downmix table. The regular 7.1
+// presentation contains this contribution from each corresponding height feed.
+const XLL_X_HEIGHT_DOWNMIX_GAIN: f32 = 23_170.0 / 32_768.0;
 
 /// Demux and decode all complete DTS frames buffered in `bridge.dts_buf`.
 pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
@@ -55,11 +66,15 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
                 break;
             }
             if exss_has_xll(&rest[fs..fs + es]) {
-                let base = bridge.total_samples;
-                match bridge.dts_hd_decoder.decode(&rest[..fs], &rest[fs..fs + es]) {
+                match bridge
+                    .dts_hd_decoder
+                    .decode(&rest[..fs], &rest[fs..fs + es])
+                {
                     Ok(hd) => {
                         let n = hd_samples(&hd);
-                        result.frames.push(build_hd_frame(&hd));
+                        if let Some(frame) = build_hd_frame(&hd, &mut bridge.dts_height_locked) {
+                            result.frames.push(frame);
+                        }
                         bridge.total_samples += n as u64;
                         bridge.dts_frame_count += 1;
                     }
@@ -67,7 +82,6 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
                     Err(e) => {
                         let msg = format!("dts_hd_decode_error={e:?}");
                         log::warn!("{msg}");
-                        let _ = base;
                         if bridge.strict {
                             result.error_message = RString::from(msg);
                             bridge.reset_pipeline();
@@ -148,34 +162,120 @@ fn speaker_to_label(spkr: usize) -> RChannelLabel {
         3 => RChannelLabel::Ls,
         4 => RChannelLabel::Rs,
         5 => RChannelLabel::LFE,
-        6 => RChannelLabel::Cb,    // Cs (rear center)
-        7 => RChannelLabel::Lb,    // Lsr (rear surround left)
-        8 => RChannelLabel::Rb,    // Rsr (rear surround right)
+        6 => RChannelLabel::Cb, // Cs (rear center)
+        7 => RChannelLabel::Lb, // Lsr (rear surround left)
+        8 => RChannelLabel::Rb, // Rsr (rear surround right)
         _ => RChannelLabel::Unknown,
     }
 }
 
-/// Build a bed frame from a decoded DTS-HD frame (per-speaker f32).
-fn build_hd_frame(hd: &HdFrame) -> RDecodedFrame {
+
+/// Build a labeled-channel frame from a decoded DTS-HD frame (per-speaker
+/// f32). Fixed channels only — a DTS:X fixed 7.1.4 presentation is twelve
+/// labeled channels, never fabricated metadata
+/// (`docs/channel-object-contract.md`).
+///
+/// `height_locked` latches once a valid XLL-X quartet has been emitted: from
+/// then on a frame with a missing/invalid quartet keeps the 12-channel shape
+/// (composite bed + silent heights) instead of collapsing to 8 channels, so
+/// the host never renegotiates mid-stream and no content is lost (the folded
+/// height contribution stays in the bed for that frame).
+fn build_hd_frame(hd: &HdFrame, height_locked: &mut bool) -> Option<RDecodedFrame> {
     // Active speakers in ascending index order = stable channel order.
     let active: Vec<usize> = (0..hd.samples.len())
         .filter(|&s| hd.samples[s].is_some())
         .collect();
     let sample_count = hd_samples(hd);
-    let channel_count = active.len();
+
+    // Validate every bed channel length before any indexing: a decoder bug or
+    // malformed stream must degrade to a dropped frame, never a panic.
+    let mut bed: Vec<&[f32]> = Vec::with_capacity(active.len());
+    for &spkr in &active {
+        let channel = hd.samples[spkr].as_ref().expect("active speaker");
+        if channel.len() != sample_count {
+            log::warn!(
+                "dts: bed channel {spkr} length {} != {sample_count}; dropping frame",
+                channel.len()
+            );
+            return None;
+        }
+        bed.push(channel.as_slice());
+    }
+
+    // The XLL-X channel set carries four full-coded waveforms but no
+    // one-to-one speaker mask. Treat its stable stereo pairs as front-height
+    // L/R followed by rear-height L/R. Keep the mapping isolated here so it
+    // can be replaced without touching the lossless decoder if later metadata
+    // proves otherwise.
+    let height_samples: Option<&[Vec<f32>; 4]> =
+        hd.x_samples
+            .as_slice()
+            .try_into()
+            .ok()
+            .filter(|channels: &&[Vec<f32>; 4]| {
+                channels.iter().all(|channel| channel.len() == sample_count)
+            });
+    if height_samples.is_none() && hd.x_present && *height_locked {
+        let err = hd.x_decode_error.unwrap_or("no quartet");
+        log::warn!("dts: XLL-X quartet unavailable ({err}); emitting silent heights");
+    }
+
+    let emit_heights = height_samples.is_some() || *height_locked;
+    let height_count = if emit_heights {
+        XLL_X_HEIGHT_LABELS.len()
+    } else {
+        0
+    };
+    let channel_count = active.len() + height_count;
+
+    // Per-channel embedded-height source for the unfold, hoisted out of the
+    // sample loop (no per-sample match / Option deref): DCA speakers
+    // 1=L, 2=R, 7=Lsr, 8=Rsr carry the -3 dB fold of TFL/TFR/TBL/TBR.
+    let fold_source: Vec<Option<&[f32]>> = active
+        .iter()
+        .map(|&spkr| {
+            let height_idx = match spkr {
+                1 => 0usize,
+                2 => 1,
+                7 => 2,
+                8 => 3,
+                _ => return None,
+            };
+            height_samples.map(|h| h[height_idx].as_slice())
+        })
+        .collect();
 
     let mut pcm: RVec<i32> = RVec::with_capacity(sample_count * channel_count);
     for s in 0..sample_count {
-        for &spkr in &active {
-            pcm.push(float_to_pcm_i32(hd.samples[spkr].as_ref().unwrap()[s]));
+        for (channel, fold) in bed.iter().zip(fold_source.iter()) {
+            let sample = match fold {
+                Some(height) => channel[s] - height[s] * XLL_X_HEIGHT_DOWNMIX_GAIN,
+                None => channel[s],
+            };
+            pcm.push(float_to_pcm_i32(sample));
+        }
+        if let Some(height_samples) = height_samples {
+            for channel in height_samples.iter() {
+                pcm.push(float_to_pcm_i32(channel[s]));
+            }
+        } else {
+            for _ in 0..height_count {
+                pcm.push(0);
+            }
         }
     }
+
     let mut channel_labels: RVec<RChannelLabel> = RVec::with_capacity(channel_count);
     for &spkr in &active {
         channel_labels.push(speaker_to_label(spkr));
     }
+    channel_labels.extend(XLL_X_HEIGHT_LABELS[..height_count].iter().copied());
 
-    RDecodedFrame {
+    if height_samples.is_some() {
+        *height_locked = true;
+    }
+
+    Some(RDecodedFrame {
         sampling_frequency: hd.sample_rate,
         sample_count: sample_count as u32,
         channel_count: channel_count as u32,
@@ -186,7 +286,7 @@ fn build_hd_frame(hd: &HdFrame) -> RDecodedFrame {
         drc_ramp_duration: 0,
         dialogue_level: None.into(),
         is_new_segment: false,
-    }
+    })
 }
 
 /// Build a bed frame from a plain DTS core PCM frame (DCA primary order + LFE).
@@ -222,5 +322,201 @@ fn build_core_frame(core: &CorePcmFrame) -> RDecodedFrame {
         drc_ramp_duration: 0,
         dialogue_level: None.into(),
         is_new_segment: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_COUNT: usize = 2;
+
+    fn hd_frame(samples: Vec<Option<Vec<f32>>>, x_samples: Vec<Vec<f32>>) -> HdFrame {
+        HdFrame {
+            sample_rate: 48_000,
+            output_mask: 0,
+            samples,
+            x_present: !x_samples.is_empty(),
+            x_imax: false,
+            x_payload: Vec::new(),
+            x_payload_offset: 0,
+            x_samples,
+            x_pcm_bit_res: 24,
+            x_bits_consumed: 0,
+            x_decode_error: None,
+            x_header_tail_bits: 0,
+            xll_frame_segments: 1,
+            xll_segment_samples: SAMPLE_COUNT,
+            xll_segment_size_bits: 0,
+            xll_band_crc_present: 0,
+            xll_scalable_lsbs: false,
+            exss_descriptor_tail: Vec::new(),
+            exss_descriptor_tail_bits: 0,
+            x_descriptor_offset: None,
+            x_descriptor_size: None,
+            x_descriptor_navigation_used: false,
+        }
+    }
+
+    fn assert_pcm_close(actual: i32, expected: f32) {
+        let expected = float_to_pcm_i32(expected);
+        assert!(
+            actual.abs_diff(expected) <= 1,
+            "actual={actual}, expected={expected}"
+        );
+    }
+
+    #[test]
+    fn xll_x_heights_are_removed_from_the_compatible_bed() {
+        let heights = [
+            vec![0.40, -0.20],
+            vec![-0.30, 0.10],
+            vec![0.20, -0.40],
+            vec![-0.10, 0.30],
+        ];
+        let dry = [
+            vec![0.05, -0.06],
+            vec![-0.07, 0.08],
+            vec![0.09, -0.10],
+            vec![-0.11, 0.12],
+        ];
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        samples[0] = Some(vec![0.01, -0.01]);
+        samples[1] = Some(
+            dry[0]
+                .iter()
+                .zip(&heights[0])
+                .map(|(&bed, &height)| bed + height * XLL_X_HEIGHT_DOWNMIX_GAIN)
+                .collect(),
+        );
+        samples[2] = Some(
+            dry[1]
+                .iter()
+                .zip(&heights[1])
+                .map(|(&bed, &height)| bed + height * XLL_X_HEIGHT_DOWNMIX_GAIN)
+                .collect(),
+        );
+        samples[3] = Some(vec![0.02, -0.02]);
+        samples[4] = Some(vec![0.03, -0.03]);
+        samples[5] = Some(vec![0.04, -0.04]);
+        samples[7] = Some(
+            dry[2]
+                .iter()
+                .zip(&heights[2])
+                .map(|(&bed, &height)| bed + height * XLL_X_HEIGHT_DOWNMIX_GAIN)
+                .collect(),
+        );
+        samples[8] = Some(
+            dry[3]
+                .iter()
+                .zip(&heights[3])
+                .map(|(&bed, &height)| bed + height * XLL_X_HEIGHT_DOWNMIX_GAIN)
+                .collect(),
+        );
+
+        let hd = hd_frame(samples, heights.into());
+        let mut locked = false;
+        let frame = build_hd_frame(&hd, &mut locked).expect("valid frame");
+        assert!(locked, "a valid quartet must latch the height lock");
+
+        assert_eq!(frame.sample_count, SAMPLE_COUNT as u32);
+        assert_eq!(frame.channel_count, 12);
+        assert_eq!(
+            frame.channel_labels.as_slice(),
+            &[
+                RChannelLabel::C,
+                RChannelLabel::L,
+                RChannelLabel::R,
+                RChannelLabel::Ls,
+                RChannelLabel::Rs,
+                RChannelLabel::LFE,
+                RChannelLabel::Lb,
+                RChannelLabel::Rb,
+                RChannelLabel::Tfl,
+                RChannelLabel::Tfr,
+                RChannelLabel::Tbl,
+                RChannelLabel::Tbr,
+            ]
+        );
+        assert!(
+            frame.metadata.is_empty(),
+            "a fixed presentation must not fabricate metadata"
+        );
+
+        for sample in 0..SAMPLE_COUNT {
+            let row = &frame.pcm[sample * 12..(sample + 1) * 12];
+            assert_pcm_close(row[1], dry[0][sample]);
+            assert_pcm_close(row[2], dry[1][sample]);
+            assert_pcm_close(row[6], dry[2][sample]);
+            assert_pcm_close(row[7], dry[3][sample]);
+            for height in 0..4 {
+                assert_pcm_close(row[8 + height], hd.x_samples[height][sample]);
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_xll_x_quartet_keeps_the_compatible_bed_unchanged() {
+        let composite_left = vec![0.25, -0.25];
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        samples[0] = Some(vec![0.0; SAMPLE_COUNT]);
+        samples[1] = Some(composite_left.clone());
+        samples[2] = Some(vec![0.0; SAMPLE_COUNT]);
+        samples[3] = Some(vec![0.0; SAMPLE_COUNT]);
+        samples[4] = Some(vec![0.0; SAMPLE_COUNT]);
+        samples[5] = Some(vec![0.0; SAMPLE_COUNT]);
+        samples[7] = Some(vec![0.0; SAMPLE_COUNT]);
+        samples[8] = Some(vec![0.0; SAMPLE_COUNT]);
+        let hd = hd_frame(samples, vec![vec![0.5; SAMPLE_COUNT]; 3]);
+
+        // Not locked yet: an invalid quartet keeps the plain 8-channel bed.
+        let mut locked = false;
+        let frame = build_hd_frame(&hd, &mut locked).expect("valid frame");
+        assert!(!locked, "an invalid quartet must not latch the lock");
+
+        assert_eq!(frame.channel_count, 8);
+        assert!(frame.metadata.is_empty());
+        for sample in 0..SAMPLE_COUNT {
+            assert_eq!(
+                frame.pcm[sample * 8 + 1],
+                float_to_pcm_i32(composite_left[sample])
+            );
+        }
+    }
+
+    #[test]
+    fn locked_stream_keeps_shape_with_silent_heights_on_quartet_dropout() {
+        let composite_left = vec![0.25, -0.25];
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        for idx in [0usize, 2, 3, 4, 5, 7, 8] {
+            samples[idx] = Some(vec![0.0; SAMPLE_COUNT]);
+        }
+        samples[1] = Some(composite_left.clone());
+        // Invalid quartet (3 channels) after a previous frame locked heights.
+        let hd = hd_frame(samples, vec![vec![0.5; SAMPLE_COUNT]; 3]);
+
+        let mut locked = true;
+        let frame = build_hd_frame(&hd, &mut locked).expect("valid frame");
+
+        // Stable 12-channel shape: composite bed (no unfold without a
+        // quartet) + silent height channels — the host never renegotiates.
+        assert_eq!(frame.channel_count, 12);
+        assert!(frame.metadata.is_empty());
+        for sample in 0..SAMPLE_COUNT {
+            let row = &frame.pcm[sample * 12..(sample + 1) * 12];
+            assert_eq!(row[1], float_to_pcm_i32(composite_left[sample]));
+            assert!(row[8..12].iter().all(|&s| s == 0));
+        }
+    }
+
+    #[test]
+    fn mismatched_bed_channel_length_drops_the_frame() {
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        samples[0] = Some(vec![0.0; SAMPLE_COUNT]);
+        samples[1] = Some(vec![0.0; SAMPLE_COUNT + 1]); // corrupt length
+        let hd = hd_frame(samples, Vec::new());
+
+        let mut locked = false;
+        assert!(build_hd_frame(&hd, &mut locked).is_none());
     }
 }


### PR DESCRIPTION
Phase 5 of Omniphony `docs/channel-object-contract.md`: the XLL-X campaign re-landed in the contract model, plus every review fix.

## What ships
- The `dca` decoder work from `research/spatial-object-layer` (XLL-X quartet decode, EXSS navigation, research examples + campaign doc, now marked landed).
- Bridge integration rewritten: the reconstructed 7.1.4 presentation is **twelve labeled fixed channels** (7.1 bed with the exact Q15 −3 dB height fold removed + TFL/TFR/TBL/TBR), **no fabricated metadata**, `has_objects` stays false — placement belongs to the renderer (virtualized by default, crossover applies, per the phase-2b plan).

## Review fixes applied
- **EXSS tail parse is best-effort** (was the track-killing blocker): speculative fields parsed on a savepoint, discarded + rewound on any failure/overrun; tail captured byte-wise and only for XLL assets; moved, not cloned.
- `checked_sub` on the XLL LSB seek; bed channel lengths validated before indexing (malformed frame → dropped, never a panic); per-sample unfold from a precomputed per-channel table (no match/deref per sample); XLL-X syncwords named; `x_decode_error` allocation-free static kind.
- **Stable channel shape**: once the quartet locks, dropout frames emit composite bed + silent heights at 12ch instead of renegotiating to 8ch mid-stream.
- Corpus-gated tests re-pointed at the real dump location (the old `SSD_B` path never existed → they silently self-skipped).

## Validation
- 49 bridge + 12 dca tests green **with the corpus exercised**: quartet decode on the real Ex Machina stream, EXSS nav discovery through the best-effort tail, 7.1 bed still **bit-exact vs ffmpeg**, 12-channel raw-transport assertions.
- mpv end-to-end smoke (fresh liborender ABI 0.6 + this bridge): raw `.dts` plays, DTS:X container hint honored, renderer output clean.

## Before merging — A/B listening pass
A/B bridge builds are staged in `workflows/spatial-object-layer/config/` (`A-main` vs `B-dtsx`); launch commands in the session notes. Please listen before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)