### PR TITLE
Add experimental spatial extension presentations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "generational-arena"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,9 +282,27 @@ dependencies = [
  "eac3",
  "libc",
  "log",
+ "serde",
+ "serde_yaml_ng",
  "spdif",
  "sys",
  "truehd",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -579,6 +603,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +742,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ dca = { version = "0.1.0", path = "dca" }
 abi_stable = "0.11"
 log = "0.4"
 anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml_ng = "0.10"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Play any TrueHD/Atmos file:
 - **mpv** —
 
   ```sh
-  mpv --ad=orender --ad-orender-osc film.mkv
+  mpv --ad=orender --ad-orender-osc input.mkv
   ```
 
   `--ad=orender` is what switches mpv over to object rendering for this

--- a/dca/examples/xll_alt_layout_probe.rs
+++ b/dca/examples/xll_alt_layout_probe.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Survey the stable D0/D1/D3 payload prefix, channel-set mapping bits, and bytes
+// left after decoded audio in a bounded number of alternate-profile frames.
+// Research tool only; it is not used by the realtime decoder.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_alt_layout_probe -- \
+//     <track.dts> [max-frames]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{BufReader, ErrorKind, Read};
+
+use dca::{HdDecoder, HdError, SYNCWORD_SUBSTREAM, parse_header};
+
+const HEADER_BYTES: usize = 18;
+const EXSS_PREFIX_BYTES: usize = 16;
+const OUTER_SUFFIX: [u8; 6] = [0x03, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+const INNER_SUFFIX: [u8; 6] = [0x02, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn read_bits(data: &[u8], position: &mut usize, width: usize) -> Option<u32> {
+    if width > 32 || position.checked_add(width)? > data.len() * 8 {
+        return None;
+    }
+    let mut value = 0;
+    for _ in 0..width {
+        value = (value << 1) | ((data[*position / 8] >> (7 - *position % 8)) & 1) as u32;
+        *position += 1;
+    }
+    Some(value)
+}
+
+fn exss_size(data: &[u8]) -> Option<usize> {
+    let mut bit = 0;
+    if read_bits(data, &mut bit, 32)? != SYNCWORD_SUBSTREAM {
+        return None;
+    }
+    read_bits(data, &mut bit, 8)?;
+    read_bits(data, &mut bit, 2)?;
+    let wide = read_bits(data, &mut bit, 1)? as usize;
+    read_bits(data, &mut bit, 8 + 4 * wide)?;
+    Some(read_bits(data, &mut bit, 16 + 4 * wide)? as usize + 1)
+}
+
+fn geometry_at(control: &[u8], offset: usize) -> bool {
+    let mut bit = offset;
+    let Some(a) = read_bits(control, &mut bit, 4) else {
+        return false;
+    };
+    let Some(b) = read_bits(control, &mut bit, 4) else {
+        return false;
+    };
+    let Some(c) = read_bits(control, &mut bit, 5) else {
+        return false;
+    };
+    let (Some(segments), Some(samples)) = (1usize.checked_shl(a), 1usize.checked_shl(b)) else {
+        return false;
+    };
+    segments <= 8 && segments * samples == 512 && (3..=19).contains(&(c as usize))
+}
+
+fn unique_geometry(control: &[u8], start: usize, end: usize) -> Option<usize> {
+    let values: Vec<_> = (start..=end)
+        .filter(|&offset| geometry_at(control, offset))
+        .collect();
+    (values.len() == 1).then(|| values[0])
+}
+
+fn mapping_bits(payload: &[u8], offset: usize) -> Option<(usize, u32)> {
+    let mut bit = offset * 8;
+    read_bits(payload, &mut bit, 10)?;
+    let channels = read_bits(payload, &mut bit, 4)? as usize + 1;
+    read_bits(payload, &mut bit, channels)?;
+    read_bits(payload, &mut bit, 5)?;
+    read_bits(payload, &mut bit, 5)?;
+    read_bits(payload, &mut bit, 4)?;
+    read_bits(payload, &mut bit, 2)?;
+    read_bits(payload, &mut bit, 2)?;
+    Some((channels, read_bits(payload, &mut bit, 2)?))
+}
+
+fn header_size(payload: &[u8], offset: usize) -> Option<usize> {
+    let mut bit = offset.checked_mul(8)?;
+    read_bits(payload, &mut bit, 10).map(|size| size as usize + 1)
+}
+
+fn crc16_ccitt(data: &[u8]) -> u16 {
+    let mut crc = 0xffffu16;
+    for &byte in data {
+        crc ^= (byte as u16) << 8;
+        for _ in 0..8 {
+            crc = if crc & 0x8000 != 0 {
+                (crc << 1) ^ 0x1021
+            } else {
+                crc << 1
+            };
+        }
+    }
+    crc
+}
+
+fn valid_header(payload: &[u8], offset: usize, expected_channels: usize) -> bool {
+    let mut bit = offset * 8;
+    let Some(size) = read_bits(payload, &mut bit, 10).map(|value| value as usize + 1) else {
+        return false;
+    };
+    let Some(channels) = read_bits(payload, &mut bit, 4).map(|value| value as usize + 1) else {
+        return false;
+    };
+    let Some(end) = offset.checked_add(size) else {
+        return false;
+    };
+    channels == expected_channels && end <= payload.len() && crc16_ccitt(&payload[offset..end]) == 0
+}
+
+fn layout(payload: &[u8]) -> Option<(u8, usize, usize)> {
+    let profile = match payload.get(..4)? {
+        [0xf1, 0x40, 0x00, 0xd0] => 0u8,
+        [0xf1, 0x40, 0x00, 0xd1] => 1u8,
+        [0xf1, 0x40, 0x00, 0xd3] => 3u8,
+        _ => return None,
+    };
+    let minimum_prefix = if profile == 0 { 48 } else { 49 };
+    let prefix_end = (minimum_prefix..payload.len().min(96)).find(|&offset| {
+        payload.get(offset..offset + OUTER_SUFFIX.len()) == Some(&OUTER_SUFFIX)
+            && crc16_ccitt(&payload[..offset]) == 0
+    })?;
+    let control_start = prefix_end + OUTER_SUFFIX.len();
+    let bias = control_start + 12;
+    let inner_start = if profile == 0 { 18 } else { 19 };
+    let tag = *payload.get(control_start)?;
+    let control_size = if tag == 0xb2 { 7 } else { 8 };
+    let outer = payload.get(control_start..control_start + control_size)?;
+    let first = control_start + control_size;
+    let first_channels = match profile {
+        0 => 1,
+        1 => 2,
+        3 => 4,
+        _ => return None,
+    };
+    if !valid_header(payload, first, first_channels) {
+        return None;
+    }
+    let common = unique_geometry(outer, 18, if profile == 3 { 31 } else { 25 })?;
+    let mut bit = 9;
+    let span = read_bits(outer, &mut bit, common.checked_sub(14)?)? as usize;
+    let nominal = span.checked_mul(2)?.checked_add(bias)?;
+    for second in [Some(nominal), nominal.checked_sub(1)]
+        .into_iter()
+        .flatten()
+    {
+        if !valid_header(payload, second, 4) {
+            continue;
+        }
+        let window = payload.get(second.checked_sub(24)?..second)?;
+        let suffix = window.windows(6).rposition(|bytes| bytes == INNER_SUFFIX)?;
+        let inner = window.get(suffix + 6..)?;
+        if (8..=9).contains(&inner.len()) && unique_geometry(inner, inner_start, 26).is_some() {
+            return Some((profile, control_start + control_size, second));
+        }
+    }
+    None
+}
+
+fn alternate_payload(exss: &[u8]) -> Option<&[u8]> {
+    let start = exss.windows(4).position(|bytes| {
+        matches!(
+            bytes,
+            [0xf1, 0x40, 0x00, 0xd0] | [0xf1, 0x40, 0x00, 0xd1] | [0xf1, 0x40, 0x00, 0xd3]
+        )
+    })?;
+    exss.get(start..)
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("input.dts");
+    let max_frames = args
+        .next()
+        .map(|value| value.parse::<u64>().expect("max-frames"))
+        .unwrap_or(20_000);
+    let input = std::fs::File::open(path).expect("open input");
+    let mut reader = BufReader::with_capacity(1024 * 1024, input);
+    let mut decoder = HdDecoder::new();
+    let mut core = Vec::new();
+    let mut exss = Vec::new();
+    let mut header = [0u8; HEADER_BYTES];
+    let mut patterns = BTreeMap::<(u8, usize, u32, usize, u32), u64>::new();
+    let mut header_layouts = BTreeMap::<(usize, usize, usize), u64>::new();
+    let mut outer_controls = BTreeMap::<Vec<u8>, u64>::new();
+    let mut inner_controls = BTreeMap::<Vec<u8>, u64>::new();
+    let mut trailers = BTreeMap::<Vec<u8>, u64>::new();
+    let mut prefixes = BTreeSet::new();
+    let mut frames = 0u64;
+    while frames < max_frames {
+        match reader.read_exact(&mut header) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof => break,
+            Err(error) => panic!("read core: {error}"),
+        }
+        let info = parse_header(&header).expect("parse core");
+        core.resize(info.frame_size, 0);
+        core[..HEADER_BYTES].copy_from_slice(&header);
+        reader.read_exact(&mut core[HEADER_BYTES..]).unwrap();
+        exss.resize(EXSS_PREFIX_BYTES, 0);
+        reader.read_exact(&mut exss).unwrap();
+        let size = exss_size(&exss).unwrap();
+        exss.resize(size, 0);
+        reader.read_exact(&mut exss[EXSS_PREFIX_BYTES..]).unwrap();
+        match decoder.decode(&core, &exss) {
+            Ok(frame) => {
+                let payload = if frame.x_imax {
+                    frame.x_payload.as_slice()
+                } else if let Some(payload) = alternate_payload(&exss) {
+                    payload
+                } else {
+                    continue;
+                };
+                let Some((profile, first, second)) = layout(payload) else {
+                    let candidates = (0..payload.len().min(256))
+                        .filter_map(|offset| {
+                            (1..=8)
+                                .find(|&channels| valid_header(payload, offset, channels))
+                                .map(|channels| (offset, channels))
+                        })
+                        .collect::<Vec<_>>();
+                    panic!(
+                        "alternate layout; sync={:02x?} payload={} header candidates={candidates:?}",
+                        &payload[..4],
+                        payload.len()
+                    );
+                };
+                let (first_channels, first_bits) = mapping_bits(payload, first).unwrap();
+                let (second_channels, second_bits) = mapping_bits(payload, second).unwrap();
+                *patterns
+                    .entry((
+                        profile,
+                        first_channels,
+                        first_bits,
+                        second_channels,
+                        second_bits,
+                    ))
+                    .or_default() += 1;
+                let first_size = header_size(payload, first).expect("first header size");
+                let second_size = header_size(payload, second).expect("second header size");
+                *header_layouts
+                    .entry((first_size, second - first, second_size))
+                    .or_default() += 1;
+                let prefix_end = payload
+                    .windows(OUTER_SUFFIX.len())
+                    .position(|bytes| bytes == OUTER_SUFFIX)
+                    .expect("outer suffix");
+                *outer_controls
+                    .entry(payload[prefix_end + OUTER_SUFFIX.len()..first].to_vec())
+                    .or_default() += 1;
+                let inner_window = &payload[second.saturating_sub(24)..second];
+                let inner_suffix = inner_window
+                    .windows(INNER_SUFFIX.len())
+                    .rposition(|bytes| bytes == INNER_SUFFIX)
+                    .expect("inner suffix");
+                *inner_controls
+                    .entry(inner_window[inner_suffix + INNER_SUFFIX.len()..].to_vec())
+                    .or_default() += 1;
+                let trailer_start = frame.x_bits_consumed.div_ceil(8);
+                if trailer_start != 0 && trailer_start <= payload.len() {
+                    *trailers
+                        .entry(payload[trailer_start..].to_vec())
+                        .or_default() += 1;
+                }
+                prefixes.insert(payload[..prefix_end].to_vec());
+                frames += 1;
+            }
+            Err(HdError::Pending) => {}
+            Err(error) => panic!("decode: {error:?}"),
+        }
+    }
+    println!(
+        "frames={frames} patterns={patterns:?} prefixes={}",
+        prefixes.len(),
+    );
+    let mut header_layouts = header_layouts.into_iter().collect::<Vec<_>>();
+    header_layouts.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+    println!("unique_header_layouts={}", header_layouts.len());
+    for (layout, count) in header_layouts.into_iter().take(20) {
+        println!("header_layout count={count} value={layout:?}");
+    }
+    println!(
+        "outer_controls={} inner_controls={}",
+        outer_controls.len(),
+        inner_controls.len()
+    );
+    let mut outer_controls = outer_controls.into_iter().collect::<Vec<_>>();
+    outer_controls.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+    for (control, count) in outer_controls.into_iter().take(20) {
+        println!("outer count={count} hex={}", hex(&control));
+    }
+    let mut inner_controls = inner_controls.into_iter().collect::<Vec<_>>();
+    inner_controls.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+    for (control, count) in inner_controls.into_iter().take(20) {
+        println!("inner count={count} hex={}", hex(&control));
+    }
+    for prefix in prefixes {
+        println!(
+            "prefix={}",
+            prefix
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
+        );
+    }
+    let mut trailer_counts: Vec<_> = trailers.into_iter().collect();
+    trailer_counts.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+    println!("unique_trailers={}", trailer_counts.len());
+    for (trailer, count) in trailer_counts.into_iter().take(20) {
+        println!(
+            "trailer count={count} len={} hex={}",
+            trailer.len(),
+            trailer
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>()
+        );
+    }
+}

--- a/dca/examples/xll_alt_nav.rs
+++ b/dca/examples/xll_alt_nav.rs
@@ -1,0 +1,1224 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Analyze the compact navigation word preceding the two bare XLL channel sets
+// in the alternate end-of-frame extension profile.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_alt_nav -- <in.dts> [max_mb]
+
+// This is an offline diagnostic. It deliberately discovers the channel-set
+// boundaries by CRC rather than adding a per-frame scan to the realtime path.
+
+use std::collections::{BTreeSet, HashMap};
+use std::io::Read;
+
+use dca::parser::parse_header;
+use dca::{exss_substream_size, HdDecoder};
+
+const ALT_SYNC_D0: [u8; 4] = 0xf140_00d0u32.to_be_bytes();
+const ALT_SYNC_D1: [u8; 4] = 0xf140_00d1u32.to_be_bytes();
+const INNER_SUFFIX: [u8; 6] = [0x02, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct Candidate {
+    byte_offset: usize,
+    header_size: usize,
+    channels: usize,
+    pcm_resolution: usize,
+    storage_resolution: usize,
+    residual_mask: u32,
+}
+
+#[derive(Clone, Debug)]
+struct Observation {
+    frame: usize,
+    payload_size: usize,
+    payload: Vec<u8>,
+    prefix: Vec<u8>,
+    navigation: Vec<u8>,
+    first: Candidate,
+    second: Candidate,
+    first_header: Vec<u8>,
+    second_header: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum TerminalNaviOrder {
+    ChannelSetMajor,
+    SegmentMajor,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct TerminalNaviLayout {
+    segments: usize,
+    size_bits: usize,
+    trailer_bytes: usize,
+    order: TerminalNaviOrder,
+    first_gap: isize,
+    second_gap: isize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct CommonParameters {
+    segments: usize,
+    segment_samples: usize,
+    segment_size_bits: usize,
+    band_crc_mode: u32,
+    scalable_lsbs: bool,
+    channel_mask_bits: usize,
+    fixed_lsb_width: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum HeaderSyntax {
+    StandardUnmapped,
+    StandardOneToOne,
+    AlternatePrefix(usize),
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct HeaderConfig {
+    syntax: HeaderSyntax,
+    channel_mask_bits: usize,
+    channel_mask: Option<u32>,
+    positions: Vec<(u16, u16, u8)>,
+    segment_size_bits: usize,
+    scalable_lsbs: bool,
+    band_crc_mode: u32,
+    lsb_section_size: usize,
+    predictor_orders: Vec<u32>,
+    tail_bits: usize,
+}
+
+#[derive(Clone, Copy)]
+enum Target {
+    PayloadSize,
+    SecondOffset,
+    FirstSpan,
+    FirstBody,
+    SecondSpan,
+    SecondBody,
+}
+
+impl Target {
+    const ALL: [Self; 6] = [
+        Self::PayloadSize,
+        Self::SecondOffset,
+        Self::FirstSpan,
+        Self::FirstBody,
+        Self::SecondSpan,
+        Self::SecondBody,
+    ];
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::PayloadSize => "payload_size",
+            Self::SecondOffset => "second_offset",
+            Self::FirstSpan => "first_span",
+            Self::FirstBody => "first_body",
+            Self::SecondSpan => "second_span",
+            Self::SecondBody => "second_body",
+        }
+    }
+
+    fn value(self, observation: &Observation) -> usize {
+        match self {
+            Self::PayloadSize => observation.payload_size,
+            Self::SecondOffset => observation.second.byte_offset,
+            Self::FirstSpan => observation.second.byte_offset - observation.first.byte_offset,
+            Self::FirstBody => {
+                observation.second.byte_offset
+                    - observation.first.byte_offset
+                    - observation.first.header_size
+            }
+            Self::SecondSpan => observation.payload_size - observation.second.byte_offset,
+            Self::SecondBody => {
+                observation.payload_size
+                    - observation.second.byte_offset
+                    - observation.second.header_size
+            }
+        }
+    }
+}
+
+fn read_bits(data: &[u8], bit_offset: usize, width: usize) -> Option<u32> {
+    if width > 32 || bit_offset.checked_add(width)? > data.len() * 8 {
+        return None;
+    }
+    let mut value = 0u32;
+    for bit in bit_offset..bit_offset + width {
+        value = (value << 1) | ((data[bit / 8] >> (7 - bit % 8)) & 1) as u32;
+    }
+    Some(value)
+}
+
+fn take_bits(data: &[u8], bit: &mut usize, width: usize) -> Option<u32> {
+    let value = read_bits(data, *bit, width)?;
+    *bit = bit.checked_add(width)?;
+    Some(value)
+}
+
+fn ceil_log2(value: usize) -> usize {
+    if value <= 1 {
+        0
+    } else {
+        (usize::BITS - (value - 1).leading_zeros()) as usize
+    }
+}
+
+fn parse_header_config(
+    header: &[u8],
+    payload_size: usize,
+    syntax: HeaderSyntax,
+    channel_mask_bits: usize,
+    segment_size_bits: usize,
+    scalable_lsbs: bool,
+    band_crc_mode: u32,
+) -> Option<HeaderConfig> {
+    let mut bit = 0usize;
+    let header_size = take_bits(header, &mut bit, 10)? as usize + 1;
+    let channels = take_bits(header, &mut bit, 4)? as usize + 1;
+    if header_size != header.len() || channels > 16 {
+        return None;
+    }
+    take_bits(header, &mut bit, channels)?;
+    let pcm_resolution = take_bits(header, &mut bit, 5)? as usize + 1;
+    let storage_resolution = take_bits(header, &mut bit, 5)? as usize + 1;
+    let frequency_index = take_bits(header, &mut bit, 4)?;
+    let frequency_modifier = take_bits(header, &mut bit, 2)?;
+    let replacement_set = take_bits(header, &mut bit, 2)?;
+    if pcm_resolution > storage_resolution
+        || !matches!(storage_resolution, 16 | 20 | 24)
+        || frequency_index != 12
+        || frequency_modifier != 0
+        || replacement_set != 0
+    {
+        return None;
+    }
+
+    let mut channel_mask = None;
+    let mut positions = Vec::new();
+    if syntax == HeaderSyntax::StandardOneToOne {
+        take_bits(header, &mut bit, 1)?; // primary channel set
+        let downmix_coefficients = take_bits(header, &mut bit, 1)? != 0;
+        if downmix_coefficients {
+            // The coefficient count depends on hierarchy state. Keep this
+            // first probe strict rather than guessing through that syntax.
+            return None;
+        }
+        take_bits(header, &mut bit, 1)?; // hierarchical channel set
+        let mask_enabled = take_bits(header, &mut bit, 1)? != 0;
+        if mask_enabled {
+            channel_mask = Some(take_bits(header, &mut bit, channel_mask_bits)?);
+            if channel_mask?.count_ones() as usize != channels {
+                return None;
+            }
+        } else {
+            for _ in 0..channels {
+                positions.push((
+                    take_bits(header, &mut bit, 9)? as u16,
+                    take_bits(header, &mut bit, 9)? as u16,
+                    take_bits(header, &mut bit, 7)? as u8,
+                ));
+            }
+        }
+    } else if syntax == HeaderSyntax::StandardUnmapped && take_bits(header, &mut bit, 1)? != 0 {
+        let coefficient_bits = 6 + 2 * take_bits(header, &mut bit, 3)? as usize;
+        let speaker_configurations = take_bits(header, &mut bit, 2)? as usize + 1;
+        for _ in 0..speaker_configurations {
+            let active_channels = take_bits(header, &mut bit, channels)?;
+            let speakers = take_bits(header, &mut bit, 6)? as usize + 1;
+            let mask_enabled = take_bits(header, &mut bit, 1)? != 0;
+            if mask_enabled {
+                take_bits(header, &mut bit, channel_mask_bits)?;
+            }
+            for _ in 0..speakers {
+                if !mask_enabled {
+                    take_bits(header, &mut bit, 9)?;
+                    take_bits(header, &mut bit, 9)?;
+                    take_bits(header, &mut bit, 7)?;
+                }
+                for channel in 0..channels {
+                    if active_channels & (1 << channel) != 0 {
+                        take_bits(header, &mut bit, coefficient_bits)?;
+                    }
+                }
+            }
+        }
+    } else if let HeaderSyntax::AlternatePrefix(prefix_bits) = syntax {
+        take_bits(header, &mut bit, prefix_bits)?;
+    }
+
+    let decorrelated = take_bits(header, &mut bit, 1)? != 0;
+    if decorrelated && channels > 1 {
+        let order_bits = ceil_log2(channels);
+        let mut order_mask = 0u32;
+        for _ in 0..channels {
+            let order = take_bits(header, &mut bit, order_bits)? as usize;
+            if order >= channels || order_mask & (1 << order) != 0 {
+                return None;
+            }
+            order_mask |= 1 << order;
+        }
+        for _ in 0..channels / 2 {
+            if take_bits(header, &mut bit, 1)? != 0 {
+                take_bits(header, &mut bit, 7)?;
+            }
+        }
+    }
+
+    let mut predictor_orders = Vec::with_capacity(channels);
+    for _ in 0..channels {
+        predictor_orders.push(take_bits(header, &mut bit, 4)?);
+    }
+    for &order in &predictor_orders {
+        if order == 0 {
+            take_bits(header, &mut bit, 2)?;
+        }
+    }
+    for &order in &predictor_orders {
+        for _ in 0..order {
+            if take_bits(header, &mut bit, 8)? == 0xff {
+                return None;
+            }
+        }
+    }
+
+    let mut lsb_section_size = 0usize;
+    if scalable_lsbs {
+        lsb_section_size = take_bits(header, &mut bit, segment_size_bits)? as usize;
+        if lsb_section_size > payload_size {
+            return None;
+        }
+        if lsb_section_size != 0 && band_crc_mode > 1 {
+            lsb_section_size += 2;
+        }
+        for _ in 0..channels {
+            let width = take_bits(header, &mut bit, 4)?;
+            if width != 0 && lsb_section_size == 0 {
+                return None;
+            }
+        }
+        for _ in 0..channels {
+            take_bits(header, &mut bit, 4)?;
+        }
+    }
+
+    let header_bits = header.len() * 8;
+    if bit > header_bits {
+        return None;
+    }
+    let tail_bits = header_bits - bit;
+    if tail_bits < 16 {
+        return None;
+    }
+    Some(HeaderConfig {
+        syntax,
+        channel_mask_bits: if channel_mask.is_some() {
+            channel_mask_bits
+        } else {
+            0
+        },
+        channel_mask,
+        positions,
+        segment_size_bits,
+        scalable_lsbs,
+        band_crc_mode,
+        lsb_section_size,
+        predictor_orders,
+        tail_bits,
+    })
+}
+
+fn header_config_candidates(header: &[u8], payload_size: usize) -> Vec<HeaderConfig> {
+    let mut candidates = BTreeSet::new();
+    let syntaxes = [
+        HeaderSyntax::StandardUnmapped,
+        HeaderSyntax::StandardOneToOne,
+    ]
+    .into_iter()
+    .chain((0usize..=24).map(HeaderSyntax::AlternatePrefix));
+    for syntax in syntaxes {
+        for channel_mask_bits in 1usize..=32 {
+            for segment_size_bits in 4usize..=20 {
+                for scalable_lsbs in [false, true] {
+                    for band_crc_mode in 0u32..=3 {
+                        if let Some(candidate) = parse_header_config(
+                            header,
+                            payload_size,
+                            syntax,
+                            channel_mask_bits,
+                            segment_size_bits,
+                            scalable_lsbs,
+                            band_crc_mode,
+                        ) {
+                            candidates.insert(candidate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    candidates.into_iter().collect()
+}
+
+fn candidate_at(data: &[u8], byte_offset: usize) -> Option<Candidate> {
+    let mut bit = byte_offset * 8;
+    let header_size = read_bits(data, bit, 10)? as usize + 1;
+    bit += 10;
+    let channels = read_bits(data, bit, 4)? as usize + 1;
+    bit += 4;
+    if channels > 16 {
+        return None;
+    }
+    let residual_mask = read_bits(data, bit, channels)?;
+    bit += channels;
+    let pcm_resolution = read_bits(data, bit, 5)? as usize + 1;
+    bit += 5;
+    let storage_resolution = read_bits(data, bit, 5)? as usize + 1;
+    bit += 5;
+    let frequency_index = read_bits(data, bit, 4)?;
+    bit += 4;
+    let frequency_modifier = read_bits(data, bit, 2)?;
+    bit += 2;
+    let replacement_set = read_bits(data, bit, 2)?;
+
+    let end = byte_offset.checked_add(header_size)?;
+    if end > data.len()
+        || !matches!(storage_resolution, 16 | 20 | 24)
+        || pcm_resolution > storage_resolution
+        || frequency_index != 12
+        || frequency_modifier != 0
+        || replacement_set != 0
+    {
+        return None;
+    }
+
+    Some(Candidate {
+        byte_offset,
+        header_size,
+        channels,
+        pcm_resolution,
+        storage_resolution,
+        residual_mask,
+    })
+}
+
+fn crc16_ccitt(data: &[u8]) -> u16 {
+    let mut crc = 0xffffu16;
+    for &byte in data {
+        crc ^= (byte as u16) << 8;
+        for _ in 0..8 {
+            crc = if crc & 0x8000 != 0 {
+                (crc << 1) ^ 0x1021
+            } else {
+                crc << 1
+            };
+        }
+    }
+    crc
+}
+
+fn crc_candidates(payload: &[u8]) -> Vec<Candidate> {
+    let mut candidates = Vec::new();
+    for byte_offset in 0..payload.len() {
+        let Some(candidate) = candidate_at(payload, byte_offset) else {
+            continue;
+        };
+        let end = byte_offset + candidate.header_size;
+        if crc16_ccitt(&payload[byte_offset..end]) == 0 {
+            candidates.push(candidate);
+        }
+    }
+    candidates
+}
+
+fn crc_subranges(data: &[u8]) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    for start in 0..data.len() {
+        for end in start + 3..=data.len() {
+            if crc16_ccitt(&data[start..end]) == 0 {
+                ranges.push((start, end));
+            }
+        }
+    }
+    ranges
+}
+
+fn fixed_prefix_size(payload: &[u8]) -> Option<usize> {
+    match payload.get(..4)? {
+        sync if sync == ALT_SYNC_D0 => Some(54),
+        sync if sync == ALT_SYNC_D1 => Some(55),
+        _ => None,
+    }
+}
+
+fn terminal_navi_layouts(observation: &Observation) -> Vec<TerminalNaviLayout> {
+    let mut layouts = Vec::new();
+    for segments in [1usize, 2, 4, 8] {
+        for size_bits in 4usize..=20 {
+            let Some(navi_payload_bits) = (segments * 2).checked_mul(size_bits) else {
+                continue;
+            };
+            let navi_size = navi_payload_bits.div_ceil(8) + 2;
+            for trailer_bytes in 0usize..=16 {
+                let Some(navi_end) = observation.payload.len().checked_sub(trailer_bytes) else {
+                    continue;
+                };
+                let Some(navi_start) = navi_end.checked_sub(navi_size) else {
+                    continue;
+                };
+                if crc16_ccitt(&observation.payload[navi_start..navi_end]) != 0 {
+                    continue;
+                }
+                let mut entries = Vec::with_capacity(segments * 2);
+                for entry in 0..segments * 2 {
+                    let Some(size) = read_bits(
+                        &observation.payload,
+                        navi_start * 8 + entry * size_bits,
+                        size_bits,
+                    ) else {
+                        entries.clear();
+                        break;
+                    };
+                    entries.push(size as usize + 1);
+                }
+                if entries.len() != segments * 2 {
+                    continue;
+                }
+                for order in [
+                    TerminalNaviOrder::ChannelSetMajor,
+                    TerminalNaviOrder::SegmentMajor,
+                ] {
+                    let (first_bytes, second_bytes) = match order {
+                        TerminalNaviOrder::ChannelSetMajor => (
+                            entries[..segments].iter().sum::<usize>(),
+                            entries[segments..].iter().sum::<usize>(),
+                        ),
+                        TerminalNaviOrder::SegmentMajor => (
+                            entries.iter().step_by(2).sum::<usize>(),
+                            entries.iter().skip(1).step_by(2).sum::<usize>(),
+                        ),
+                    };
+                    let first_end =
+                        observation.first.byte_offset + observation.first.header_size + first_bytes;
+                    let second_end = observation.second.byte_offset
+                        + observation.second.header_size
+                        + second_bytes;
+                    layouts.push(TerminalNaviLayout {
+                        segments,
+                        size_bits,
+                        trailer_bytes,
+                        order,
+                        first_gap: observation.second.byte_offset as isize - first_end as isize,
+                        second_gap: navi_start as isize - second_end as isize,
+                    });
+                }
+            }
+        }
+    }
+    layouts
+}
+
+fn common_parameters_at(control: &[u8], bit_offset: usize) -> Option<CommonParameters> {
+    let segments = 1usize.checked_shl(read_bits(control, bit_offset, 4)?)?;
+    let segment_samples = 1usize.checked_shl(read_bits(control, bit_offset + 4, 4)?)?;
+    let segment_size_bits = read_bits(control, bit_offset + 8, 5)? as usize + 1;
+    let band_crc_mode = read_bits(control, bit_offset + 13, 2)?;
+    let scalable_lsbs = read_bits(control, bit_offset + 15, 1)? != 0;
+    let channel_mask_bits = read_bits(control, bit_offset + 16, 5)? as usize + 1;
+    let fixed_lsb_width = if scalable_lsbs {
+        read_bits(control, bit_offset + 21, 4)? as usize
+    } else {
+        0
+    };
+    Some(CommonParameters {
+        segments,
+        segment_samples,
+        segment_size_bits,
+        band_crc_mode,
+        scalable_lsbs,
+        channel_mask_bits,
+        fixed_lsb_width,
+    })
+}
+
+fn common_parameters(control: &[u8]) -> Option<CommonParameters> {
+    common_parameters_at(control, 24)
+}
+
+fn geometry_candidates(control: &[u8]) -> Vec<(usize, usize, usize)> {
+    let mut candidates = Vec::new();
+    for bit_offset in 0..=control.len().saturating_mul(8).saturating_sub(13) {
+        let Some(parameters) = common_parameters_at(control, bit_offset) else {
+            continue;
+        };
+        if parameters.segments <= 8
+            && parameters.segments * parameters.segment_samples == 512
+            && (4..=20).contains(&parameters.segment_size_bits)
+        {
+            candidates.push((
+                bit_offset,
+                parameters.segments,
+                parameters.segment_size_bits,
+            ));
+        }
+    }
+    candidates
+}
+
+fn inner_control(observation: &Observation) -> Option<&[u8]> {
+    let start = observation.second.byte_offset.saturating_sub(24);
+    let window = observation
+        .payload
+        .get(start..observation.second.byte_offset)?;
+    let suffix = window
+        .windows(INNER_SUFFIX.len())
+        .rposition(|bytes| bytes == INNER_SUFFIX)?;
+    window.get(suffix + INNER_SUFFIX.len()..)
+}
+
+fn print_control_layouts(group: &[&Observation]) {
+    let mut outer = HashMap::<(Vec<(usize, usize, usize)>, isize), usize>::new();
+    let mut inner = HashMap::<(usize, u8, Vec<(usize, usize, usize)>), usize>::new();
+    let mut missing_inner = 0usize;
+
+    for observation in group {
+        let candidates = geometry_candidates(&observation.navigation);
+        let residual = if let [(bit_offset, _, _)] = candidates.as_slice() {
+            let width = bit_offset.saturating_sub(14);
+            read_bits(&observation.navigation, 9, width)
+                .map(|span| observation.second.byte_offset as isize - span as isize * 2)
+                .unwrap_or(isize::MIN)
+        } else {
+            isize::MIN
+        };
+        *outer.entry((candidates, residual)).or_default() += 1;
+
+        if let Some(control) = inner_control(observation) {
+            *inner
+                .entry((
+                    control.len(),
+                    control.first().copied().unwrap_or_default(),
+                    geometry_candidates(control),
+                ))
+                .or_default() += 1;
+        } else {
+            missing_inner += 1;
+        }
+    }
+
+    let mut outer = outer.into_iter().collect::<Vec<_>>();
+    outer.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "  outer geometry candidates / boundary residual: {:?}",
+        outer.iter().take(12).collect::<Vec<_>>()
+    );
+    let mut inner = inner.into_iter().collect::<Vec<_>>();
+    inner.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "  inner controls (bytes, tag, candidates): {:?}; missing {missing_inner}",
+        inner.iter().take(16).collect::<Vec<_>>()
+    );
+}
+
+fn immediate_navi_geometries(
+    payload: &[u8],
+    header: Candidate,
+    boundary: usize,
+) -> BTreeSet<(usize, usize)> {
+    let mut geometries = BTreeSet::new();
+    let navi_start = header.byte_offset + header.header_size;
+    for segments in [1usize, 2, 4, 8] {
+        for size_bits in 4usize..=20 {
+            let navi_size = (segments * size_bits).div_ceil(8) + 2;
+            let Some(navi_end) = navi_start.checked_add(navi_size) else {
+                continue;
+            };
+            if navi_end > boundary || crc16_ccitt(&payload[navi_start..navi_end]) != 0 {
+                continue;
+            }
+            let mut audio_bytes = 0usize;
+            for segment in 0..segments {
+                let Some(size) =
+                    read_bits(payload, navi_start * 8 + segment * size_bits, size_bits)
+                else {
+                    audio_bytes = usize::MAX;
+                    break;
+                };
+                let Some(next) = audio_bytes.checked_add(size as usize + 1) else {
+                    audio_bytes = usize::MAX;
+                    break;
+                };
+                audio_bytes = next;
+            }
+            let Some(audio_end) = navi_end.checked_add(audio_bytes) else {
+                continue;
+            };
+            if audio_end <= boundary && boundary - audio_end <= 20 {
+                geometries.insert((segments, size_bits));
+            }
+        }
+    }
+    geometries
+}
+
+fn immediate_navi_gap(
+    payload: &[u8],
+    header: Candidate,
+    boundary: usize,
+    parameters: CommonParameters,
+) -> Option<usize> {
+    let navi_start = header.byte_offset.checked_add(header.header_size)?;
+    let navi_size = (parameters.segments * parameters.segment_size_bits).div_ceil(8) + 2;
+    let navi_end = navi_start.checked_add(navi_size)?;
+    if navi_end > boundary || crc16_ccitt(payload.get(navi_start..navi_end)?) != 0 {
+        return None;
+    }
+    let mut audio_bytes = 0usize;
+    for segment in 0..parameters.segments {
+        let size = read_bits(
+            payload,
+            navi_start * 8 + segment * parameters.segment_size_bits,
+            parameters.segment_size_bits,
+        )? as usize
+            + 1;
+        audio_bytes = audio_bytes.checked_add(size)?;
+    }
+    boundary.checked_sub(navi_end.checked_add(audio_bytes)?)
+}
+
+fn print_d1_common_geometry(group: &[&Observation]) {
+    if group.len() < 16 || group[0].navigation.first() != Some(&0xc5) {
+        return;
+    }
+
+    let mut geometries = HashMap::<(CommonParameters, Option<usize>, Option<usize>), usize>::new();
+    let mut first_gaps = HashMap::<Option<usize>, usize>::new();
+    let mut second_gaps = HashMap::<Option<usize>, usize>::new();
+    let mut second_geometry_counts = HashMap::<Vec<(usize, usize)>, usize>::new();
+    let mut second_prefix_geometry_counts = HashMap::<(u32, Vec<(usize, usize)>), usize>::new();
+    let mut unique_second_geometries = Vec::new();
+    let mut rare_second_geometries = Vec::new();
+    let mut second_control_partial_offsets = HashMap::<(u8, usize, usize), usize>::new();
+    let mut gap_examples = HashMap::<(usize, usize), (usize, Vec<u8>)>::new();
+    let mut unusual_first_controls = Vec::new();
+    for observation in group {
+        let Some(parameters) = common_parameters(&observation.navigation) else {
+            continue;
+        };
+        if parameters.segments * parameters.segment_samples != 512 {
+            unusual_first_controls.push((
+                observation.frame,
+                observation.navigation.clone(),
+                observation.second.byte_offset,
+                observation.second.byte_offset as isize
+                    - read_bits(&observation.navigation, 9, 10).unwrap() as isize * 2,
+                immediate_navi_geometries(
+                    &observation.payload,
+                    observation.first,
+                    observation.second.byte_offset,
+                ),
+            ));
+        }
+        let first_gap = immediate_navi_gap(
+            &observation.payload,
+            observation.first,
+            observation.second.byte_offset,
+            parameters,
+        );
+        let second_gap = immediate_navi_gap(
+            &observation.payload,
+            observation.second,
+            observation.payload_size,
+            parameters,
+        );
+        *geometries
+            .entry((parameters, first_gap, second_gap))
+            .or_default() += 1;
+        *first_gaps.entry(first_gap).or_default() += 1;
+        *second_gaps.entry(second_gap).or_default() += 1;
+        let second_geometries = immediate_navi_geometries(
+            &observation.payload,
+            observation.second,
+            observation.payload_size,
+        )
+        .into_iter()
+        .collect::<Vec<_>>();
+        *second_geometry_counts
+            .entry(second_geometries.clone())
+            .or_default() += 1;
+        let second_prefix = read_bits(&observation.second_header, 36, 2).unwrap();
+        *second_prefix_geometry_counts
+            .entry((second_prefix, second_geometries.clone()))
+            .or_default() += 1;
+        if second_geometries.as_slice() != [(2, 10)] && rare_second_geometries.len() < 16 {
+            rare_second_geometries.push((
+                observation.frame,
+                observation.navigation.clone(),
+                parameters,
+                read_bits(&observation.first_header, 36, 2).unwrap(),
+                second_prefix,
+                second_geometries.clone(),
+            ));
+        }
+        if let [geometry] = second_geometries.as_slice() {
+            unique_second_geometries.push((observation, *geometry));
+            if let Some(gap) = first_gap {
+                let gap_bytes = &observation.payload
+                    [observation.second.byte_offset - gap..observation.second.byte_offset];
+                gap_examples
+                    .entry(*geometry)
+                    .or_insert_with(|| (observation.frame, gap_bytes.to_vec()));
+                const SECOND_PREFIX: [u8; 6] = [0x02, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+                if let Some(prefix_offset) = gap_bytes
+                    .windows(SECOND_PREFIX.len())
+                    .rposition(|window| window == SECOND_PREFIX)
+                {
+                    let control = &gap_bytes[prefix_offset + SECOND_PREFIX.len()..];
+                    let expected = (geometry.0.ilog2() << 9)
+                        | ((512 / geometry.0).ilog2() << 5)
+                        | (geometry.1 - 1) as u32;
+                    for bit_offset in 0..=control.len() * 8 - 13 {
+                        if read_bits(control, bit_offset, 13) == Some(expected) {
+                            *second_control_partial_offsets
+                                .entry((control[0], control.len(), bit_offset))
+                                .or_default() += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut geometries = geometries.into_iter().collect::<Vec<_>>();
+    geometries.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!("  D1 common geometry (params, first gap, second gap):");
+    for (geometry, count) in geometries.iter().take(16) {
+        println!("    {count}/{}: {geometry:?}", group.len());
+    }
+    let mut first_gaps = first_gaps.into_iter().collect::<Vec<_>>();
+    let mut second_gaps = second_gaps.into_iter().collect::<Vec<_>>();
+    first_gaps.sort_unstable_by_key(|entry| entry.0);
+    second_gaps.sort_unstable_by_key(|entry| entry.0);
+    println!("  D1 common first-gap distribution: {first_gaps:?}");
+    println!("  D1 common second-gap distribution: {second_gaps:?}");
+
+    let mut second_geometry_counts = second_geometry_counts.into_iter().collect::<Vec<_>>();
+    second_geometry_counts.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "  D1 second structural geometries ({} uniquely identified): {:?}",
+        unique_second_geometries.len(),
+        second_geometry_counts.iter().take(12).collect::<Vec<_>>()
+    );
+    let mut second_prefix_geometry_counts = second_prefix_geometry_counts
+        .into_iter()
+        .collect::<Vec<_>>();
+    second_prefix_geometry_counts.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "  D1 second prefix bits / geometry: {:?}",
+        second_prefix_geometry_counts
+            .iter()
+            .take(16)
+            .collect::<Vec<_>>()
+    );
+    println!("  D1 rare second geometries: {rare_second_geometries:02x?}");
+    println!("  D1 unusual first controls: {unusual_first_controls:02x?}");
+    let mut gap_examples = gap_examples.into_iter().collect::<Vec<_>>();
+    gap_examples.sort_unstable_by_key(|entry| entry.0);
+    println!("  D1 interstitial examples by second geometry: {gap_examples:02x?}");
+    let mut second_control_partial_offsets = second_control_partial_offsets
+        .into_iter()
+        .collect::<Vec<_>>();
+    second_control_partial_offsets.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "  D1 second-control tag/bytes/common-prefix offset: {:?}",
+        second_control_partial_offsets
+            .iter()
+            .take(16)
+            .collect::<Vec<_>>()
+    );
+    let mut boundary_residuals = HashMap::<isize, Vec<(usize, Vec<u8>, usize)>>::new();
+    for observation in group {
+        let field = read_bits(&observation.navigation, 9, 10).unwrap() as isize;
+        let residual = observation.second.byte_offset as isize - field * 2;
+        boundary_residuals.entry(residual).or_default().push((
+            observation.frame,
+            observation.navigation.clone(),
+            observation.second.byte_offset,
+        ));
+    }
+    let mut boundary_residuals = boundary_residuals.into_iter().collect::<Vec<_>>();
+    boundary_residuals.sort_unstable_by(|a, b| b.1.len().cmp(&a.1.len()));
+    println!("  D1 second boundary minus bits 9..19 * 2:");
+    for (residual, frames) in &boundary_residuals {
+        println!(
+            "    {residual:+}: {} frames; first {:?}",
+            frames.len(),
+            frames.first()
+        );
+    }
+}
+
+fn print_common_parameter_offsets(group: &[&Observation]) {
+    if group.len() < 16 {
+        return;
+    }
+    let control_bits = group[0].navigation.len() * 8;
+    let mut matches = Vec::new();
+    for bit_offset in 0..=control_bits.saturating_sub(21) {
+        let mut first_matches = 0usize;
+        let mut second_matches = 0usize;
+        let mut both_matches = 0usize;
+        for observation in group {
+            let Some(parameters) = common_parameters_at(&observation.navigation, bit_offset) else {
+                continue;
+            };
+            if parameters.segments * parameters.segment_samples != 512
+                || parameters.band_crc_mode != 0
+                || parameters.scalable_lsbs
+            {
+                continue;
+            }
+            let first = immediate_navi_geometries(
+                &observation.payload,
+                observation.first,
+                observation.second.byte_offset,
+            )
+            .contains(&(parameters.segments, parameters.segment_size_bits));
+            let second = immediate_navi_geometries(
+                &observation.payload,
+                observation.second,
+                observation.payload_size,
+            )
+            .contains(&(parameters.segments, parameters.segment_size_bits));
+            first_matches += usize::from(first);
+            second_matches += usize::from(second);
+            both_matches += usize::from(first && second);
+        }
+        matches.push((both_matches, first_matches, second_matches, bit_offset));
+    }
+    matches.sort_unstable_by(|a, b| b.cmp(a));
+    println!("  candidate common-parameter offsets (both/first/second immediate):");
+    for &(both, first, second, bit_offset) in matches.iter().take(8) {
+        println!(
+            "    bit {bit_offset:>2}: {both}/{first}/{second} of {} frames",
+            group.len()
+        );
+    }
+}
+
+fn print_field_relations(observations: &[&Observation], navigation_bytes: usize) {
+    if observations.len() < 16 {
+        return;
+    }
+    let navigation_bits = navigation_bytes * 8;
+    let sample = &observations[..observations.len().min(4000)];
+    println!(
+        "field relations for {navigation_bytes}-byte navigation ({} frames):",
+        sample.len()
+    );
+    for target in Target::ALL {
+        let first = target.value(sample[0]);
+        if sample
+            .iter()
+            .all(|observation| target.value(observation) == first)
+        {
+            continue;
+        }
+        let mut matches = Vec::new();
+        for width in 4usize..=20 {
+            if width > navigation_bits {
+                break;
+            }
+            for bit_offset in 0..=navigation_bits - width {
+                for scale in [1isize, 2, 4, 8] {
+                    let mut biases = HashMap::<isize, usize>::new();
+                    for observation in sample {
+                        let field = read_bits(&observation.navigation, bit_offset, width)
+                            .expect("bounded navigation field")
+                            as isize;
+                        let bias = target.value(observation) as isize - field * scale;
+                        *biases.entry(bias).or_default() += 1;
+                    }
+                    let Some((&bias, &count)) = biases.iter().max_by_key(|(_, count)| **count)
+                    else {
+                        continue;
+                    };
+                    if count * 100 >= sample.len() * 50 {
+                        matches.push((count, width, bit_offset, scale, bias));
+                    }
+                }
+            }
+        }
+        matches.sort_unstable_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)).then(a.2.cmp(&b.2)));
+        println!("  {}:", target.name());
+        for &(count, width, bit_offset, scale, bias) in matches.iter().take(8) {
+            println!(
+                "    bits {bit_offset:>2}..{:<2} * {scale} {bias:+} => {count}/{}",
+                bit_offset + width,
+                sample.len()
+            );
+        }
+    }
+}
+
+fn print_stable_header_parameters(observations: &[Observation]) {
+    type StaticConfig = (HeaderSyntax, usize, bool, u32);
+    let mut first_counts = HashMap::<StaticConfig, usize>::new();
+    let mut second_counts = HashMap::<StaticConfig, usize>::new();
+    for observation in observations {
+        for (header, counts) in [
+            (&observation.first_header, &mut first_counts),
+            (&observation.second_header, &mut second_counts),
+        ] {
+            let configs = header_config_candidates(header, observation.payload_size)
+                .into_iter()
+                .map(|config| {
+                    (
+                        config.syntax,
+                        config.segment_size_bits,
+                        config.scalable_lsbs,
+                        config.band_crc_mode,
+                    )
+                })
+                .collect::<BTreeSet<_>>();
+            for config in configs {
+                *counts.entry(config).or_default() += 1;
+            }
+        }
+    }
+    for (name, counts) in [("first", first_counts), ("second", second_counts)] {
+        let mut counts = counts.into_iter().collect::<Vec<_>>();
+        counts.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        println!("stable {name}-header parameter candidates:");
+        for (config, frames) in counts.iter().take(16) {
+            println!("  {frames}/{} frames: {config:?}", observations.len());
+        }
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: xll_alt_nav <in.dts> [max_mb]");
+    let max_mb: usize = args
+        .next()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(64);
+    let quick = args.next().as_deref() == Some("quick");
+
+    let mut input = std::fs::File::open(&path).expect("open input");
+    let mut bytes = vec![0u8; max_mb * 1024 * 1024];
+    let read = input.read(&mut bytes).expect("read input");
+    bytes.truncate(read);
+
+    let mut decoder = HdDecoder::new();
+    let mut observations = Vec::new();
+    let mut offset = 0usize;
+    let mut frame = 0usize;
+    let mut rejected_layouts = 0usize;
+
+    while offset + 18 < bytes.len() {
+        let core = match parse_header(&bytes[offset..]) {
+            Ok(header) => header,
+            Err(_) => break,
+        };
+        let exss_offset = offset + core.frame_size;
+        let exss_len = match bytes
+            .get(exss_offset..)
+            .and_then(exss_substream_size)
+            .filter(|length| exss_offset + length <= bytes.len())
+        {
+            Some(length) => length,
+            None => break,
+        };
+
+        if let Ok(decoded) = decoder.decode(
+            &bytes[offset..exss_offset],
+            &bytes[exss_offset..exss_offset + exss_len],
+        ) {
+            if decoded.x_imax {
+                let payload = &decoded.x_payload;
+                if let Some(prefix_size) = fixed_prefix_size(payload) {
+                    let candidates = crc_candidates(payload);
+                    if let [first, second] = candidates.as_slice() {
+                        if first.byte_offset >= prefix_size {
+                            observations.push(Observation {
+                                frame,
+                                payload_size: payload.len(),
+                                payload: payload.to_vec(),
+                                prefix: payload[..prefix_size].to_vec(),
+                                navigation: payload[prefix_size..first.byte_offset].to_vec(),
+                                first: *first,
+                                second: *second,
+                                first_header: payload
+                                    [first.byte_offset..first.byte_offset + first.header_size]
+                                    .to_vec(),
+                                second_header: payload
+                                    [second.byte_offset..second.byte_offset + second.header_size]
+                                    .to_vec(),
+                            });
+                        } else {
+                            rejected_layouts += 1;
+                        }
+                    } else {
+                        rejected_layouts += 1;
+                    }
+                }
+            }
+            frame += 1;
+        }
+        offset += core.frame_size + exss_len;
+    }
+
+    println!("read {read} bytes from {path}");
+    println!(
+        "accepted observations: {}; rejected layouts: {rejected_layouts}",
+        observations.len()
+    );
+    let mut prefixes = HashMap::<Vec<u8>, usize>::new();
+    for observation in &observations {
+        *prefixes.entry(observation.prefix.clone()).or_default() += 1;
+    }
+    let mut prefixes = prefixes.into_iter().collect::<Vec<_>>();
+    prefixes.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!("fixed prefixes: {}", prefixes.len());
+    for (prefix, frames) in prefixes.iter().take(4) {
+        println!(
+            "  {frames} frames: {prefix:02x?}; CRC-valid subranges: {:?}",
+            crc_subranges(prefix)
+        );
+    }
+    if !quick {
+        let mut parseable_second_headers = 0usize;
+        let mut first_parseable_second_header = None;
+        let mut first_parseable_boundaries = Vec::new();
+        let mut second_header_mask_widths = HashMap::<usize, usize>::new();
+        for observation in &observations {
+            let configs =
+                header_config_candidates(&observation.second_header, observation.payload_size);
+            if !configs.is_empty() {
+                parseable_second_headers += 1;
+                let widths = configs
+                    .iter()
+                    .filter_map(|config| config.channel_mask.map(|_| config.channel_mask_bits))
+                    .collect::<BTreeSet<_>>();
+                for width in widths {
+                    *second_header_mask_widths.entry(width).or_default() += 1;
+                }
+                if first_parseable_boundaries.len() < 8 {
+                    first_parseable_boundaries.push((
+                        observation.frame,
+                        observation.navigation.clone(),
+                        observation.first.byte_offset,
+                        observation.first.header_size,
+                        observation.second.byte_offset,
+                        observation.second.header_size,
+                        observation.payload_size,
+                    ));
+                }
+                if first_parseable_second_header.is_none() {
+                    first_parseable_second_header = Some((
+                        observation.frame,
+                        observation.first_header.clone(),
+                        header_config_candidates(
+                            &observation.first_header,
+                            observation.payload_size,
+                        )
+                        .into_iter()
+                        .next(),
+                        observation.second,
+                        observation.payload_size,
+                        observation.second_header.clone(),
+                        configs.len(),
+                        configs.into_iter().next(),
+                    ));
+                }
+            }
+        }
+        println!(
+            "parseable second headers: {parseable_second_headers}/{}; first: {first_parseable_second_header:02x?}",
+            observations.len()
+        );
+        println!("first parseable boundaries: {first_parseable_boundaries:02x?}");
+        println!("second-header mask widths by frame: {second_header_mask_widths:?}");
+        print_stable_header_parameters(&observations);
+    }
+    let mut terminal_layout_counts = HashMap::<TerminalNaviLayout, usize>::new();
+    let mut terminal_frames = 0usize;
+    for observation in &observations {
+        let layouts = terminal_navi_layouts(observation);
+        if !layouts.is_empty() {
+            terminal_frames += 1;
+        }
+        for layout in layouts {
+            *terminal_layout_counts.entry(layout).or_default() += 1;
+        }
+    }
+    let mut terminal_layout_counts = terminal_layout_counts.into_iter().collect::<Vec<_>>();
+    terminal_layout_counts.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "CRC-valid terminal navigation: {terminal_frames}/{} frames; top structural layouts:",
+        observations.len()
+    );
+    for (layout, frames) in terminal_layout_counts.iter().take(16) {
+        println!("  {frames} frames: {layout:?}");
+    }
+    let mut groups = HashMap::<(usize, u8), Vec<&Observation>>::new();
+    for observation in &observations {
+        groups
+            .entry((
+                observation.navigation.len(),
+                observation.navigation.first().copied().unwrap_or_default(),
+            ))
+            .or_default()
+            .push(observation);
+    }
+    let mut groups = groups.into_iter().collect::<Vec<_>>();
+    groups.sort_unstable_by_key(|&((bytes, tag), _)| (bytes, tag));
+    for ((navigation_bytes, tag), group) in groups {
+        let first = group[0];
+        println!(
+            "navigation bytes {navigation_bytes}, tag {tag:#04x}: {} frames; first frame {}; control {:02x?}; common {:?}; first/second offsets {}/{}; payload {}",
+            group.len(),
+            first.frame,
+            first.navigation,
+            common_parameters(&first.navigation),
+            first.first.byte_offset,
+            first.second.byte_offset,
+            first.payload_size
+        );
+        let mut common_counts = HashMap::<CommonParameters, usize>::new();
+        for observation in &group {
+            if let Some(parameters) = common_parameters(&observation.navigation) {
+                *common_counts.entry(parameters).or_default() += 1;
+            }
+        }
+        let mut common_counts = common_counts.into_iter().collect::<Vec<_>>();
+        common_counts.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+        println!(
+            "  common@bit24 variants: {:?}",
+            common_counts.iter().take(8).collect::<Vec<_>>()
+        );
+        if !quick {
+            let first_configs = header_config_candidates(&first.first_header, first.payload_size);
+            let second_configs = header_config_candidates(&first.second_header, first.payload_size);
+            println!(
+                "  first header {:02x?}: {} configurations; first {:?}",
+                first.first_header,
+                first_configs.len(),
+                first_configs.iter().take(8).collect::<Vec<_>>()
+            );
+            println!(
+                "  second header {:02x?}: {} configurations; first {:?}",
+                first.second_header,
+                second_configs.len(),
+                second_configs.iter().take(8).collect::<Vec<_>>()
+            );
+        }
+        print_control_layouts(&group);
+        print_common_parameter_offsets(&group);
+        print_d1_common_geometry(&group);
+        print_field_relations(&group, navigation_bytes);
+    }
+}

--- a/dca/examples/xll_alt_validate.rs
+++ b/dca/examples/xll_alt_validate.rs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Stream an alternate extension profile through the high-level decoder and
+// report bounded-memory PCM integrity statistics. This diagnostic deliberately
+// does not infer speaker or object semantics.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_alt_validate -- <in.dts>
+
+use std::collections::BTreeMap;
+use std::io::{BufReader, ErrorKind, Read};
+
+use dca::{HdDecoder, HdError, SYNCWORD_SUBSTREAM, parse_header};
+
+const HEADER_BYTES: usize = 18;
+const EXSS_PREFIX_BYTES: usize = 16;
+const READER_CAPACITY: usize = 1024 * 1024;
+
+fn read_bits(data: &[u8], position: &mut usize, width: usize) -> Option<u32> {
+    if width > 32 || position.checked_add(width)? > data.len() * 8 {
+        return None;
+    }
+    let mut value = 0u32;
+    for _ in 0..width {
+        value = (value << 1) | ((data[*position / 8] >> (7 - *position % 8)) & 1) as u32;
+        *position += 1;
+    }
+    Some(value)
+}
+
+fn exss_size_from_prefix(data: &[u8]) -> Option<usize> {
+    let mut position = 0usize;
+    if read_bits(data, &mut position, 32)? != SYNCWORD_SUBSTREAM {
+        return None;
+    }
+    read_bits(data, &mut position, 8)?;
+    read_bits(data, &mut position, 2)?;
+    let wide_header = read_bits(data, &mut position, 1)? as usize;
+    read_bits(data, &mut position, 8 + 4 * wide_header)?;
+    Some(read_bits(data, &mut position, 16 + 4 * wide_header)? as usize + 1)
+}
+
+#[derive(Clone, Copy, Default)]
+struct ChannelStats {
+    samples: u64,
+    frames: u64,
+    silent_frames: u64,
+    clipped_samples: u64,
+    non_finite_samples: u64,
+    sum: f64,
+    square_sum: f64,
+    diff_square_sum: f64,
+    differences: u64,
+    boundary_square_sum: f64,
+    boundaries: u64,
+    peak: f32,
+    max_difference: f32,
+    max_boundary: f32,
+    previous: Option<f32>,
+}
+
+struct ErrorProfile {
+    frames: u64,
+    min_payload: usize,
+    max_payload: usize,
+    first_frame: u64,
+    first_prefix: Vec<u8>,
+    layout_probe: String,
+}
+
+impl ErrorProfile {
+    fn new(frame: u64, payload: &[u8]) -> Self {
+        Self {
+            frames: 0,
+            min_payload: usize::MAX,
+            max_payload: 0,
+            first_frame: frame,
+            first_prefix: payload.iter().take(80).copied().collect(),
+            layout_probe: layout_probe(payload),
+        }
+    }
+
+    fn add(&mut self, payload_size: usize) {
+        self.frames += 1;
+        self.min_payload = self.min_payload.min(payload_size);
+        self.max_payload = self.max_payload.max(payload_size);
+    }
+}
+
+fn geometry_candidates(control: &[u8]) -> Vec<(usize, usize, usize)> {
+    let mut candidates = Vec::new();
+    for offset in 0..=control.len().saturating_mul(8).saturating_sub(13) {
+        let mut position = offset;
+        let Some(segment_log2) = read_bits(control, &mut position, 4) else {
+            continue;
+        };
+        let Some(segment_samples_log2) = read_bits(control, &mut position, 4) else {
+            continue;
+        };
+        let Some(size_bits) = read_bits(control, &mut position, 5) else {
+            continue;
+        };
+        let Some(segments) = 1usize.checked_shl(segment_log2) else {
+            continue;
+        };
+        let Some(segment_samples) = 1usize.checked_shl(segment_samples_log2) else {
+            continue;
+        };
+        let size_bits = size_bits as usize + 1;
+        if segments <= 8
+            && segments.checked_mul(segment_samples) == Some(512)
+            && (4..=20).contains(&size_bits)
+        {
+            candidates.push((offset, segments, size_bits));
+        }
+    }
+    candidates
+}
+
+fn layout_probe(payload: &[u8]) -> String {
+    const INNER_SUFFIX: [u8; 6] = [0x02, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+    let (control_start, offset_bias) = match payload.get(..4) {
+        Some([0xf1, 0x40, 0x00, 0xd0]) => (54, 66),
+        Some([0xf1, 0x40, 0x00, 0xd1]) => (55, 67),
+        _ => return "unknown profile".to_owned(),
+    };
+    let Some(&tag) = payload.get(control_start) else {
+        return "short payload".to_owned();
+    };
+    let control_size = if tag == 0xb2 { 7 } else { 8 };
+    let Some(outer) = payload.get(control_start..control_start + control_size) else {
+        return "short outer control".to_owned();
+    };
+    let outer_candidates = geometry_candidates(outer);
+    let mut inner = Vec::new();
+    for &(common_bit, _, _) in &outer_candidates {
+        let Some(width) = common_bit.checked_sub(14) else {
+            continue;
+        };
+        let mut position = 9;
+        let Some(span) = read_bits(outer, &mut position, width) else {
+            continue;
+        };
+        let Some(nominal) = (span as usize)
+            .checked_mul(2)
+            .and_then(|span| span.checked_add(offset_bias))
+        else {
+            continue;
+        };
+        for second_offset in [Some(nominal), nominal.checked_sub(1)]
+            .into_iter()
+            .flatten()
+        {
+            let start = second_offset.saturating_sub(24);
+            let Some(window) = payload.get(start..second_offset) else {
+                continue;
+            };
+            let Some(suffix) = window
+                .windows(INNER_SUFFIX.len())
+                .rposition(|bytes| bytes == INNER_SUFFIX)
+            else {
+                continue;
+            };
+            let control = &window[suffix + INNER_SUFFIX.len()..];
+            inner.push((
+                second_offset,
+                control.to_vec(),
+                geometry_candidates(control),
+            ));
+        }
+    }
+    format!("outer={outer:02x?} candidates={outer_candidates:?} inner={inner:02x?}")
+}
+
+impl ChannelStats {
+    fn add_frame(&mut self, samples: &[f32]) {
+        self.frames += 1;
+        let mut frame_peak = 0.0f32;
+        for &sample in samples {
+            if !sample.is_finite() {
+                self.non_finite_samples += 1;
+                continue;
+            }
+            let magnitude = sample.abs();
+            frame_peak = frame_peak.max(magnitude);
+            self.peak = self.peak.max(magnitude);
+            self.clipped_samples += u64::from(magnitude >= 1.0);
+            self.sum += sample as f64;
+            self.square_sum += (sample as f64).powi(2);
+            if let Some(previous) = self.previous {
+                let difference = (sample - previous).abs();
+                self.max_difference = self.max_difference.max(difference);
+                self.diff_square_sum += (difference as f64).powi(2);
+                self.differences += 1;
+            }
+            self.previous = Some(sample);
+            self.samples += 1;
+        }
+        self.silent_frames += u64::from(frame_peak == 0.0);
+    }
+
+    fn add_boundary(&mut self, first: f32) {
+        if let Some(previous) = self.previous {
+            let difference = (first - previous).abs();
+            self.max_boundary = self.max_boundary.max(difference);
+            self.boundary_square_sum += (difference as f64).powi(2);
+            self.boundaries += 1;
+        }
+    }
+
+    fn print(&self, channel: usize) {
+        let samples = self.samples.max(1) as f64;
+        let mean = self.sum / samples;
+        let rms = (self.square_sum / samples).sqrt();
+        let diff_rms = (self.diff_square_sum / self.differences.max(1) as f64).sqrt();
+        let boundary_rms = (self.boundary_square_sum / self.boundaries.max(1) as f64).sqrt();
+        println!(
+            "channel {channel}: frames={} samples={} silent_frames={} mean={mean:+.9e} rms={rms:.9e} peak={:.9e} clipped={} non_finite={} diff_rms={diff_rms:.9e} max_diff={:.9e} boundary_rms={boundary_rms:.9e} max_boundary={:.9e}",
+            self.frames,
+            self.samples,
+            self.silent_frames,
+            self.peak,
+            self.clipped_samples,
+            self.non_finite_samples,
+            self.max_difference,
+            self.max_boundary,
+        );
+    }
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: xll_alt_validate <in.dts>");
+    let input = std::fs::File::open(&path).expect("open input");
+    let file_bytes = input.metadata().expect("input metadata").len();
+    let mut reader = BufReader::with_capacity(READER_CAPACITY, input);
+    let mut decoder = HdDecoder::new();
+    let mut core = Vec::new();
+    let mut exss = Vec::new();
+    let mut header = [0u8; HEADER_BYTES];
+    let mut frames = 0u64;
+    let mut decoded_frames = 0u64;
+    let mut pending_frames = 0u64;
+    let mut input_bytes = 0u64;
+    let mut channel_counts = BTreeMap::<usize, u64>::new();
+    let mut pcm_resolutions = BTreeMap::<usize, u64>::new();
+    let mut extension_errors = BTreeMap::<&'static str, u64>::new();
+    let mut error_profiles = BTreeMap::<(&'static str, u8), ErrorProfile>::new();
+    let mut channel_stats = Vec::<ChannelStats>::new();
+
+    loop {
+        match reader.read_exact(&mut header) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof => break,
+            Err(error) => panic!("read core header at frame {frames}: {error}"),
+        }
+        let info = parse_header(&header).expect("parse core header");
+        core.resize(info.frame_size, 0);
+        core[..HEADER_BYTES].copy_from_slice(&header);
+        reader
+            .read_exact(&mut core[HEADER_BYTES..])
+            .expect("read core frame");
+
+        exss.resize(EXSS_PREFIX_BYTES, 0);
+        reader.read_exact(&mut exss).expect("read EXSS size prefix");
+        let exss_size = exss_size_from_prefix(&exss).unwrap_or_else(|| {
+            panic!(
+                "parse EXSS size at frame {frames}: head={:02x?}",
+                &exss[..EXSS_PREFIX_BYTES]
+            )
+        });
+        exss.resize(exss_size, 0);
+        reader
+            .read_exact(&mut exss[EXSS_PREFIX_BYTES..])
+            .expect("read EXSS frame");
+        input_bytes += (core.len() + exss.len()) as u64;
+
+        match decoder.decode(&core, &exss) {
+            Ok(frame) => {
+                if frame.x_imax {
+                    *channel_counts.entry(frame.x_samples.len()).or_default() += 1;
+                    *pcm_resolutions.entry(frame.x_pcm_bit_res).or_default() += 1;
+                    if let Some(error) = frame.x_decode_error {
+                        *extension_errors.entry(error).or_default() += 1;
+                        let tag_offset = match frame.x_payload.get(..4) {
+                            Some([0xf1, 0x40, 0x00, 0xd0]) => 54,
+                            Some([0xf1, 0x40, 0x00, 0xd1]) => 55,
+                            _ => usize::MAX,
+                        };
+                        let tag = frame.x_payload.get(tag_offset).copied().unwrap_or_default();
+                        error_profiles
+                            .entry((error, tag))
+                            .or_insert_with(|| ErrorProfile::new(frames, &frame.x_payload))
+                            .add(frame.x_payload.len());
+                    }
+                    if !frame.x_samples.is_empty() {
+                        decoded_frames += 1;
+                        if channel_stats.len() < frame.x_samples.len() {
+                            channel_stats.resize(frame.x_samples.len(), ChannelStats::default());
+                        }
+                        for (stats, samples) in channel_stats.iter_mut().zip(&frame.x_samples) {
+                            if let Some(&first) = samples.first() {
+                                stats.add_boundary(first);
+                            }
+                            stats.add_frame(samples);
+                        }
+                    }
+                }
+            }
+            Err(HdError::Pending) => pending_frames += 1,
+            Err(error) => panic!("decode frame {frames}: {error:?}"),
+        }
+        frames += 1;
+        if frames.is_multiple_of(100_000) {
+            eprintln!(
+                "{frames} frames, {:.1}% of input",
+                input_bytes as f64 * 100.0 / file_bytes.max(1) as f64
+            );
+        }
+    }
+
+    println!("file: {path}");
+    println!("bytes: {input_bytes}/{file_bytes}");
+    println!("frames: {frames}; pending: {pending_frames}");
+    println!("decoded alternate frames: {decoded_frames}");
+    println!("source counts: {channel_counts:?}");
+    println!("PCM resolutions: {pcm_resolutions:?}");
+    println!("extension errors: {extension_errors:?}");
+    println!("error profiles (kind, control tag):");
+    for ((error, tag), profile) in error_profiles {
+        println!(
+            "  {error}, {tag:#04x}: frames={} payload={}..={} first_frame={} prefix={:02x?} probe={}",
+            profile.frames,
+            profile.min_payload,
+            profile.max_payload,
+            profile.first_frame,
+            profile.first_prefix,
+            profile.layout_probe,
+        );
+    }
+    for (channel, stats) in channel_stats.iter().enumerate() {
+        stats.print(channel);
+    }
+}

--- a/dca/examples/xll_bed_correlation.rs
+++ b/dca/examples/xll_bed_correlation.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Measure sample and frame-RMS correlations between decoded alternate-profile
+// extension sources and the lossless bed. Research tool only; it is not used by
+// the realtime decoder.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_bed_correlation -- <track.dts>
+
+use std::io::Read;
+
+use dca::{HdDecoder, HdError, exss_substream_size, parse_header};
+
+const BED: [(usize, &str); 8] = [
+    (0, "C"),
+    (1, "L"),
+    (2, "R"),
+    (3, "Ls"),
+    (4, "Rs"),
+    (5, "LFE"),
+    (7, "Lb"),
+    (8, "Rb"),
+];
+
+#[derive(Default)]
+struct Correlations {
+    observations: u64,
+    x_sum: Vec<f64>,
+    x_square: Vec<f64>,
+    bed_sum: [f64; BED.len()],
+    bed_square: [f64; BED.len()],
+    cross: Vec<[f64; BED.len()]>,
+}
+
+impl Correlations {
+    fn with_sources(sources: usize) -> Self {
+        Self {
+            x_sum: vec![0.0; sources],
+            x_square: vec![0.0; sources],
+            cross: vec![[0.0; BED.len()]; sources],
+            ..Self::default()
+        }
+    }
+
+    fn add(&mut self, extension: &[Vec<f32>], bed: &[&[f32]]) {
+        let samples = extension[0].len();
+        self.observations += samples as u64;
+        for (source, channel) in extension.iter().enumerate() {
+            for &sample in channel {
+                let sample = sample as f64;
+                self.x_sum[source] += sample;
+                self.x_square[source] += sample * sample;
+            }
+        }
+        for (speaker, channel) in bed.iter().enumerate() {
+            for &sample in *channel {
+                let sample = sample as f64;
+                self.bed_sum[speaker] += sample;
+                self.bed_square[speaker] += sample * sample;
+            }
+        }
+        for (source, extension_channel) in extension.iter().enumerate() {
+            for (speaker, bed_channel) in bed.iter().enumerate() {
+                self.cross[source][speaker] += extension_channel
+                    .iter()
+                    .zip(*bed_channel)
+                    .map(|(&x, &y)| x as f64 * y as f64)
+                    .sum::<f64>();
+            }
+        }
+    }
+
+    fn add_rms(&mut self, extension: &[Vec<f32>], bed: &[&[f32]]) {
+        self.observations += 1;
+        let x_rms = extension
+            .iter()
+            .map(|channel| {
+                (channel
+                    .iter()
+                    .map(|&sample| (sample as f64).powi(2))
+                    .sum::<f64>()
+                    / channel.len() as f64)
+                    .sqrt()
+            })
+            .collect::<Vec<_>>();
+        let bed_rms = bed
+            .iter()
+            .map(|channel| {
+                (channel
+                    .iter()
+                    .map(|&sample| (sample as f64).powi(2))
+                    .sum::<f64>()
+                    / channel.len() as f64)
+                    .sqrt()
+            })
+            .collect::<Vec<_>>();
+        for (source, &value) in x_rms.iter().enumerate() {
+            self.x_sum[source] += value;
+            self.x_square[source] += value * value;
+        }
+        for (speaker, &value) in bed_rms.iter().enumerate() {
+            self.bed_sum[speaker] += value;
+            self.bed_square[speaker] += value * value;
+        }
+        for (source, &x) in x_rms.iter().enumerate() {
+            for (speaker, &y) in bed_rms.iter().enumerate() {
+                self.cross[source][speaker] += x * y;
+            }
+        }
+    }
+
+    fn correlation(&self, source: usize, speaker: usize) -> f64 {
+        let n = self.observations as f64;
+        let covariance =
+            self.cross[source][speaker] - self.x_sum[source] * self.bed_sum[speaker] / n;
+        let x_variance = self.x_square[source] - self.x_sum[source].powi(2) / n;
+        let bed_variance = self.bed_square[speaker] - self.bed_sum[speaker].powi(2) / n;
+        if x_variance <= 0.0 || bed_variance <= 0.0 {
+            f64::NAN
+        } else {
+            covariance / (x_variance * bed_variance).sqrt()
+        }
+    }
+
+    fn print(&self, title: &str) {
+        println!("{title} (n={}):", self.observations);
+        print!("       ");
+        for (_, name) in BED {
+            print!(" {name:>7}");
+        }
+        println!();
+        for source in 0..self.x_sum.len() {
+            print!("  X{source:<2} ");
+            for speaker in 0..BED.len() {
+                print!(" {:>+7.3}", self.correlation(source, speaker));
+            }
+            println!();
+        }
+    }
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: xll_bed_correlation <track.dts>");
+    let mut input = Vec::new();
+    std::fs::File::open(&path)
+        .expect("open input")
+        .read_to_end(&mut input)
+        .expect("read input");
+
+    let mut decoder = HdDecoder::new();
+    let mut sample_correlations = None;
+    let mut rms_correlations = None;
+    let mut offset = 0usize;
+    let mut frames = 0u64;
+    let mut output_mask = None;
+    while offset + 18 <= input.len() {
+        let header = parse_header(&input[offset..]).expect("parse core");
+        let exss_offset = offset.checked_add(header.frame_size).expect("core offset");
+        let exss_size = exss_substream_size(&input[exss_offset..]).expect("parse EXSS");
+        let frame_end = exss_offset.checked_add(exss_size).expect("frame end");
+        let frame =
+            match decoder.decode(&input[offset..exss_offset], &input[exss_offset..frame_end]) {
+                Ok(frame) => frame,
+                Err(HdError::Pending) => {
+                    offset = frame_end;
+                    continue;
+                }
+                Err(error) => panic!("decode frame {frames}: {error:?}"),
+            };
+        if frame.x_samples.is_empty() {
+            offset = frame_end;
+            continue;
+        }
+        output_mask.get_or_insert(frame.output_mask);
+        let samples = frame.x_samples[0].len();
+        if frame
+            .x_samples
+            .iter()
+            .any(|channel| channel.len() != samples)
+        {
+            panic!("inconsistent extension channel lengths at frame {frames}");
+        }
+        let bed = BED.map(|(speaker, _)| {
+            frame
+                .samples
+                .get(speaker)
+                .and_then(Option::as_deref)
+                .expect("missing bed speaker")
+        });
+        if bed.iter().any(|channel| channel.len() != samples) {
+            panic!("inconsistent bed channel lengths at frame {frames}");
+        }
+
+        let sample_stats = sample_correlations
+            .get_or_insert_with(|| Correlations::with_sources(frame.x_samples.len()));
+        let rms_stats = rms_correlations
+            .get_or_insert_with(|| Correlations::with_sources(frame.x_samples.len()));
+        sample_stats.add(&frame.x_samples, &bed);
+        rms_stats.add_rms(&frame.x_samples, &bed);
+        frames += 1;
+        offset = frame_end;
+    }
+
+    println!("file: {path}");
+    println!("decoded frames: {frames}");
+    println!("bed output mask: {:#010x}", output_mask.expect("no bed"));
+    sample_correlations
+        .expect("no extension sources")
+        .print("sample correlation");
+    rms_correlations
+        .expect("no extension sources")
+        .print("frame-RMS correlation");
+}

--- a/dca/examples/xll_corpus_probe.rs
+++ b/dca/examples/xll_corpus_probe.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Classify XLL-X profiles and decoded extension-source activity over an initial
+// bounded portion of one or more raw `[core][EXSS]` elementary streams.
+// Research tool only; it is not used by the realtime decoder.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_corpus_probe -- \
+//     [--max-mb 128] <track.dts> [track.dts ...]
+
+use std::collections::BTreeMap;
+use std::io::Read;
+
+use dca::{HdDecoder, HdError, exss_substream_size, parse_header};
+
+#[derive(Default)]
+struct SourceEnergy {
+    square_sum: f64,
+    samples: u64,
+    nonzero_samples: u64,
+}
+
+fn profile_name(payload: &[u8], standard: bool, alternate: bool) -> &'static str {
+    match payload.get(..4) {
+        Some([0xf1, 0x40, 0x00, 0xd0]) => "D0",
+        Some([0xf1, 0x40, 0x00, 0xd1]) => "D1",
+        Some([0xf1, 0x40, 0x00, 0xd3]) => "D3",
+        _ if standard => "standard",
+        _ if alternate => "alternate-unknown",
+        _ => "none",
+    }
+}
+
+fn probe(path: &str, max_mb: usize) -> Result<(), String> {
+    let mut input = std::fs::File::open(path).map_err(|error| format!("open: {error}"))?;
+    let limit = max_mb
+        .checked_mul(1024 * 1024)
+        .ok_or_else(|| "max-mb overflow".to_string())?;
+    let mut bytes = vec![0u8; limit];
+    let read = input
+        .read(&mut bytes)
+        .map_err(|error| format!("read: {error}"))?;
+    bytes.truncate(read);
+
+    let mut decoder = HdDecoder::new();
+    let mut offset = 0usize;
+    let mut frames = 0u64;
+    let mut decoded = 0u64;
+    let mut pending = 0u64;
+    let mut profiles = BTreeMap::<&'static str, u64>::new();
+    let mut source_counts = BTreeMap::<usize, u64>::new();
+    let mut pcm_resolutions = BTreeMap::<usize, u64>::new();
+    let mut errors = BTreeMap::<&'static str, u64>::new();
+    let mut energy = Vec::<SourceEnergy>::new();
+    let mut sample_rate = 0u32;
+
+    while offset + 18 <= bytes.len() {
+        let header = match parse_header(&bytes[offset..]) {
+            Ok(header) => header,
+            Err(_) => break,
+        };
+        let exss_offset = match offset.checked_add(header.frame_size) {
+            Some(value) => value,
+            None => break,
+        };
+        let Some(exss) = bytes.get(exss_offset..) else {
+            break;
+        };
+        let Some(exss_size) = exss_substream_size(exss) else {
+            break;
+        };
+        let Some(frame_end) = exss_offset.checked_add(exss_size) else {
+            break;
+        };
+        let Some(core) = bytes.get(offset..exss_offset) else {
+            break;
+        };
+        let Some(exss) = bytes.get(exss_offset..frame_end) else {
+            break;
+        };
+
+        match decoder.decode(core, exss) {
+            Ok(frame) => {
+                frames += 1;
+                if frame.x_present || frame.x_imax {
+                    decoded += 1;
+                    *profiles
+                        .entry(profile_name(
+                            &frame.x_payload,
+                            frame.x_present,
+                            frame.x_imax,
+                        ))
+                        .or_default() += 1;
+                    *source_counts.entry(frame.x_samples.len()).or_default() += 1;
+                    *pcm_resolutions.entry(frame.x_pcm_bit_res).or_default() += 1;
+                    if let Some(error) = frame.x_decode_error {
+                        *errors.entry(error).or_default() += 1;
+                    }
+                    sample_rate = frame.sample_rate;
+                    energy.resize_with(frame.x_samples.len(), SourceEnergy::default);
+                    for (stats, channel) in energy.iter_mut().zip(&frame.x_samples) {
+                        for &sample in channel {
+                            let value = sample as f64;
+                            stats.square_sum += value * value;
+                            stats.samples += 1;
+                            stats.nonzero_samples += u64::from(sample != 0.0);
+                        }
+                    }
+                }
+            }
+            Err(HdError::Pending) => pending += 1,
+            Err(error) => return Err(format!("decode at byte {offset}: {error:?}")),
+        }
+        offset = frame_end;
+    }
+
+    let sources = energy
+        .iter()
+        .enumerate()
+        .map(|(index, stats)| {
+            let rms = (stats.square_sum / stats.samples.max(1) as f64).sqrt();
+            let active = 100.0 * stats.nonzero_samples as f64 / stats.samples.max(1) as f64;
+            format!("X{index}={rms:.6}/{active:.1}%")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    println!(
+        "{path}\tread={read}\tframes={frames}\tpending={pending}\text={decoded}\trate={sample_rate}\tprofiles={profiles:?}\tsources={source_counts:?}\tpcm={pcm_resolutions:?}\terrors={errors:?}\tactivity={sources}"
+    );
+    Ok(())
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut max_mb = 128usize;
+    let mut paths = Vec::new();
+    while let Some(argument) = args.next() {
+        if argument == "--max-mb" {
+            max_mb = args
+                .next()
+                .expect("--max-mb requires a value")
+                .parse()
+                .expect("invalid --max-mb value");
+        } else {
+            paths.push(argument);
+        }
+    }
+    if paths.is_empty() {
+        eprintln!("usage: xll_corpus_probe [--max-mb 128] <track.dts> [track.dts ...]");
+        std::process::exit(2);
+    }
+    let mut failed = false;
+    for path in paths {
+        if let Err(error) = probe(&path, max_mb) {
+            eprintln!("{path}: {error}");
+            failed = true;
+        }
+    }
+    if failed {
+        std::process::exit(1);
+    }
+}

--- a/dca/examples/xll_d3_frame_features.rs
+++ b/dca/examples/xll_d3_frame_features.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Export frame-level D3 structural fields for offline correlation studies.
+// Research tool only; it is not used by the realtime decoder.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_d3_frame_features -- <track.dts>
+
+use std::io::{BufReader, ErrorKind, Read};
+
+use dca::{HdDecoder, HdError, SYNCWORD_SUBSTREAM, parse_header};
+
+const HEADER_BYTES: usize = 18;
+const EXSS_PREFIX_BYTES: usize = 16;
+const D3_SYNC: [u8; 4] = [0xf1, 0x40, 0x00, 0xd3];
+const OUTER_SUFFIX: [u8; 6] = [0x03, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+const INNER_SUFFIX: [u8; 6] = [0x02, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn read_bits(data: &[u8], position: &mut usize, width: usize) -> Option<u32> {
+    if width > 32 || position.checked_add(width)? > data.len() * 8 {
+        return None;
+    }
+    let mut value = 0;
+    for _ in 0..width {
+        value = (value << 1) | ((data[*position / 8] >> (7 - *position % 8)) & 1) as u32;
+        *position += 1;
+    }
+    Some(value)
+}
+
+fn exss_size(data: &[u8]) -> Option<usize> {
+    let mut bit = 0;
+    if read_bits(data, &mut bit, 32)? != SYNCWORD_SUBSTREAM {
+        return None;
+    }
+    read_bits(data, &mut bit, 8)?;
+    read_bits(data, &mut bit, 2)?;
+    let wide = read_bits(data, &mut bit, 1)? as usize;
+    read_bits(data, &mut bit, 8 + 4 * wide)?;
+    Some(read_bits(data, &mut bit, 16 + 4 * wide)? as usize + 1)
+}
+
+fn crc16_ccitt(data: &[u8]) -> u16 {
+    let mut crc = 0xffffu16;
+    for &byte in data {
+        crc ^= (byte as u16) << 8;
+        for _ in 0..8 {
+            crc = if crc & 0x8000 != 0 {
+                (crc << 1) ^ 0x1021
+            } else {
+                crc << 1
+            };
+        }
+    }
+    crc
+}
+
+fn valid_header(payload: &[u8], offset: usize, expected_channels: usize) -> bool {
+    let mut bit = offset * 8;
+    let Some(size) = read_bits(payload, &mut bit, 10).map(|value| value as usize + 1) else {
+        return false;
+    };
+    let Some(channels) = read_bits(payload, &mut bit, 4).map(|value| value as usize + 1) else {
+        return false;
+    };
+    let Some(end) = offset.checked_add(size) else {
+        return false;
+    };
+    channels == expected_channels && end <= payload.len() && crc16_ccitt(&payload[offset..end]) == 0
+}
+
+fn header_size(payload: &[u8], offset: usize) -> Option<usize> {
+    let mut bit = offset.checked_mul(8)?;
+    read_bits(payload, &mut bit, 10).map(|size| size as usize + 1)
+}
+
+fn geometry_at(control: &[u8], offset: usize) -> bool {
+    let mut bit = offset;
+    let Some(a) = read_bits(control, &mut bit, 4) else {
+        return false;
+    };
+    let Some(b) = read_bits(control, &mut bit, 4) else {
+        return false;
+    };
+    let Some(c) = read_bits(control, &mut bit, 5) else {
+        return false;
+    };
+    let (Some(segments), Some(samples)) = (1usize.checked_shl(a), 1usize.checked_shl(b)) else {
+        return false;
+    };
+    segments <= 8 && segments * samples == 512 && (3..=19).contains(&(c as usize))
+}
+
+fn unique_geometry(control: &[u8], start: usize, end: usize) -> Option<usize> {
+    let values: Vec<_> = (start..=end)
+        .filter(|&offset| geometry_at(control, offset))
+        .collect();
+    (values.len() == 1).then(|| values[0])
+}
+
+struct Layout<'a> {
+    prefix: &'a [u8],
+    outer: &'a [u8],
+    inner: &'a [u8],
+    first: usize,
+    first_size: usize,
+    second: usize,
+    second_size: usize,
+    outer_geometry: usize,
+    inner_geometry: usize,
+}
+
+fn layout(payload: &[u8]) -> Option<Layout<'_>> {
+    if payload.get(..4)? != D3_SYNC {
+        return None;
+    }
+    let prefix_end = (49..payload.len().min(96)).find(|&offset| {
+        payload.get(offset..offset + OUTER_SUFFIX.len()) == Some(&OUTER_SUFFIX)
+            && crc16_ccitt(&payload[..offset]) == 0
+    })?;
+    let control_start = prefix_end + OUTER_SUFFIX.len();
+    let tag = *payload.get(control_start)?;
+    let control_size = if tag == 0xb2 { 7 } else { 8 };
+    let outer = payload.get(control_start..control_start + control_size)?;
+    let first = control_start + control_size;
+    if !valid_header(payload, first, 4) {
+        return None;
+    }
+    let outer_geometry = unique_geometry(outer, 18, 31)?;
+    let mut bit = 9;
+    let span = read_bits(outer, &mut bit, outer_geometry.checked_sub(14)?)? as usize;
+    let nominal = span.checked_mul(2)?.checked_add(control_start + 12)?;
+    for second in [Some(nominal), nominal.checked_sub(1)]
+        .into_iter()
+        .flatten()
+    {
+        if !valid_header(payload, second, 4) {
+            continue;
+        }
+        let window = payload.get(second.checked_sub(24)?..second)?;
+        let suffix = window.windows(6).rposition(|bytes| bytes == INNER_SUFFIX)?;
+        let inner = window.get(suffix + INNER_SUFFIX.len()..)?;
+        if !(8..=9).contains(&inner.len()) {
+            continue;
+        }
+        let Some(inner_geometry) = unique_geometry(inner, 19, 26) else {
+            continue;
+        };
+        return Some(Layout {
+            prefix: &payload[..prefix_end],
+            outer,
+            inner,
+            first,
+            first_size: header_size(payload, first)?,
+            second,
+            second_size: header_size(payload, second)?,
+            outer_geometry,
+            inner_geometry,
+        });
+    }
+    None
+}
+
+fn alternate_payload(exss: &[u8]) -> Option<&[u8]> {
+    let start = exss.windows(4).position(|bytes| bytes == D3_SYNC)?;
+    exss.get(start..)
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("input.dts");
+    let input = std::fs::File::open(path).expect("open input");
+    let mut reader = BufReader::with_capacity(1024 * 1024, input);
+    let mut decoder = HdDecoder::new();
+    let mut core = Vec::new();
+    let mut exss = Vec::new();
+    let mut header = [0u8; HEADER_BYTES];
+    let mut decoded_index = 0u64;
+
+    println!(
+        "frame\ttime\tpayload_size\tx_payload_offset\tx_payload_size\t\
+         descriptor_bits\tdescriptor_hex\tprefix_len\tprefix_hex\t\
+         outer_len\touter_hex\touter_geometry\tfirst_offset\tfirst_size\t\
+         inner_len\tinner_hex\tinner_geometry\tsecond_offset\tsecond_size\t\
+         consumed_bytes\ttrailer_len"
+    );
+
+    loop {
+        match reader.read_exact(&mut header) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof => break,
+            Err(error) => panic!("read core: {error}"),
+        }
+        let info = parse_header(&header).expect("parse core");
+        core.resize(info.frame_size, 0);
+        core[..HEADER_BYTES].copy_from_slice(&header);
+        reader.read_exact(&mut core[HEADER_BYTES..]).unwrap();
+        exss.resize(EXSS_PREFIX_BYTES, 0);
+        reader.read_exact(&mut exss).unwrap();
+        let size = exss_size(&exss).unwrap();
+        exss.resize(size, 0);
+        reader.read_exact(&mut exss[EXSS_PREFIX_BYTES..]).unwrap();
+
+        match decoder.decode(&core, &exss) {
+            Ok(frame) => {
+                let payload = if frame.x_imax {
+                    frame.x_payload.as_slice()
+                } else if let Some(payload) = alternate_payload(&exss) {
+                    payload
+                } else {
+                    continue;
+                };
+                let Some(layout) = layout(payload) else {
+                    continue;
+                };
+                let consumed_bytes = frame.x_bits_consumed.div_ceil(8);
+                let trailer_len = payload.len().saturating_sub(consumed_bytes);
+                println!(
+                    "{decoded_index}\t{:.9}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    decoded_index as f64 * 512.0 / 48_000.0,
+                    payload.len(),
+                    frame.x_payload_offset,
+                    frame.x_payload.len(),
+                    frame.exss_descriptor_tail_bits,
+                    hex(&frame.exss_descriptor_tail),
+                    layout.prefix.len(),
+                    hex(layout.prefix),
+                    layout.outer.len(),
+                    hex(layout.outer),
+                    layout.outer_geometry,
+                    layout.first,
+                    layout.first_size,
+                    layout.inner.len(),
+                    hex(layout.inner),
+                    layout.inner_geometry,
+                    layout.second,
+                    layout.second_size,
+                    consumed_bytes,
+                    trailer_len,
+                );
+                decoded_index += 1;
+            }
+            Err(HdError::Pending) => {}
+            Err(error) => panic!("decode: {error:?}"),
+        }
+    }
+}

--- a/dca/examples/xll_pcm_range.rs
+++ b/dca/examples/xll_pcm_range.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Extract a time range as interleaved f32le: active bed speakers in ascending
+// DCA index order, followed by the decoded XLL-X extension sources. The tool
+// prints the exact channel order needed by the Python system-identification
+// scripts. Research tool only; it is not used by the realtime decoder.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_pcm_range -- \
+//     <input.dts> <output.f32le> <start-seconds> <end-seconds>
+
+use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
+
+use dca::{HdDecoder, HdError, SYNCWORD_SUBSTREAM, parse_header};
+
+const HEADER_BYTES: usize = 18;
+const EXSS_PREFIX_BYTES: usize = 16;
+
+fn read_bits(data: &[u8], position: &mut usize, width: usize) -> Option<u32> {
+    if width > 32 || position.checked_add(width)? > data.len() * 8 {
+        return None;
+    }
+    let mut value = 0u32;
+    for _ in 0..width {
+        value = (value << 1) | ((data[*position / 8] >> (7 - *position % 8)) & 1) as u32;
+        *position += 1;
+    }
+    Some(value)
+}
+
+fn exss_size(data: &[u8]) -> Option<usize> {
+    let mut bit = 0usize;
+    if read_bits(data, &mut bit, 32)? != SYNCWORD_SUBSTREAM {
+        return None;
+    }
+    read_bits(data, &mut bit, 8)?;
+    read_bits(data, &mut bit, 2)?;
+    let wide = read_bits(data, &mut bit, 1)? as usize;
+    read_bits(data, &mut bit, 8 + 4 * wide)?;
+    Some(read_bits(data, &mut bit, 16 + 4 * wide)? as usize + 1)
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let input_path = args.next().expect("input.dts");
+    let output_path = args.next().expect("output.f32le");
+    let start_seconds: f64 = args
+        .next()
+        .expect("start seconds")
+        .parse()
+        .expect("start number");
+    let end_seconds: f64 = args
+        .next()
+        .expect("end seconds")
+        .parse()
+        .expect("end number");
+    assert!(end_seconds > start_seconds, "end must be after start");
+
+    let input = std::fs::File::open(input_path).expect("open input");
+    let mut reader = BufReader::with_capacity(1024 * 1024, input);
+    let mut output = BufWriter::with_capacity(
+        1024 * 1024,
+        std::fs::File::create(output_path).expect("create output"),
+    );
+    let mut decoder = HdDecoder::new();
+    let mut core = Vec::new();
+    let mut exss = Vec::new();
+    let mut header = [0u8; HEADER_BYTES];
+    let mut sample_position = 0u64;
+    let mut written = 0u64;
+    let mut speakers = None::<Vec<usize>>;
+    let mut extensions = None::<usize>;
+    let mut sample_rate = None::<u32>;
+
+    loop {
+        match reader.read_exact(&mut header) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof => break,
+            Err(error) => panic!("read core header: {error}"),
+        }
+        let info = parse_header(&header).expect("parse core");
+        core.resize(info.frame_size, 0);
+        core[..HEADER_BYTES].copy_from_slice(&header);
+        reader
+            .read_exact(&mut core[HEADER_BYTES..])
+            .expect("read core");
+        exss.resize(EXSS_PREFIX_BYTES, 0);
+        reader.read_exact(&mut exss).expect("read EXSS prefix");
+        let size = exss_size(&exss).expect("parse EXSS size");
+        exss.resize(size, 0);
+        reader
+            .read_exact(&mut exss[EXSS_PREFIX_BYTES..])
+            .expect("read EXSS");
+
+        match decoder.decode(&core, &exss) {
+            Ok(frame) => {
+                let count = frame
+                    .samples
+                    .iter()
+                    .find_map(|channel| channel.as_ref().map(Vec::len))
+                    .unwrap_or(0);
+                let rate = *sample_rate.get_or_insert(frame.sample_rate);
+                let start_sample = (start_seconds * rate as f64) as u64;
+                let end_sample = (end_seconds * rate as f64) as u64;
+                if sample_position + count as u64 > start_sample && sample_position < end_sample {
+                    if !(frame.x_present || frame.x_imax) || frame.x_samples.is_empty() {
+                        panic!("requested range has no decoded XLL-X sources");
+                    }
+                    let active: Vec<_> = frame
+                        .samples
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, channel)| channel.as_ref().map(|_| index))
+                        .collect();
+                    if let Some(expected) = &speakers {
+                        assert_eq!(&active, expected, "bed speaker order changed");
+                    } else {
+                        speakers = Some(active.clone());
+                    }
+                    if let Some(expected) = extensions {
+                        assert_eq!(frame.x_samples.len(), expected, "source count changed");
+                    } else {
+                        extensions = Some(frame.x_samples.len());
+                    }
+                    for sample in 0..count {
+                        let absolute = sample_position + sample as u64;
+                        if absolute < start_sample {
+                            continue;
+                        }
+                        if absolute >= end_sample {
+                            break;
+                        }
+                        for &speaker in &active {
+                            output
+                                .write_all(
+                                    &frame.samples[speaker].as_ref().unwrap()[sample].to_le_bytes(),
+                                )
+                                .expect("write bed");
+                        }
+                        for channel in &frame.x_samples {
+                            output
+                                .write_all(&channel[sample].to_le_bytes())
+                                .expect("write extension");
+                        }
+                        written += 1;
+                    }
+                }
+                sample_position += count as u64;
+                if sample_position >= end_sample {
+                    break;
+                }
+            }
+            Err(HdError::Pending) => {}
+            Err(error) => panic!("decode: {error:?}"),
+        }
+    }
+    output.flush().expect("flush");
+    println!(
+        "rate={} speakers={:?} extensions={} written={} seconds={:.3}",
+        sample_rate.unwrap_or(0),
+        speakers.unwrap_or_default(),
+        extensions.unwrap_or(0),
+        written,
+        written as f64 / sample_rate.unwrap_or(48_000) as f64
+    );
+}

--- a/dca/examples/xll_rms_envelope.rs
+++ b/dca/examples/xll_rms_envelope.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Write one interleaved f32le RMS row per decoded XLL frame: the eight
+// compatible-bed channels followed by every XLL-X extension source. This is a
+// compact research artifact for aligning alternate encodes of the same
+// programme; it is not used by the realtime decoder.
+//
+// Usage:
+//   cargo run -p dca --release --example xll_rms_envelope -- \
+//     <track.dts> <output.f32le>
+
+use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
+
+use dca::{parse_header, HdDecoder, HdError, SYNCWORD_SUBSTREAM};
+
+const HEADER_BYTES: usize = 18;
+const BED: [(usize, &str); 8] = [
+    (0, "C"),
+    (1, "L"),
+    (2, "R"),
+    (3, "Ls"),
+    (4, "Rs"),
+    (5, "LFE"),
+    (7, "Lb"),
+    (8, "Rb"),
+];
+
+fn read_bits(data: &[u8], position: &mut usize, width: usize) -> Option<u32> {
+    if width > 32 || position.checked_add(width)? > data.len() * 8 {
+        return None;
+    }
+    let mut value = 0u32;
+    for _ in 0..width {
+        value = (value << 1) | ((data[*position / 8] >> (7 - *position % 8)) & 1) as u32;
+        *position += 1;
+    }
+    Some(value)
+}
+
+fn exss_size(data: &[u8]) -> Option<usize> {
+    let mut bit = 0usize;
+    if read_bits(data, &mut bit, 32)? != SYNCWORD_SUBSTREAM {
+        return None;
+    }
+    read_bits(data, &mut bit, 8)?;
+    read_bits(data, &mut bit, 2)?;
+    let wide = read_bits(data, &mut bit, 1)? as usize;
+    read_bits(data, &mut bit, 8 + 4 * wide)?;
+    Some(read_bits(data, &mut bit, 16 + 4 * wide)? as usize + 1)
+}
+
+fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let square_sum = samples
+        .iter()
+        .map(|&sample| {
+            let sample = sample as f64;
+            sample * sample
+        })
+        .sum::<f64>();
+    (square_sum / samples.len() as f64).sqrt() as f32
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let input_path = args.next().expect("input.dts");
+    let output_path = args.next().expect("output.f32le");
+
+    let input = std::fs::File::open(&input_path).expect("open input");
+    let mut reader = BufReader::with_capacity(1024 * 1024, input);
+    let output = std::fs::File::create(&output_path).expect("create output");
+    let mut output = BufWriter::with_capacity(1024 * 1024, output);
+    let mut decoder = HdDecoder::new();
+    let mut core = Vec::new();
+    let mut exss = Vec::new();
+    let mut header = [0u8; HEADER_BYTES];
+    let mut extensions = None::<usize>;
+    let mut frame_samples = None::<usize>;
+    let mut sample_rate = None::<u32>;
+    let mut frames = 0u64;
+
+    loop {
+        match reader.read_exact(&mut header) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof => break,
+            Err(error) => panic!("read core header: {error}"),
+        }
+        let info = parse_header(&header).expect("parse core");
+        core.resize(info.frame_size, 0);
+        core[..HEADER_BYTES].copy_from_slice(&header);
+        reader
+            .read_exact(&mut core[HEADER_BYTES..])
+            .expect("read core");
+
+        exss.resize(16, 0);
+        reader.read_exact(&mut exss).expect("read EXSS prefix");
+        let size = exss_size(&exss).expect("parse EXSS size");
+        exss.resize(size, 0);
+        reader
+            .read_exact(&mut exss[16..])
+            .expect("read EXSS payload");
+
+        let frame = match decoder.decode(&core, &exss) {
+            Ok(frame) => frame,
+            Err(HdError::Pending) => continue,
+            Err(error) => panic!("decode frame {frames}: {error:?}"),
+        };
+        if frame.x_samples.is_empty() {
+            continue;
+        }
+        let count = frame.x_samples[0].len();
+        if frame.x_samples.iter().any(|channel| channel.len() != count) {
+            panic!("inconsistent extension channel lengths at frame {frames}");
+        }
+        if let Some(expected) = extensions {
+            assert_eq!(
+                frame.x_samples.len(),
+                expected,
+                "extension count changed at frame {frames}"
+            );
+        } else {
+            extensions = Some(frame.x_samples.len());
+        }
+        if let Some(expected) = frame_samples {
+            assert_eq!(count, expected, "frame size changed at frame {frames}");
+        } else {
+            frame_samples = Some(count);
+        }
+        if let Some(expected) = sample_rate {
+            assert_eq!(
+                frame.sample_rate, expected,
+                "sample rate changed at frame {frames}"
+            );
+        } else {
+            sample_rate = Some(frame.sample_rate);
+        }
+
+        for (speaker, _) in BED {
+            let samples = frame
+                .samples
+                .get(speaker)
+                .and_then(Option::as_deref)
+                .expect("missing bed speaker");
+            assert_eq!(
+                samples.len(),
+                count,
+                "bed frame size changed at frame {frames}"
+            );
+            output
+                .write_all(&rms(samples).to_le_bytes())
+                .expect("write bed RMS");
+        }
+        for channel in &frame.x_samples {
+            output
+                .write_all(&rms(channel).to_le_bytes())
+                .expect("write extension RMS");
+        }
+        frames += 1;
+    }
+    output.flush().expect("flush output");
+
+    println!("file={input_path}");
+    println!("output={output_path}");
+    println!(
+        "sample_rate={} frame_samples={} bed={} extensions={} channels={} frames={frames}",
+        sample_rate.unwrap_or(0),
+        frame_samples.unwrap_or(0),
+        BED.len(),
+        extensions.unwrap_or(0),
+        BED.len() + extensions.unwrap_or(0),
+    );
+    println!(
+        "channel_order={}{}",
+        BED.map(|(_, name)| name).join(","),
+        (0..extensions.unwrap_or(0))
+            .map(|source| format!(",X{source}"))
+            .collect::<String>()
+    );
+}

--- a/dca/examples/xll_x_chs.rs
+++ b/dca/examples/xll_x_chs.rs
@@ -106,6 +106,21 @@ fn main() {
     let mut candidate_frames = 0usize;
     let mut count_matching_frames = 0usize;
     let mut all_offsets: HashMap<usize, usize> = HashMap::new();
+    let mut all_fields: HashMap<(usize, usize, usize, usize, usize, u32), usize> = HashMap::new();
+    let mut all_crc_valid: HashMap<(usize, usize, usize, usize, usize, u32), usize> =
+        HashMap::new();
+    let mut crc_valid_layouts: HashMap<Vec<(usize, usize, usize, usize, usize, u32)>, usize> =
+        HashMap::new();
+    let mut full_crc_sequences: HashMap<Vec<(usize, usize, usize, u32)>, usize> = HashMap::new();
+    let mut full_crc_offsets: HashMap<(usize, usize, usize, u32), (usize, usize, usize)> =
+        HashMap::new();
+    let mut chunk_boundary_deltas: HashMap<(usize, usize, isize), usize> = HashMap::new();
+    let mut chunk_navi_crc_valid: HashMap<(usize, usize), usize> = HashMap::new();
+    let mut chunk_navi_hypotheses: HashMap<(usize, usize, usize, usize, isize), usize> =
+        HashMap::new();
+    let mut first_full_crc_candidates = Vec::new();
+    let mut first_layout_payload_prefixes = Vec::new();
+    let mut last_full_crc_signature = None;
     let mut count_matching_offsets: HashMap<usize, usize> = HashMap::new();
     let mut header_sizes: HashMap<usize, usize> = HashMap::new();
     let mut exact_offset_frames = 0usize;
@@ -206,13 +221,15 @@ fn main() {
                     let header_size =
                         (((payload[22] as usize) << 2) | ((payload[23] as usize) >> 6)) + 1;
                     let data_start = 22 + header_size;
-                    first_layout_bytes = Some((
-                        payload.len(),
-                        header_size,
-                        data_start,
-                        payload[data_start..payload.len().min(data_start + 24)].to_vec(),
-                        payload[payload.len().saturating_sub(24)..].to_vec(),
-                    ));
+                    if data_start <= payload.len() {
+                        first_layout_bytes = Some((
+                            payload.len(),
+                            header_size,
+                            data_start,
+                            payload[data_start..payload.len().min(data_start + 24)].to_vec(),
+                            payload[payload.len().saturating_sub(24)..].to_vec(),
+                        ));
+                    }
                 }
                 if frame.x_samples.len() == 4 {
                     *channel_header_tails
@@ -299,8 +316,26 @@ fn main() {
                     candidate_frames += 1;
                 }
                 let mut count_match = false;
+                let mut crc_valid_layout = Vec::new();
                 for candidate in candidates {
+                    let candidate_fields = (
+                        candidate.bit_offset,
+                        candidate.header_size,
+                        candidate.channels,
+                        candidate.pcm_resolution,
+                        candidate.storage_resolution,
+                        candidate.residual_mask,
+                    );
                     *all_offsets.entry(candidate.bit_offset).or_default() += 1;
+                    *all_fields.entry(candidate_fields).or_default() += 1;
+                    if candidate.bit_offset % 8 == 0 {
+                        let start = candidate.bit_offset / 8;
+                        let end = start + candidate.header_size;
+                        if end <= payload.len() && crc16_ccitt(&payload[start..end]) == 0 {
+                            *all_crc_valid.entry(candidate_fields).or_default() += 1;
+                            crc_valid_layout.push(candidate_fields);
+                        }
+                    }
                     if candidate.bit_offset == SEARCH_START {
                         exact_offset_frames += 1;
                         *exact_basic_fields
@@ -338,6 +373,134 @@ fn main() {
                 }
                 if count_match {
                     count_matching_frames += 1;
+                }
+                if !crc_valid_layout.is_empty() {
+                    crc_valid_layout.sort_unstable();
+                    *crc_valid_layouts.entry(crc_valid_layout).or_default() += 1;
+                }
+                let mut full_crc_candidates = Vec::new();
+                for byte_offset in 0..payload.len() {
+                    let Some(candidate) = candidate_at(payload, byte_offset * 8) else {
+                        continue;
+                    };
+                    let end = byte_offset + candidate.header_size;
+                    if end > payload.len() || crc16_ccitt(&payload[byte_offset..end]) != 0 {
+                        continue;
+                    }
+                    let format = (
+                        candidate.channels,
+                        candidate.pcm_resolution,
+                        candidate.storage_resolution,
+                        candidate.residual_mask,
+                    );
+                    full_crc_candidates.push((
+                        byte_offset,
+                        candidate.header_size,
+                        candidate.channels,
+                        format,
+                    ));
+                    let entry = full_crc_offsets.entry(format).or_insert((0, usize::MAX, 0));
+                    entry.0 += 1;
+                    entry.1 = entry.1.min(byte_offset);
+                    entry.2 = entry.2.max(byte_offset);
+                }
+                let full_crc_sequence = full_crc_candidates
+                    .iter()
+                    .map(|candidate| candidate.3)
+                    .collect::<Vec<_>>();
+                if !full_crc_sequence.is_empty() {
+                    *full_crc_sequences.entry(full_crc_sequence).or_default() += 1;
+                }
+                let full_crc_signature = (payload.len(), full_crc_candidates.clone());
+                if last_full_crc_signature.as_ref() != Some(&full_crc_signature) {
+                    if first_full_crc_candidates.len() < 64 {
+                        first_full_crc_candidates.push((
+                            frames,
+                            payload.len(),
+                            full_crc_candidates.clone(),
+                        ));
+                    }
+                    if first_layout_payload_prefixes.len() < 8 {
+                        first_layout_payload_prefixes.push((
+                            frames,
+                            payload.len(),
+                            payload[..payload.len().min(96)].to_vec(),
+                        ));
+                    }
+                    last_full_crc_signature = Some(full_crc_signature);
+                }
+                if full_crc_candidates.len() == 2 {
+                    for (index, &(byte_offset, header_size, channels, _)) in
+                        full_crc_candidates.iter().enumerate()
+                    {
+                        let navi_start = byte_offset + header_size;
+                        let navi_payload_bits =
+                            frame.xll_frame_segments * frame.xll_segment_size_bits;
+                        let navi_size = navi_payload_bits.div_ceil(8) + 2;
+                        if navi_start + navi_size > payload.len() {
+                            continue;
+                        }
+                        let mut bit = navi_start * 8;
+                        let mut audio_bytes = 0usize;
+                        let mut valid_navi = true;
+                        for _ in 0..frame.xll_frame_segments {
+                            let Some(size) =
+                                read_bits(payload, &mut bit, frame.xll_segment_size_bits)
+                            else {
+                                valid_navi = false;
+                                break;
+                            };
+                            audio_bytes += size as usize + 1;
+                        }
+                        if !valid_navi {
+                            continue;
+                        }
+                        if crc16_ccitt(&payload[navi_start..navi_start + navi_size]) == 0 {
+                            *chunk_navi_crc_valid.entry((index, channels)).or_default() += 1;
+                        }
+                        let predicted_audio_end = navi_start + navi_size + audio_bytes;
+                        let boundary = full_crc_candidates
+                            .get(index + 1)
+                            .map(|candidate| candidate.0)
+                            .unwrap_or(payload.len());
+                        let delta = boundary as isize - predicted_audio_end as isize;
+                        *chunk_boundary_deltas
+                            .entry((index, channels, delta))
+                            .or_default() += 1;
+
+                        for segments in 1usize..=32 {
+                            for size_bits in 4usize..=20 {
+                                let navi_payload_bits = segments * size_bits;
+                                let navi_size = navi_payload_bits.div_ceil(8) + 2;
+                                if navi_start + navi_size > payload.len()
+                                    || crc16_ccitt(&payload[navi_start..navi_start + navi_size])
+                                        != 0
+                                {
+                                    continue;
+                                }
+                                let mut bit = navi_start * 8;
+                                let mut audio_bytes = 0usize;
+                                let mut valid = true;
+                                for _ in 0..segments {
+                                    let Some(size) = read_bits(payload, &mut bit, size_bits) else {
+                                        valid = false;
+                                        break;
+                                    };
+                                    audio_bytes += size as usize + 1;
+                                }
+                                if !valid {
+                                    continue;
+                                }
+                                let predicted_audio_end = navi_start + navi_size + audio_bytes;
+                                let delta = boundary as isize - predicted_audio_end as isize;
+                                if (0..=16).contains(&delta) {
+                                    *chunk_navi_hypotheses
+                                        .entry((index, channels, segments, size_bits, delta))
+                                        .or_default() += 1;
+                                }
+                            }
+                        }
+                    }
                 }
             }
             frames += 1;
@@ -539,6 +702,64 @@ fn main() {
         "top offsets regardless of channel count: {:?}",
         &any_offsets[..any_offsets.len().min(12)]
     );
+    let mut all_fields = all_fields.into_iter().collect::<Vec<_>>();
+    all_fields.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "top candidates as ((bit offset, header bytes, channels, PCM bits, storage bits, residual mask), frames, CRC-valid):"
+    );
+    for (fields, occurrences) in all_fields.into_iter().take(20) {
+        let crc_valid = all_crc_valid.get(&fields).copied().unwrap_or_default();
+        println!("  {fields:?}: {occurrences}, CRC {crc_valid}/{occurrences}");
+    }
+    let mut crc_valid_layouts = crc_valid_layouts.into_iter().collect::<Vec<_>>();
+    crc_valid_layouts.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!("top per-frame CRC-valid candidate layouts:");
+    for (layout, occurrences) in crc_valid_layouts.into_iter().take(20) {
+        println!("  {occurrences}: {layout:?}");
+    }
+    let mut full_crc_sequences = full_crc_sequences.into_iter().collect::<Vec<_>>();
+    full_crc_sequences.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "top full-payload CRC-valid channel sequences (channels, PCM bits, storage bits, residual mask):"
+    );
+    for (sequence, occurrences) in full_crc_sequences.into_iter().take(20) {
+        println!("  {occurrences}: {sequence:?}");
+    }
+    let mut full_crc_offsets = full_crc_offsets.into_iter().collect::<Vec<_>>();
+    full_crc_offsets.sort_unstable_by(|a, b| b.1.0.cmp(&a.1.0));
+    println!("full-payload CRC-valid formats as (format, frames, min/max byte offset):");
+    for (format, (occurrences, min_offset, max_offset)) in full_crc_offsets.into_iter().take(20) {
+        println!("  {format:?}: {occurrences}, {min_offset}..={max_offset}");
+    }
+    let mut chunk_boundary_deltas = chunk_boundary_deltas.into_iter().collect::<Vec<_>>();
+    chunk_boundary_deltas.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!("chunk NAVI landing as ((chunk index, channels, boundary-audio-end bytes), frames):");
+    for (key, occurrences) in chunk_boundary_deltas.into_iter().take(20) {
+        println!("  {key:?}: {occurrences}");
+    }
+    println!(
+        "chunk NAVI CRC-valid frames as ((chunk index, channels), frames): {chunk_navi_crc_valid:?}"
+    );
+    let mut chunk_navi_hypotheses = chunk_navi_hypotheses.into_iter().collect::<Vec<_>>();
+    chunk_navi_hypotheses.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    println!(
+        "top landing NAVI hypotheses as ((chunk index, channels, segments, size bits, trailing bytes), frames):"
+    );
+    for (key, occurrences) in chunk_navi_hypotheses.into_iter().take(100) {
+        println!("  {key:?}: {occurrences}");
+    }
+    println!(
+        "first full-payload CRC-valid candidates as (frame, payload bytes, [(byte offset, header bytes, channels, format)]):"
+    );
+    for entry in first_full_crc_candidates {
+        println!("  {entry:?}");
+    }
+    println!(
+        "first layout-change payload prefixes as (frame, payload bytes, first up-to-96 bytes):"
+    );
+    for entry in first_layout_payload_prefixes {
+        println!("  {entry:02x?}");
+    }
 }
 
 fn pearson(a: &[f64], b: &[f64]) -> f64 {

--- a/dca/scripts/gen_tables.py
+++ b/dca/scripts/gen_tables.py
@@ -15,11 +15,6 @@ import re
 import sys
 from pathlib import Path
 
-DEFAULT_SRC = Path(
-    "/home/user/dev/spatial-renderer/reference-sources/ffmpeg_sources/libavcodec"
-)
-
-
 def strip_comments(text: str) -> str:
     text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
     text = re.sub(r"//[^\n]*", "", text)
@@ -93,7 +88,11 @@ HUFF_TABLES = [
 
 
 def main() -> None:
-    src_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_SRC
+    if len(sys.argv) < 2:
+        raise SystemExit(
+            "usage: gen_tables.py <ffmpeg-libavcodec-directory> [output-path]"
+        )
+    src_dir = Path(sys.argv[1])
     out_path = (
         Path(sys.argv[2])
         if len(sys.argv) > 2

--- a/dca/src/dcadec/exss.rs
+++ b/dca/src/dcadec/exss.rs
@@ -546,19 +546,22 @@ mod tests {
         assert_eq!(parse_xll_x_navigation(&[0; 8]), None);
     }
 
-    // Validate EXSS parsing on the real Ex Machina DTS-HD MA stream (7.1).
+    // Validate EXSS parsing on a real DTS-HD MA 7.1 stream.
     // Skips if the (uncommitted) dump is absent.
     #[test]
     fn parses_real_exss_locates_xll() {
-        const DUMP: &str = "/mnt/local/SSD_A-CT4000/DTS:X-Dumps/Ex.Machina.2014.dtsx.eng.dts";
-        if !std::path::Path::new(DUMP).exists() {
-            eprintln!("skipping: 7.1 dump not present");
+        let Ok(dump) = std::env::var("HARLETTY_DTSX_STANDARD_CORPUS") else {
+            eprintln!("skipping: HARLETTY_DTSX_STANDARD_CORPUS is not set");
+            return;
+        };
+        if !std::path::Path::new(&dump).is_file() {
+            eprintln!("skipping: configured 7.1 corpus is not readable");
             return;
         }
         // The stream is [core][exss][core][exss]…; the EXSS sits immediately
         // after the first core frame (don't naive-scan — 0x64582025 can occur
         // inside core audio data).
-        let bytes = std::fs::read(DUMP).unwrap();
+        let bytes = std::fs::read(dump).unwrap();
         let core = crate::parser::parse_header(&bytes).expect("core header");
         let pos = core.frame_size;
         let sync = 0x6458_2025u32.to_be_bytes();

--- a/dca/src/dcadec/xll.rs
+++ b/dca/src/dcadec/xll.rs
@@ -2,7 +2,7 @@
 //
 // DTS-HD Master Audio lossless (XLL) decoder. Ported from ffmpeg's dca_xll.c.
 // Supports the single-frequency-band path (freq <= 96 kHz, the common BluRay
-// case incl. Ex Machina's 7.1) with residual-coded channels combined against
+// 7.1 case) with residual-coded channels combined against
 // the fixed-point core output. Two frequency bands and embedded hierarchical
 // downmix are not supported (rejected) — they don't occur in 48 kHz 7.1 MA.
 
@@ -10,9 +10,9 @@ use super::core::DCA_SPEAKER_L;
 use super::core::DCA_SPEAKER_LSS;
 use super::core::DCA_SPEAKER_R;
 use super::core::DCA_SPEAKER_RSS;
-use super::exss::{sampling_freq, ExssAsset};
+use super::exss::{ExssAsset, sampling_freq};
 use super::synth::CoreOutput;
-use super::tables::{DMIXTABLE, DMIX_PRIMARY_NCH, INV_DMIXTABLE, XLL_REFL_COEFF};
+use super::tables::{DMIX_PRIMARY_NCH, DMIXTABLE, INV_DMIXTABLE, XLL_REFL_COEFF};
 use crate::bitstream::BitReader;
 
 const DCA_XLL_CHANNELS_MAX: usize = 8;
@@ -20,9 +20,15 @@ const DCA_XLL_CHSETS_MAX: usize = 3;
 const DCA_XLL_PRED_ORDER_MAX: usize = 16;
 /// XLL-X (DTS:X spatial extension) end-of-frame syncword.
 const DCA_SYNCWORD_XLL_X: u32 = 0x0200_0850;
-/// XLL-X IMAX-variant syncword (low bit varies across titles).
-const DCA_SYNCWORD_XLL_X_IMAX: u32 = 0xF140_00D0;
+const DCA_SYNCWORD_XLL_X_ALT_D0: u32 = 0xF140_00D0;
+const DCA_SYNCWORD_XLL_X_ALT_D1: u32 = 0xF140_00D1;
+const DCA_SYNCWORD_XLL_X_ALT_D3: u32 = 0xF140_00D3;
 const DCA_SYNCWORD_XLL: u32 = 0x41A2_9547;
+const XLL_X_ALT_FRAME_SAMPLES: usize = 512;
+const XLL_X_ALT_MAX_SEGMENTS: usize = 8;
+const XLL_X_ALT_MAX_INTERSTITIAL: usize = 20;
+const XLL_X_ALT_OUTER_SUFFIX: [u8; 6] = [0x03, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+const XLL_X_ALT_INNER_SUFFIX: [u8; 6] = [0x02, 0x34, 0x38, 0x8c, 0x4f, 0x00];
 const FF_DCA_DMIXTABLE_OFFSET: usize = 242 - 201; // SIZE - INV_SIZE
 const FF_DCA_DMIXTABLE_SIZE: usize = 242;
 const FF_DCA_INV_DMIXTABLE_SIZE: usize = 201;
@@ -35,6 +41,31 @@ pub(crate) enum XllError {
     Unsupported(&'static str),
 }
 type R<T> = Result<T, XllError>;
+
+#[derive(Clone, Copy)]
+struct AlternateGeometry {
+    segments: usize,
+    navigation_size_bits: usize,
+}
+
+#[derive(Clone, Copy)]
+struct AlternateHeader {
+    offset: usize,
+    size: usize,
+    channels: usize,
+}
+
+#[derive(Clone, Copy)]
+enum AlternateProfile {
+    D0,
+    D1,
+    D3,
+}
+
+struct AlternateLayout {
+    headers: [AlternateHeader; 2],
+    geometries: [AlternateGeometry; 2],
+}
 
 /// Allocation-free kind string for a failed XLL-X decode (the audio path
 /// never formats errors per frame; the bridge logs this rate-limited).
@@ -61,6 +92,234 @@ fn seek(gb: &mut BitReader, pos: usize) -> R<()> {
     } else {
         Err(XllError::Invalid("seek past end"))
     }
+}
+
+fn crc16_ccitt(data: &[u8]) -> u16 {
+    let mut crc = 0xffffu16;
+    for &byte in data {
+        crc ^= (byte as u16) << 8;
+        for _ in 0..8 {
+            crc = if crc & 0x8000 != 0 {
+                (crc << 1) ^ 0x1021
+            } else {
+                crc << 1
+            };
+        }
+    }
+    crc
+}
+
+fn alternate_geometry_at(control: &[u8], bit_offset: usize) -> Option<AlternateGeometry> {
+    let mut bits = BitReader::with_offset(control, bit_offset);
+    let segment_log2 = rb(&mut bits, 4).ok()?;
+    let segment_samples_log2 = rb(&mut bits, 4).ok()?;
+    let navigation_size_bits = rb(&mut bits, 5).ok()? as usize + 1;
+    let segments = 1usize.checked_shl(segment_log2)?;
+    let segment_samples = 1usize.checked_shl(segment_samples_log2)?;
+    if segments <= XLL_X_ALT_MAX_SEGMENTS
+        && segments.checked_mul(segment_samples) == Some(XLL_X_ALT_FRAME_SAMPLES)
+        && (4..=20).contains(&navigation_size_bits)
+    {
+        Some(AlternateGeometry {
+            segments,
+            navigation_size_bits,
+        })
+    } else {
+        None
+    }
+}
+
+fn alternate_unique_geometry(
+    control: &[u8],
+    first_bit: usize,
+    last_bit: usize,
+) -> R<(usize, AlternateGeometry)> {
+    let mut selected = None;
+    for bit_offset in first_bit..=last_bit {
+        if let Some(geometry) = alternate_geometry_at(control, bit_offset) {
+            if selected.is_some() {
+                return Err(XllError::Invalid("ambiguous alternate XLL control"));
+            }
+            selected = Some((bit_offset, geometry));
+        }
+    }
+    selected.ok_or(XllError::Invalid("missing alternate XLL geometry"))
+}
+
+fn alternate_header_at(payload: &[u8], byte_offset: usize) -> Option<AlternateHeader> {
+    let mut bits = BitReader::with_offset(payload, byte_offset.checked_mul(8)?);
+    let header_size = rb(&mut bits, 10).ok()? as usize + 1;
+    let channels = rb(&mut bits, 4).ok()? as usize + 1;
+    if channels > DCA_XLL_CHANNELS_MAX || rb(&mut bits, channels).is_err() {
+        return None;
+    }
+    let pcm_resolution = rb(&mut bits, 5).ok()? as usize + 1;
+    let storage_resolution = rb(&mut bits, 5).ok()? as usize + 1;
+    let frequency_index = rb(&mut bits, 4).ok()?;
+    let frequency_modifier = rb(&mut bits, 2).ok()?;
+    let replacement_set = rb(&mut bits, 2).ok()?;
+    let header_end = byte_offset.checked_add(header_size)?;
+    if header_end > payload.len()
+        || pcm_resolution > storage_resolution
+        || !matches!(storage_resolution, 16 | 20 | 24)
+        || frequency_index != 12
+        || frequency_modifier != 0
+        || replacement_set != 0
+        || crc16_ccitt(payload.get(byte_offset..header_end)?) != 0
+    {
+        return None;
+    }
+    Some(AlternateHeader {
+        offset: byte_offset,
+        size: header_size,
+        channels,
+    })
+}
+
+fn alternate_second_header(
+    payload: &[u8],
+    control: &[u8],
+    common_bit: usize,
+    offset_bias: usize,
+) -> R<AlternateHeader> {
+    let field_width = common_bit
+        .checked_sub(14)
+        .ok_or(XllError::Invalid("alternate XLL size field"))?;
+    let mut bits = BitReader::with_offset(control, 9);
+    let encoded_span = rb(&mut bits, field_width)? as usize;
+    let nominal = encoded_span
+        .checked_mul(2)
+        .and_then(|span| span.checked_add(offset_bias))
+        .ok_or(XllError::Invalid("alternate XLL header offset overflow"))?;
+    let mut selected = None;
+    for offset in [Some(nominal), nominal.checked_sub(1)]
+        .into_iter()
+        .flatten()
+    {
+        let Some(header) = alternate_header_at(payload, offset) else {
+            continue;
+        };
+        if header.channels != 4 {
+            continue;
+        }
+        if selected.is_some() {
+            return Err(XllError::Invalid("ambiguous alternate XLL header"));
+        }
+        selected = Some(header);
+    }
+    selected.ok_or(XllError::Invalid("missing alternate XLL second header"))
+}
+
+fn alternate_inner_control(payload: &[u8], second_header_offset: usize) -> R<&[u8]> {
+    let search_start = second_header_offset.saturating_sub(24);
+    let window = payload
+        .get(search_start..second_header_offset)
+        .ok_or(XllError::Invalid("short alternate XLL interstitial"))?;
+    let prefix_offset = window
+        .windows(XLL_X_ALT_INNER_SUFFIX.len())
+        .rposition(|bytes| bytes == XLL_X_ALT_INNER_SUFFIX)
+        .ok_or(XllError::Invalid("missing alternate XLL inner suffix"))?;
+    let control_start = prefix_offset + XLL_X_ALT_INNER_SUFFIX.len();
+    let control = window
+        .get(control_start..)
+        .ok_or(XllError::Invalid("short alternate XLL inner control"))?;
+    if !(8..=9).contains(&control.len()) {
+        return Err(XllError::Invalid("alternate XLL inner control size"));
+    }
+    Ok(control)
+}
+
+fn alternate_outer_layout(payload: &[u8], profile: AlternateProfile) -> R<(usize, usize, usize)> {
+    const MAX_PREFIX_BYTES: usize = 96;
+
+    let minimum_prefix = match profile {
+        AlternateProfile::D0 => 48,
+        AlternateProfile::D1 | AlternateProfile::D3 => 49,
+    };
+    let search_end = payload.len().min(MAX_PREFIX_BYTES);
+    let mut prefix_end = None;
+    for candidate in minimum_prefix..search_end {
+        let Some(suffix_end) = candidate.checked_add(XLL_X_ALT_OUTER_SUFFIX.len()) else {
+            break;
+        };
+        if suffix_end > payload.len() {
+            break;
+        }
+        if payload.get(candidate..suffix_end) != Some(&XLL_X_ALT_OUTER_SUFFIX)
+            || crc16_ccitt(&payload[..candidate]) != 0
+        {
+            continue;
+        }
+        if prefix_end.replace(candidate).is_some() {
+            return Err(XllError::Invalid("ambiguous alternate XLL prefix"));
+        }
+    }
+    let prefix_end = prefix_end.ok_or(XllError::Invalid("alternate XLL prefix CRC"))?;
+    let control_start = prefix_end
+        .checked_add(XLL_X_ALT_OUTER_SUFFIX.len())
+        .ok_or(XllError::Invalid("alternate XLL control offset overflow"))?;
+    let control_size = match payload.get(control_start) {
+        Some(0xb2) => 7,
+        Some(0xc2..=0xc6) => 8,
+        _ => {
+            return Err(match profile {
+                AlternateProfile::D0 => XllError::Invalid("alternate D0 control tag"),
+                AlternateProfile::D1 => XllError::Invalid("alternate D1 control tag"),
+                AlternateProfile::D3 => XllError::Invalid("alternate D3 control tag"),
+            });
+        }
+    };
+    Ok((control_start, control_size, control_start + 12))
+}
+
+fn alternate_layout(payload: &[u8]) -> R<AlternateLayout> {
+    let syncword = payload
+        .get(..4)
+        .and_then(|bytes| bytes.try_into().ok())
+        .map(u32::from_be_bytes)
+        .ok_or(XllError::Invalid("short alternate XLL payload"))?;
+    let profile = match syncword {
+        DCA_SYNCWORD_XLL_X_ALT_D0 => AlternateProfile::D0,
+        DCA_SYNCWORD_XLL_X_ALT_D1 => AlternateProfile::D1,
+        DCA_SYNCWORD_XLL_X_ALT_D3 => AlternateProfile::D3,
+        _ => return Err(XllError::Invalid("unknown alternate XLL profile")),
+    };
+    let (control_start, control_size, offset_bias) = alternate_outer_layout(payload, profile)?;
+    let first_header_offset = control_start
+        .checked_add(control_size)
+        .ok_or(XllError::Invalid("alternate XLL header offset overflow"))?;
+    let outer_control = payload
+        .get(control_start..first_header_offset)
+        .ok_or(XllError::Invalid("short alternate XLL outer control"))?;
+    let first_geometry_end = match profile {
+        AlternateProfile::D3 => 31,
+        AlternateProfile::D0 | AlternateProfile::D1 => 25,
+    };
+    let (common_bit, first_geometry) =
+        alternate_unique_geometry(outer_control, 18, first_geometry_end)?;
+    let first_header = alternate_header_at(payload, first_header_offset)
+        .ok_or(XllError::Invalid("invalid alternate XLL first header"))?;
+    let expected_first_channels = match profile {
+        AlternateProfile::D0 => 1,
+        AlternateProfile::D1 => 2,
+        AlternateProfile::D3 => 4,
+    };
+    if first_header.channels != expected_first_channels {
+        return Err(XllError::Invalid(
+            "unexpected alternate XLL first channel count",
+        ));
+    }
+    let second_header = alternate_second_header(payload, outer_control, common_bit, offset_bias)?;
+    let inner_control = alternate_inner_control(payload, second_header.offset)?;
+    let second_geometry_start = match profile {
+        AlternateProfile::D0 => 18,
+        AlternateProfile::D1 | AlternateProfile::D3 => 19,
+    };
+    let (_, second_geometry) = alternate_unique_geometry(inner_control, second_geometry_start, 26)?;
+    Ok(AlternateLayout {
+        headers: [first_header, second_header],
+        geometries: [first_geometry, second_geometry],
+    })
 }
 
 #[inline]
@@ -166,6 +425,15 @@ struct XllChSet {
     header_tail_bits: usize,
 }
 
+#[derive(Clone, Copy)]
+enum ChsMappingSyntax {
+    Asset {
+        is_primary: bool,
+        allow_unmapped: bool,
+    },
+    AlternatePrefix(usize),
+}
+
 #[derive(Default)]
 pub(crate) struct XllDecoder {
     frame_size: usize,
@@ -197,27 +465,83 @@ pub(crate) struct XllDecoder {
     pub(crate) sample_rate: u32,
     pub(crate) pcm_bit_res: usize,
     // DTS:X end-of-frame extension (ffmpeg only flags it, never parses it).
-    // Captured here for offline characterization; not used in the audio path.
     pub(crate) x_syncword_present: bool,
     pub(crate) x_imax_syncword_present: bool,
     /// Raw DTS:X extension payload (syncword + data) for the current frame.
     pub(crate) x_payload: Vec<u8>,
     /// Byte offset of `x_payload` within the XLL frame.
     pub(crate) x_payload_offset: usize,
-    /// Decoded, speaker-unmapped waveforms from the bare XLL channel set in the
-    /// DTS:X extension. These are kept separate from the 7.1 bed because the
-    /// extension does not carry a one-to-one speaker map in its channel-set
-    /// header.
+    /// Decoded, speaker-unmapped waveforms from the bare extension channel
+    /// sets. These stay separate from the lossless bed; presentation is a
+    /// bridge concern and requires independently established semantics.
     pub(crate) x_output: Vec<Vec<i32>>,
     pub(crate) x_pcm_bit_res: usize,
     pub(crate) x_bits_consumed: usize,
-    /// Sticky, allocation-free failure kind of the last XLL-X decode attempt
-    /// (cleared on the next successful decode / frame reset).
+    /// Allocation-free failure kind of the current XLL-X decode attempt.
     pub(crate) x_decode_error: Option<&'static str>,
     pub(crate) x_header_tail_bits: usize,
     x_descriptor_offset: Option<usize>,
     x_descriptor_size: Option<usize>,
     pub(crate) x_descriptor_navigation_used: bool,
+}
+
+#[derive(Clone, Copy)]
+struct AlternateDecoderState {
+    frame_size: usize,
+    nchsets: usize,
+    nframesegs: usize,
+    nsegsamples_log2: usize,
+    nsegsamples: usize,
+    nframesamples: usize,
+    seg_size_nbits: usize,
+    band_crc_present: u32,
+    scalable_lsbs: bool,
+    ch_mask_nbits: usize,
+    fixed_lsb_width: usize,
+    nfreqbands: usize,
+    nchannels: usize,
+    nactivechsets: usize,
+    one_to_one: bool,
+}
+
+impl AlternateDecoderState {
+    fn capture(decoder: &XllDecoder) -> Self {
+        Self {
+            frame_size: decoder.frame_size,
+            nchsets: decoder.nchsets,
+            nframesegs: decoder.nframesegs,
+            nsegsamples_log2: decoder.nsegsamples_log2,
+            nsegsamples: decoder.nsegsamples,
+            nframesamples: decoder.nframesamples,
+            seg_size_nbits: decoder.seg_size_nbits,
+            band_crc_present: decoder.band_crc_present,
+            scalable_lsbs: decoder.scalable_lsbs,
+            ch_mask_nbits: decoder.ch_mask_nbits,
+            fixed_lsb_width: decoder.fixed_lsb_width,
+            nfreqbands: decoder.nfreqbands,
+            nchannels: decoder.nchannels,
+            nactivechsets: decoder.nactivechsets,
+            one_to_one: decoder.one_to_one,
+        }
+    }
+
+    fn restore(self, decoder: &mut XllDecoder) {
+        decoder.frame_size = self.frame_size;
+        decoder.nchsets = self.nchsets;
+        decoder.nframesegs = self.nframesegs;
+        decoder.nsegsamples_log2 = self.nsegsamples_log2;
+        decoder.nsegsamples = self.nsegsamples;
+        decoder.nframesamples = self.nframesamples;
+        decoder.seg_size_nbits = self.seg_size_nbits;
+        decoder.band_crc_present = self.band_crc_present;
+        decoder.scalable_lsbs = self.scalable_lsbs;
+        decoder.ch_mask_nbits = self.ch_mask_nbits;
+        decoder.fixed_lsb_width = self.fixed_lsb_width;
+        decoder.nfreqbands = self.nfreqbands;
+        decoder.nchannels = self.nchannels;
+        decoder.nactivechsets = self.nactivechsets;
+        decoder.one_to_one = self.one_to_one;
+    }
 }
 
 impl XllDecoder {
@@ -374,7 +698,9 @@ impl XllDecoder {
         }
         match gb.show_bits(32) {
             Some(DCA_SYNCWORD_XLL_X) => self.x_syncword_present = true,
-            Some(sw) if (sw >> 1) == (DCA_SYNCWORD_XLL_X_IMAX >> 1) => self.x_imax_syncword_present = true,
+            Some(
+                DCA_SYNCWORD_XLL_X_ALT_D0 | DCA_SYNCWORD_XLL_X_ALT_D1 | DCA_SYNCWORD_XLL_X_ALT_D3,
+            ) => self.x_imax_syncword_present = true,
             _ => return,
         }
         if frame_end > start {
@@ -384,11 +710,15 @@ impl XllDecoder {
     }
 
     fn decode_x_extension_audio(&mut self) {
-        if !self.x_syncword_present {
+        if !self.x_syncword_present && !self.x_imax_syncword_present {
             return;
         }
         let payload = std::mem::take(&mut self.x_payload);
-        let result = self.try_decode_x_extension_audio(&payload);
+        let result = if self.x_syncword_present {
+            self.try_decode_x_extension_audio(&payload)
+        } else {
+            self.try_decode_alternate_x_extension_audio(&payload)
+        };
         self.x_payload = payload;
         if let Err(error) = result {
             self.x_output.clear();
@@ -471,7 +801,10 @@ impl XllDecoder {
             }
             Ok(())
         })();
-        let chset = self.chset.pop().expect("temporary XLL-X channel set");
+        let chset = self
+            .chset
+            .pop()
+            .ok_or(XllError::Invalid("missing temporary XLL-X channel set"))?;
         decode_result?;
 
         let shift = 24usize
@@ -491,6 +824,190 @@ impl XllDecoder {
         self.x_pcm_bit_res = chset.pcm_bit_res;
         self.x_bits_consumed = gb.position();
         Ok(())
+    }
+
+    /// Decode the two bounded channel sets carried by the alternate extension
+    /// profiles. Their controls provide the per-set segment geometry; neither
+    /// set inherits the lossless bed's common XLL geometry.
+    fn try_decode_alternate_x_extension_audio(&mut self, payload: &[u8]) -> R<()> {
+        let layout = alternate_layout(payload)?;
+        let first = self.decode_alternate_channel_set(
+            payload,
+            layout.headers[0],
+            layout.geometries[0],
+            layout.headers[1].offset,
+        )?;
+        let second = self.decode_alternate_channel_set(
+            payload,
+            layout.headers[1],
+            layout.geometries[1],
+            payload.len(),
+        )?;
+        if first.0.pcm_bit_res != second.0.pcm_bit_res {
+            return Err(XllError::Unsupported("mixed alternate XLL PCM resolutions"));
+        }
+        let pcm_bit_res = first.0.pcm_bit_res;
+        let shift = 24usize
+            .checked_sub(pcm_bit_res)
+            .ok_or(XllError::Invalid("alternate XLL PCM resolution"))?;
+        let scale = 1i32
+            .checked_shl(shift as u32)
+            .ok_or(XllError::Invalid("alternate XLL PCM scale"))?;
+
+        self.x_output.clear();
+        self.x_output
+            .reserve(first.0.nchannels + second.0.nchannels);
+        for mut samples in first.0.band.msb.into_iter().chain(second.0.band.msb) {
+            for sample in &mut samples {
+                *sample = clip23(sample.wrapping_mul(scale));
+            }
+            self.x_output.push(samples);
+        }
+        self.x_pcm_bit_res = pcm_bit_res;
+        self.x_bits_consumed = second.1;
+        // This legacy diagnostic describes the single standard-profile header;
+        // do not overload it with one of the alternate profile's two headers.
+        self.x_header_tail_bits = 0;
+        Ok(())
+    }
+
+    fn decode_alternate_channel_set(
+        &mut self,
+        payload: &[u8],
+        header: AlternateHeader,
+        geometry: AlternateGeometry,
+        boundary: usize,
+    ) -> R<(XllChSet, usize)> {
+        let saved = AlternateDecoderState::capture(self);
+        let result = self.decode_alternate_channel_set_inner(payload, header, geometry, boundary);
+        saved.restore(self);
+        result
+    }
+
+    fn decode_alternate_channel_set_inner(
+        &mut self,
+        payload: &[u8],
+        header: AlternateHeader,
+        geometry: AlternateGeometry,
+        boundary: usize,
+    ) -> R<(XllChSet, usize)> {
+        let header_end = header
+            .offset
+            .checked_add(header.size)
+            .ok_or(XllError::Invalid("alternate XLL header size overflow"))?;
+        if boundary > payload.len() || header_end > boundary {
+            return Err(XllError::Invalid("alternate XLL channel-set bounds"));
+        }
+        let boundary_bits = boundary
+            .checked_mul(8)
+            .ok_or(XllError::Invalid("alternate XLL boundary overflow"))?;
+        if !geometry.segments.is_power_of_two() || XLL_X_ALT_FRAME_SAMPLES % geometry.segments != 0
+        {
+            return Err(XllError::Invalid("alternate XLL segment count"));
+        }
+        let segment_samples = XLL_X_ALT_FRAME_SAMPLES / geometry.segments;
+        if !segment_samples.is_power_of_two() {
+            return Err(XllError::Invalid("alternate XLL segment samples"));
+        }
+
+        self.frame_size = payload.len();
+        self.nchsets = 1;
+        self.nactivechsets = 1;
+        self.nframesegs = geometry.segments;
+        self.nsegsamples = segment_samples;
+        self.nsegsamples_log2 = segment_samples.ilog2() as usize;
+        self.nframesamples = XLL_X_ALT_FRAME_SAMPLES;
+        self.seg_size_nbits = geometry.navigation_size_bits;
+        self.band_crc_present = 0;
+        self.scalable_lsbs = false;
+        self.ch_mask_nbits = 1;
+        self.fixed_lsb_width = 0;
+        self.nfreqbands = 1;
+        self.nchannels = header.channels;
+        self.one_to_one = false;
+
+        let mut bits = BitReader::with_offset(payload, header.offset * 8);
+        let mut channel_set = XllChSet::default();
+        self.chs_parse_header_with_mapping(
+            &mut bits,
+            &mut channel_set,
+            ChsMappingSyntax::AlternatePrefix(2),
+        )?;
+        let navi_start = header
+            .offset
+            .checked_add(header.size)
+            .ok_or(XllError::Invalid("alternate XLL NAVI offset overflow"))?;
+        if bits.position() != navi_start * 8
+            || channel_set.nchannels != header.channels
+            || channel_set.residual_encode != (1u32 << header.channels) - 1
+        {
+            return Err(XllError::Invalid("alternate XLL channel-set header"));
+        }
+
+        let navi_payload_bits = geometry
+            .segments
+            .checked_mul(geometry.navigation_size_bits)
+            .ok_or(XllError::Invalid("alternate XLL NAVI size overflow"))?;
+        let navi_size = navi_payload_bits.div_ceil(8) + 2;
+        let navi_end = navi_start
+            .checked_add(navi_size)
+            .filter(|&end| end <= boundary)
+            .ok_or(XllError::Invalid("short alternate XLL NAVI"))?;
+        if crc16_ccitt(&payload[navi_start..navi_end]) != 0 {
+            return Err(XllError::Invalid("alternate XLL NAVI CRC"));
+        }
+        let mut navigation = [0usize; XLL_X_ALT_MAX_SEGMENTS];
+        let mut navi_reader = BitReader::with_offset(payload, navi_start * 8);
+        let mut audio_bytes = 0usize;
+        for slot in navigation.iter_mut().take(geometry.segments) {
+            *slot = rb(&mut navi_reader, geometry.navigation_size_bits)? as usize + 1;
+            audio_bytes = audio_bytes
+                .checked_add(*slot)
+                .ok_or(XllError::Invalid("alternate XLL audio size overflow"))?;
+        }
+        let audio_end = navi_end
+            .checked_add(audio_bytes)
+            .filter(|&end| end <= boundary)
+            .ok_or(XllError::Invalid("alternate XLL audio exceeds boundary"))?;
+        if boundary - audio_end > XLL_X_ALT_MAX_INTERSTITIAL {
+            return Err(XllError::Invalid("alternate XLL interstitial too large"));
+        }
+
+        channel_set.band.msb = vec![vec![0i32; XLL_X_ALT_FRAME_SAMPLES]; header.channels];
+        channel_set.band.lsb = if channel_set.band.lsb_section_size != 0 {
+            vec![vec![0i32; XLL_X_ALT_FRAME_SAMPLES]; header.channels]
+        } else {
+            Vec::new()
+        };
+        self.chset.push(channel_set);
+        let channel_set_index = self.chset.len() - 1;
+        let decode_result = (|| {
+            seek(&mut bits, navi_end * 8)?;
+            let mut band_end = bits.position();
+            for (segment, &segment_bytes) in navigation.iter().take(geometry.segments).enumerate() {
+                band_end = band_end
+                    .checked_add(
+                        segment_bytes
+                            .checked_mul(8)
+                            .ok_or(XllError::Invalid("alternate XLL band size overflow"))?,
+                    )
+                    .filter(|&end| end <= boundary_bits)
+                    .ok_or(XllError::Invalid("alternate XLL band exceeds boundary"))?;
+                self.chs_parse_band_data(&mut bits, channel_set_index, segment, band_end)?;
+                if bits.position() > band_end || band_end - bits.position() > 32 {
+                    return Err(XllError::Invalid("alternate XLL band trailing bits"));
+                }
+                seek(&mut bits, band_end)?;
+            }
+            self.chs_filter_band_data(channel_set_index);
+            Ok(())
+        })();
+        let channel_set = self
+            .chset
+            .pop()
+            .ok_or(XllError::Invalid("missing alternate XLL channel set"))?;
+        decode_result?;
+        Ok((channel_set, audio_end * 8))
     }
 
     fn parse_common_header(&mut self, gb: &mut BitReader) -> R<()> {
@@ -563,6 +1080,22 @@ impl XllDecoder {
         is_primary: bool,
         allow_unmapped: bool,
     ) -> R<()> {
+        self.chs_parse_header_with_mapping(
+            gb,
+            c,
+            ChsMappingSyntax::Asset {
+                is_primary,
+                allow_unmapped,
+            },
+        )
+    }
+
+    fn chs_parse_header_with_mapping(
+        &mut self,
+        gb: &mut BitReader,
+        c: &mut XllChSet,
+        mapping: ChsMappingSyntax,
+    ) -> R<()> {
         let header_pos = gb.position();
         let header_size = rb(gb, 10)? as usize + 1;
         c.nchannels = rb(gb, 4)? as usize + 1;
@@ -591,69 +1124,86 @@ impl XllDecoder {
 
         // The channel-set layout depends on the asset's one_to_one_map_ch_to_spkr
         // flag (mirrors FFmpeg dca_xll.c chs_parse_header).
-        if self.one_to_one && !allow_unmapped {
-            // Normal one-to-one channel→speaker mapping (multichannel beds).
-            c.primary_chset = rb1(gb)?;
-            if c.primary_chset != is_primary {
-                return Err(XllError::Invalid("first XLL chset must be primary"));
-            }
-            c.dmix_coeffs_present = rb1(gb)?;
-            c.dmix_embedded = c.dmix_coeffs_present && rb1(gb)?;
-            if c.dmix_coeffs_present && c.primary_chset {
-                c.dmix_type = rb(gb, 3)? as usize;
-                if c.dmix_type >= 7 {
-                    return Err(XllError::Invalid("XLL primary downmix type"));
+        match mapping {
+            ChsMappingSyntax::Asset {
+                is_primary,
+                allow_unmapped,
+            } => {
+                if self.one_to_one && !allow_unmapped {
+                    // Normal one-to-one channel→speaker mapping (multichannel beds).
+                    c.primary_chset = rb1(gb)?;
+                    if c.primary_chset != is_primary {
+                        return Err(XllError::Invalid("first XLL chset must be primary"));
+                    }
+                    c.dmix_coeffs_present = rb1(gb)?;
+                    c.dmix_embedded = c.dmix_coeffs_present && rb1(gb)?;
+                    if c.dmix_coeffs_present && c.primary_chset {
+                        c.dmix_type = rb(gb, 3)? as usize;
+                        if c.dmix_type >= 7 {
+                            return Err(XllError::Invalid("XLL primary downmix type"));
+                        }
+                    }
+                    c.hier_chset = rb1(gb)?;
+                    if !c.hier_chset && self.nchsets != 1 {
+                        return Err(XllError::Unsupported("XLL chset outside hierarchy"));
+                    }
+                    if c.dmix_coeffs_present {
+                        self.parse_dmix_coeffs(gb, c)?;
+                    }
+                    // A primary chset's embedded downmix is only used for stereo-downmix
+                    // requests; it is NOT undone for full multichannel output. Non-primary
+                    // hierarchical embedded downmix (undo_down_mix) is unsupported and
+                    // rejected after sub-header parsing.
+                    if !rb1(gb)? {
+                        return Err(XllError::Unsupported("disabled XLL channel mask"));
+                    }
+                    c.ch_mask = rb(gb, self.ch_mask_nbits)?;
+                    if c.ch_mask.count_ones() as usize != c.nchannels {
+                        return Err(XllError::Invalid("XLL channel mask popcount"));
+                    }
+                    let mut j = 0;
+                    for i in 0..self.ch_mask_nbits {
+                        if c.ch_mask & (1 << i) != 0 {
+                            c.ch_remap[j] = i;
+                            j += 1;
+                        }
+                    }
+                } else {
+                    // Non one-to-one mapping (e.g. an Lt/Rt 2.0 set). Only the plain
+                    // stereo case is handled: a single 2-channel set with no custom
+                    // mapping coefficients, fixed to L/R.
+                    let mapping_coeffs_present = rb1(gb)?;
+                    if mapping_coeffs_present
+                        || (!allow_unmapped && (c.nchannels != 2 || self.nchsets != 1))
+                    {
+                        return Err(XllError::Unsupported(
+                            "custom XLL channel-to-speaker mapping",
+                        ));
+                    }
+                    c.primary_chset = true;
+                    c.dmix_coeffs_present = false;
+                    c.dmix_embedded = false;
+                    c.hier_chset = allow_unmapped;
+                    if allow_unmapped {
+                        for ch in 0..c.nchannels {
+                            c.ch_remap[ch] = ch;
+                        }
+                    } else {
+                        c.ch_mask = (1 << DCA_SPEAKER_L) | (1 << DCA_SPEAKER_R);
+                        c.ch_remap[0] = DCA_SPEAKER_L;
+                        c.ch_remap[1] = DCA_SPEAKER_R;
+                    }
                 }
             }
-            c.hier_chset = rb1(gb)?;
-            if !c.hier_chset && self.nchsets != 1 {
-                return Err(XllError::Unsupported("XLL chset outside hierarchy"));
-            }
-            if c.dmix_coeffs_present {
-                self.parse_dmix_coeffs(gb, c)?;
-            }
-            // A primary chset's embedded downmix is only used for stereo-downmix
-            // requests; it is NOT undone for full multichannel output. Non-primary
-            // hierarchical embedded downmix (undo_down_mix) is unsupported and
-            // rejected after sub-header parsing.
-            if !rb1(gb)? {
-                return Err(XllError::Unsupported("disabled XLL channel mask"));
-            }
-            c.ch_mask = rb(gb, self.ch_mask_nbits)?;
-            if c.ch_mask.count_ones() as usize != c.nchannels {
-                return Err(XllError::Invalid("XLL channel mask popcount"));
-            }
-            let mut j = 0;
-            for i in 0..self.ch_mask_nbits {
-                if c.ch_mask & (1 << i) != 0 {
-                    c.ch_remap[j] = i;
-                    j += 1;
-                }
-            }
-        } else {
-            // Non one-to-one mapping (e.g. an Lt/Rt 2.0 set). Only the plain
-            // stereo case is handled: a single 2-channel set with no custom
-            // mapping coefficients, fixed to L/R.
-            let mapping_coeffs_present = rb1(gb)?;
-            if mapping_coeffs_present
-                || (!allow_unmapped && (c.nchannels != 2 || self.nchsets != 1))
-            {
-                return Err(XllError::Unsupported(
-                    "custom XLL channel-to-speaker mapping",
-                ));
-            }
-            c.primary_chset = true;
-            c.dmix_coeffs_present = false;
-            c.dmix_embedded = false;
-            c.hier_chset = allow_unmapped;
-            if allow_unmapped {
+            ChsMappingSyntax::AlternatePrefix(prefix_bits) => {
+                rb(gb, prefix_bits)?;
+                c.primary_chset = true;
+                c.dmix_coeffs_present = false;
+                c.dmix_embedded = false;
+                c.hier_chset = true;
                 for ch in 0..c.nchannels {
                     c.ch_remap[ch] = ch;
                 }
-            } else {
-                c.ch_mask = (1 << DCA_SPEAKER_L) | (1 << DCA_SPEAKER_R);
-                c.ch_remap[0] = DCA_SPEAKER_L;
-                c.ch_remap[1] = DCA_SPEAKER_R;
             }
         }
 
@@ -677,11 +1227,17 @@ impl XllDecoder {
         b.decor_enabled = rb1(gb)?;
         if b.decor_enabled && c.nchannels > 1 {
             let ch_nbits = ceil_log2(c.nchannels);
+            let mut order_mask = 0u32;
             for i in 0..c.nchannels {
                 b.orig_order[i] = rb(gb, ch_nbits)? as usize;
                 if b.orig_order[i] >= c.nchannels {
                     return Err(XllError::Invalid("XLL original channel order"));
                 }
+                let order_bit = 1u32 << b.orig_order[i];
+                if order_mask & order_bit != 0 {
+                    return Err(XllError::Invalid("duplicate XLL original channel order"));
+                }
+                order_mask |= order_bit;
             }
             for i in 0..c.nchannels / 2 {
                 b.decor_coeff[i] = if rb1(gb)? { get_linear(gb, 7)? } else { 0 };
@@ -1278,5 +1834,1058 @@ fn ceil_log2(n: usize) -> usize {
         0
     } else {
         (usize::BITS - (n - 1).leading_zeros()) as usize
+    }
+}
+
+#[cfg(test)]
+mod alt_extension_tests {
+    use super::*;
+    use crate::parser::parse_header;
+    use crate::{HdDecoder, exss_substream_size};
+    use std::io::{BufReader, Read};
+
+    const D0_CORPUS_PATH_ENV: &str = "HARLETTY_D0_CORPUS";
+    const D1_CORPUS_PATH_ENV: &str = "HARLETTY_D1_CORPUS";
+
+    fn exss_size_from_prefix(data: &[u8]) -> Option<usize> {
+        let mut bits = BitReader::new(data);
+        if rb(&mut bits, 32).ok()? != crate::SYNCWORD_SUBSTREAM {
+            return None;
+        }
+        rb(&mut bits, 8).ok()?;
+        rb(&mut bits, 2).ok()?;
+        let wide_header = rb(&mut bits, 1).ok()? as usize;
+        rb(&mut bits, 8 + 4 * wide_header).ok()?;
+        Some(rb(&mut bits, 16 + 4 * wide_header).ok()? as usize + 1)
+    }
+
+    fn extension_payload(path: &str, target_frame: usize) -> Option<Vec<u8>> {
+        const HEADER_BYTES: usize = 18;
+        const EXSS_PREFIX_BYTES: usize = 16;
+
+        let input = std::fs::File::open(path).ok()?;
+        let mut input = BufReader::with_capacity(1024 * 1024, input);
+        let mut decoder = HdDecoder::new();
+        let mut core = Vec::new();
+        let mut exss = Vec::new();
+        let mut header = [0u8; HEADER_BYTES];
+        for frame in 0..=target_frame {
+            input.read_exact(&mut header).ok()?;
+            let info = parse_header(&header).ok()?;
+            core.resize(info.frame_size, 0);
+            core[..HEADER_BYTES].copy_from_slice(&header);
+            input.read_exact(&mut core[HEADER_BYTES..]).ok()?;
+
+            exss.resize(EXSS_PREFIX_BYTES, 0);
+            input.read_exact(&mut exss).ok()?;
+            let exss_size = exss_size_from_prefix(&exss)?;
+            exss.resize(exss_size, 0);
+            input.read_exact(&mut exss[EXSS_PREFIX_BYTES..]).ok()?;
+            let decoded = decoder.decode(&core, &exss).ok()?;
+            if frame == target_frame {
+                return Some(decoded.x_payload);
+            }
+        }
+        None
+    }
+
+    type RuntimeExtensionResult = (usize, bool, Option<&'static str>);
+
+    fn extension_payloads(
+        path: &str,
+        max_frames: usize,
+        max_bytes: u64,
+    ) -> Option<(Vec<Vec<u8>>, Vec<RuntimeExtensionResult>)> {
+        let mut input = std::fs::File::open(path).ok()?;
+        let mut bytes = Vec::with_capacity(max_bytes.min(usize::MAX as u64) as usize);
+        input
+            .by_ref()
+            .take(max_bytes)
+            .read_to_end(&mut bytes)
+            .ok()?;
+        let mut decoder = HdDecoder::new();
+        let mut payloads = Vec::new();
+        let mut runtime_results = Vec::new();
+        let mut offset = 0usize;
+        while offset + 18 < bytes.len() && payloads.len() < max_frames {
+            let Ok(core) = parse_header(&bytes[offset..]) else {
+                break;
+            };
+            let exss_offset = offset + core.frame_size;
+            let Some(exss_len) = bytes
+                .get(exss_offset..)
+                .and_then(exss_substream_size)
+                .filter(|length| exss_offset + length <= bytes.len())
+            else {
+                break;
+            };
+            if let Ok(decoded) = decoder.decode(
+                &bytes[offset..exss_offset],
+                &bytes[exss_offset..exss_offset + exss_len],
+            ) {
+                runtime_results.push((
+                    decoded.x_samples.len(),
+                    decoded
+                        .x_samples
+                        .iter()
+                        .all(|channel| channel.len() == XLL_X_ALT_FRAME_SAMPLES),
+                    decoded.x_decode_error,
+                ));
+                payloads.push(decoded.x_payload);
+            }
+            offset = exss_offset + exss_len;
+        }
+        Some((payloads, runtime_results))
+    }
+
+    fn extension_payload_from_env(variable: &str, target_frame: usize) -> Option<Vec<u8>> {
+        let path = std::env::var(variable).ok()?;
+        extension_payload(&path, target_frame)
+    }
+
+    fn extension_payloads_from_env(
+        variable: &str,
+        max_frames: usize,
+        max_bytes: u64,
+    ) -> Option<(Vec<Vec<u8>>, Vec<RuntimeExtensionResult>)> {
+        let path = std::env::var(variable).ok()?;
+        extension_payloads(&path, max_frames, max_bytes)
+    }
+
+    fn alternate_d1_header_candidates(payload: &[u8]) -> Option<[(usize, usize, usize); 2]> {
+        if payload.get(..4) != Some(&DCA_SYNCWORD_XLL_X_ALT_D1.to_be_bytes()) {
+            return None;
+        }
+        let layout = alternate_layout(payload).ok()?;
+        Some(
+            layout
+                .headers
+                .map(|header| (header.offset, header.size, header.channels)),
+        )
+    }
+
+    fn alternate_d0_header_candidates(payload: &[u8]) -> Option<[(usize, usize, usize); 2]> {
+        if payload.get(..4) != Some(&DCA_SYNCWORD_XLL_X_ALT_D0.to_be_bytes()) {
+            return None;
+        }
+        let layout = alternate_layout(payload).ok()?;
+        Some(
+            layout
+                .headers
+                .map(|header| (header.offset, header.size, header.channels)),
+        )
+    }
+
+    fn common_geometry_at(control: &[u8], bit_offset: usize) -> Option<(usize, usize)> {
+        alternate_geometry_at(control, bit_offset)
+            .map(|geometry| (geometry.segments, geometry.navigation_size_bits))
+    }
+
+    fn common_geometry_candidates(control: &[u8]) -> Vec<(usize, usize)> {
+        common_geometry_candidates_between(control, 19, 26)
+    }
+
+    fn common_geometry_candidates_between(
+        control: &[u8],
+        first_offset: usize,
+        last_offset: usize,
+    ) -> Vec<(usize, usize)> {
+        (first_offset..=last_offset)
+            .filter_map(|offset| common_geometry_at(control, offset))
+            .collect()
+    }
+
+    fn alternate_d1_first_geometries(payload: &[u8]) -> Vec<(usize, usize)> {
+        const CONTROL_OFFSET: usize = 55;
+        let control_size = match payload.get(CONTROL_OFFSET) {
+            Some(0xb2) => 7,
+            Some(0xc3..=0xc5) => 8,
+            _ => return Vec::new(),
+        };
+        payload
+            .get(CONTROL_OFFSET..CONTROL_OFFSET + control_size)
+            .map(|control| common_geometry_candidates_between(control, 18, 25))
+            .unwrap_or_default()
+    }
+
+    fn alternate_d1_second_geometries(
+        payload: &[u8],
+        second_header_offset: usize,
+    ) -> Vec<(usize, usize)> {
+        alternate_second_control(payload, second_header_offset)
+            .map(common_geometry_candidates)
+            .unwrap_or_default()
+    }
+
+    fn alternate_second_control(payload: &[u8], second_header_offset: usize) -> Option<&[u8]> {
+        alternate_inner_control(payload, second_header_offset).ok()
+    }
+
+    #[test]
+    fn alternate_layout_rejects_short_and_unknown_payloads() {
+        for syncword in [
+            DCA_SYNCWORD_XLL_X_ALT_D0,
+            DCA_SYNCWORD_XLL_X_ALT_D1,
+            DCA_SYNCWORD_XLL_X_ALT_D3,
+        ] {
+            let mut payload = [0u8; 96];
+            payload[..4].copy_from_slice(&syncword.to_be_bytes());
+            for length in 0..payload.len() {
+                assert!(alternate_layout(&payload[..length]).is_err());
+            }
+        }
+        assert!(alternate_layout(&[0u8; 128]).is_err());
+    }
+
+    #[test]
+    fn alternate_d1_outer_prefix_accepts_known_lengths() {
+        let prefixes: [&[u8]; 2] = [
+            &[
+                0xf1, 0x40, 0x00, 0xd1, 0x30, 0x28, 0x4b, 0x00, 0xe0, 0x00, 0x39, 0x00, 0x01, 0x41,
+                0x9e, 0xfe, 0xc3, 0x10, 0x28, 0x33, 0xdf, 0xe3, 0xe2, 0x00, 0x03, 0x00, 0x08, 0x81,
+                0xf4, 0xe2, 0x1a, 0xc4, 0x04, 0x7f, 0x40, 0x25, 0xbf, 0xa0, 0x49, 0xbf, 0xa8, 0x81,
+                0xbf, 0xb1, 0x01, 0xbf, 0xa0, 0xd6, 0xe3,
+            ],
+            &[
+                0xf1, 0x40, 0x00, 0xd1, 0x30, 0x28, 0x4b, 0x00, 0xe1, 0x00, 0x39, 0x40, 0x00, 0x83,
+                0x3d, 0xfc, 0x5e, 0x7a, 0x30, 0xf5, 0x50, 0x83, 0x3d, 0xff, 0x66, 0x72, 0x30, 0x53,
+                0xd0, 0x03, 0x00, 0x08, 0x81, 0xf4, 0xe2, 0x1a, 0xc4, 0x04, 0x7f, 0x40, 0x25, 0xbf,
+                0xa0, 0x49, 0xbf, 0xa8, 0x81, 0xbf, 0xb1, 0x01, 0xbf, 0xa0, 0x09, 0x98,
+            ],
+        ];
+        for prefix in prefixes {
+            assert_eq!(crc16_ccitt(prefix), 0);
+            let mut payload = prefix.to_vec();
+            payload.extend_from_slice(&XLL_X_ALT_OUTER_SUFFIX);
+            payload.push(0xb2);
+            assert_eq!(
+                alternate_outer_layout(&payload, AlternateProfile::D1),
+                Ok((
+                    prefix.len() + XLL_X_ALT_OUTER_SUFFIX.len(),
+                    7,
+                    prefix.len() + 18
+                ))
+            );
+        }
+    }
+
+    #[test]
+    fn alternate_d3_outer_prefix_is_crc_delimited() {
+        let prefix = [
+            0xf1, 0x40, 0x00, 0xd3, 0x30, 0x28, 0x4b, 0x00, 0xe1, 0x00, 0x39, 0x40, 0x0e, 0x90,
+            0x03, 0xb4, 0x00, 0x08, 0x33, 0xdf, 0xc5, 0xe7, 0xa3, 0x0f, 0x55, 0x08, 0x33, 0xdf,
+            0xf6, 0x67, 0x23, 0x05, 0x3d, 0x08, 0x33, 0xdf, 0xc5, 0x1e, 0x21, 0x0f, 0x42, 0x0c,
+            0xf7, 0xfd, 0xc7, 0x88, 0x83, 0xd0, 0x03, 0x00, 0x08, 0x81, 0xf4, 0xe2, 0x1a, 0xc4,
+            0x04, 0x7f, 0x40, 0x25, 0xbf, 0xa0, 0x49, 0xbf, 0xa8, 0x81, 0xbf, 0xb1, 0x01, 0xbf,
+            0xa0, 0xd8, 0x72,
+        ];
+        assert_eq!(prefix.len(), 73);
+        assert_eq!(crc16_ccitt(&prefix), 0);
+        let mut payload = prefix.to_vec();
+        payload.extend_from_slice(&XLL_X_ALT_OUTER_SUFFIX);
+        payload.push(0xc6);
+        assert_eq!(
+            alternate_outer_layout(&payload, AlternateProfile::D3),
+            Ok((79, 8, 91))
+        );
+    }
+
+    #[test]
+    fn alternate_extended_controls_have_expected_geometries() {
+        let d1_inner = [0xd6, 0x40, 0x0c, 0x06, 0x16, 0x70, 0x00, 0xee, 0x4d];
+        assert_eq!(common_geometry_at(&d1_inner, 26), Some((2, 12)));
+        assert_eq!(
+            common_geometry_candidates_between(&d1_inner, 19, 26),
+            [(2, 12)]
+        );
+
+        let d0_outer = [0xc5, 0x40, 0x70, 0x18, 0x48, 0x00, 0x31, 0x45];
+        assert_eq!(common_geometry_at(&d0_outer, 24), Some((2, 10)));
+        assert_eq!(
+            common_geometry_candidates_between(&d0_outer, 18, 25),
+            [(2, 10)]
+        );
+    }
+
+    #[test]
+    fn alternate_runtime_rejects_truncated_and_corrupt_payload() {
+        let Some(payload) = extension_payload_from_env(D0_CORPUS_PATH_ENV, 187) else {
+            eprintln!("skipping: alternate-extension corpus not present");
+            return;
+        };
+        let layout = alternate_layout(&payload).expect("valid corpus layout");
+        let mut decoder = XllDecoder::new();
+        decoder
+            .try_decode_alternate_x_extension_audio(&payload)
+            .expect("decode complete alternate payload");
+        assert_eq!(decoder.x_output.len(), 5);
+        assert!(
+            decoder
+                .x_output
+                .iter()
+                .all(|channel| channel.len() == XLL_X_ALT_FRAME_SAMPLES)
+        );
+
+        let required_bytes = decoder.x_bits_consumed.div_ceil(8);
+        let tail_start = required_bytes.saturating_sub(64);
+        for length in (0..96).chain(tail_start..required_bytes) {
+            let mut decoder = XllDecoder::new();
+            assert!(
+                decoder
+                    .try_decode_alternate_x_extension_audio(&payload[..length])
+                    .is_err(),
+                "accepted truncated alternate payload at {length} bytes"
+            );
+            assert!(decoder.x_output.is_empty());
+        }
+
+        for byte_offset in [
+            48,
+            layout.headers[0].offset,
+            layout.headers[0].offset + layout.headers[0].size,
+            layout.headers[1].offset,
+            layout.headers[1].offset + layout.headers[1].size,
+        ] {
+            let mut corrupt = payload.clone();
+            corrupt[byte_offset] ^= 1;
+            let mut decoder = XllDecoder::new();
+            assert!(
+                decoder
+                    .try_decode_alternate_x_extension_audio(&corrupt)
+                    .is_err()
+            );
+            assert!(decoder.x_output.is_empty());
+        }
+    }
+
+    fn direct_single_segment_candidates(
+        payload: &[u8],
+        header_offset: usize,
+        boundary: usize,
+        expected_channels: usize,
+    ) -> Vec<(usize, bool, u32, usize, usize)> {
+        let mut candidates = Vec::new();
+        for seg_size_nbits in 4usize..=20 {
+            for scalable_lsbs in [false, true] {
+                for band_crc_present in 0u32..=2 {
+                    for trailing_bytes in 0usize..=16 {
+                        let Some(band_end) = boundary.checked_sub(trailing_bytes) else {
+                            continue;
+                        };
+                        if band_end <= header_offset {
+                            continue;
+                        }
+                        let mut decoder = XllDecoder::new();
+                        decoder.frame_size = payload.len();
+                        decoder.nchsets = 1;
+                        decoder.nactivechsets = 1;
+                        decoder.nframesegs = 1;
+                        decoder.nsegsamples = 512;
+                        decoder.nsegsamples_log2 = 9;
+                        decoder.nframesamples = 512;
+                        decoder.seg_size_nbits = seg_size_nbits;
+                        decoder.band_crc_present = band_crc_present;
+                        decoder.scalable_lsbs = scalable_lsbs;
+
+                        let mut bits = BitReader::with_offset(payload, header_offset * 8);
+                        let mut channel_set = XllChSet::default();
+                        if decoder
+                            .chs_parse_header(&mut bits, &mut channel_set, true, true)
+                            .is_err()
+                            || channel_set.nchannels != expected_channels
+                        {
+                            continue;
+                        }
+                        channel_set.band.msb =
+                            vec![vec![0i32; decoder.nframesamples]; expected_channels];
+                        channel_set.band.lsb = if channel_set.band.lsb_section_size != 0 {
+                            vec![vec![0i32; decoder.nframesamples]; expected_channels]
+                        } else {
+                            Vec::new()
+                        };
+                        decoder.chset.push(channel_set);
+                        if decoder
+                            .chs_parse_band_data(&mut bits, 0, 0, band_end * 8)
+                            .is_err()
+                            || bits.position() > band_end * 8
+                        {
+                            continue;
+                        }
+                        let trailing_bits = band_end * 8 - bits.position();
+                        if trailing_bits > 32 {
+                            continue;
+                        }
+                        candidates.push((
+                            seg_size_nbits,
+                            scalable_lsbs,
+                            band_crc_present,
+                            trailing_bytes,
+                            trailing_bits,
+                        ));
+                    }
+                }
+            }
+        }
+        candidates
+    }
+
+    fn immediate_navi_candidates(
+        payload: &[u8],
+        header_offset: usize,
+        header_size: usize,
+        boundary: usize,
+        max_trailer: usize,
+        expected_geometry: Option<(usize, usize)>,
+    ) -> Vec<(usize, usize, usize, Vec<usize>)> {
+        let mut candidates = Vec::new();
+        let Some(navi_start) = header_offset.checked_add(header_size) else {
+            return candidates;
+        };
+        if navi_start > boundary || boundary > payload.len() {
+            return candidates;
+        }
+        for segments in 1usize..=8 {
+            for size_bits in 4usize..=20 {
+                if expected_geometry.is_some_and(|geometry| geometry != (segments, size_bits)) {
+                    continue;
+                }
+                let navi_size = (segments * size_bits).div_ceil(8) + 2;
+                let Some(navi_end) = navi_start.checked_add(navi_size) else {
+                    continue;
+                };
+                if navi_end > boundary || crc16_ccitt(&payload[navi_start..navi_end]) != 0 {
+                    continue;
+                }
+                let mut bits = BitReader::with_offset(payload, navi_start * 8);
+                let mut sizes = Vec::with_capacity(segments);
+                let mut audio_bytes = 0usize;
+                for _ in 0..segments {
+                    let Ok(size) = rb(&mut bits, size_bits) else {
+                        sizes.clear();
+                        continue;
+                    };
+                    let size = size as usize + 1;
+                    audio_bytes += size;
+                    sizes.push(size);
+                }
+                let Some(audio_end) = navi_end.checked_add(audio_bytes) else {
+                    continue;
+                };
+                if sizes.len() == segments
+                    && audio_end <= boundary
+                    && boundary - audio_end <= max_trailer
+                {
+                    candidates.push((segments, size_bits, boundary - audio_end, sizes));
+                }
+            }
+        }
+        candidates
+    }
+
+    #[derive(Debug)]
+    struct DecodedChannelSetCandidate {
+        segments: usize,
+        navigation_size_bits: usize,
+        header_size_bits: usize,
+        channel_mask_bits: usize,
+        channel_mask: u32,
+        scalable_lsbs: bool,
+        band_crc_present: u32,
+        navigation: Vec<usize>,
+        trailing_bits: Vec<usize>,
+        pcm_bit_res: usize,
+        header_tail_bits: usize,
+        peaks: Vec<i32>,
+        checksums: Vec<i64>,
+    }
+
+    fn decode_channel_set_candidates(
+        payload: &[u8],
+        header_offset: usize,
+        header_size: usize,
+        boundary: usize,
+        expected_channels: usize,
+        one_to_one: bool,
+        is_primary: bool,
+        allow_unmapped: bool,
+        frame_samples: usize,
+        alternate_prefix_bits: Option<usize>,
+        common_from_navigation: bool,
+        expected_geometry: Option<(usize, usize)>,
+    ) -> Vec<DecodedChannelSetCandidate> {
+        let mut candidates = Vec::new();
+        // The first D1 channel set leaves 14--18 bytes between the final
+        // NAVI-sized band and the following channel-set header. Keep this
+        // corpus probe wide enough to cover that wrapper-owned interstitial
+        // data; the NAVI itself must still pass CRC16 before decoding.
+        for (segments, navigation_size_bits, _, navigation) in immediate_navi_candidates(
+            payload,
+            header_offset,
+            header_size,
+            boundary,
+            20,
+            expected_geometry,
+        ) {
+            if !segments.is_power_of_two() || frame_samples % segments != 0 {
+                continue;
+            }
+            let segment_samples = frame_samples / segments;
+            if !segment_samples.is_power_of_two() {
+                continue;
+            }
+            let navi_start = header_offset + header_size;
+            let navi_size = (segments * navigation_size_bits).div_ceil(8) + 2;
+            let data_start = navi_start + navi_size;
+
+            let max_channel_mask_bits = if one_to_one && alternate_prefix_bits.is_none() {
+                32
+            } else {
+                1
+            };
+            for channel_mask_bits in 1usize..=max_channel_mask_bits {
+                let header_size_bits = if common_from_navigation {
+                    navigation_size_bits..=navigation_size_bits
+                } else {
+                    4usize..=20
+                };
+                for header_size_bits in header_size_bits {
+                    for scalable_lsbs in [false, true] {
+                        if common_from_navigation && scalable_lsbs {
+                            continue;
+                        }
+                        let max_band_crc = if common_from_navigation { 0 } else { 3 };
+                        for band_crc_present in 0u32..=max_band_crc {
+                            let mut decoder = XllDecoder::new();
+                            decoder.frame_size = payload.len();
+                            decoder.nchsets = 1;
+                            decoder.nactivechsets = 1;
+                            decoder.nframesegs = segments;
+                            decoder.nsegsamples = segment_samples;
+                            decoder.nsegsamples_log2 = segment_samples.ilog2() as usize;
+                            decoder.nframesamples = frame_samples;
+                            decoder.seg_size_nbits = header_size_bits;
+                            decoder.band_crc_present = band_crc_present;
+                            decoder.scalable_lsbs = scalable_lsbs;
+                            decoder.ch_mask_nbits = channel_mask_bits;
+                            decoder.one_to_one = one_to_one;
+
+                            let mut bits = BitReader::with_offset(payload, header_offset * 8);
+                            let mut channel_set = XllChSet::default();
+                            let header_result = match alternate_prefix_bits {
+                                Some(prefix_bits) => decoder.chs_parse_header_with_mapping(
+                                    &mut bits,
+                                    &mut channel_set,
+                                    ChsMappingSyntax::AlternatePrefix(prefix_bits),
+                                ),
+                                None => decoder.chs_parse_header(
+                                    &mut bits,
+                                    &mut channel_set,
+                                    is_primary,
+                                    allow_unmapped,
+                                ),
+                            };
+                            if header_result.is_err()
+                                || bits.position() != navi_start * 8
+                                || channel_set.nchannels != expected_channels
+                                || channel_set.residual_encode != (1 << expected_channels) - 1
+                            {
+                                continue;
+                            }
+                            channel_set.band.msb =
+                                vec![vec![0i32; frame_samples]; expected_channels];
+                            channel_set.band.lsb = if channel_set.band.lsb_section_size != 0 {
+                                vec![vec![0i32; frame_samples]; expected_channels]
+                            } else {
+                                Vec::new()
+                            };
+                            let channel_mask = channel_set.ch_mask;
+                            let pcm_bit_res = channel_set.pcm_bit_res;
+                            let header_tail_bits = channel_set.header_tail_bits;
+                            decoder.chset.push(channel_set);
+                            if seek(&mut bits, data_start * 8).is_err() {
+                                continue;
+                            }
+
+                            let mut band_end = bits.position();
+                            let mut trailing_bits = Vec::with_capacity(segments);
+                            let mut valid = true;
+                            for (segment, &segment_bytes) in navigation.iter().enumerate() {
+                                let Some(next_band_end) = band_end.checked_add(segment_bytes * 8)
+                                else {
+                                    valid = false;
+                                    break;
+                                };
+                                if decoder
+                                    .chs_parse_band_data(&mut bits, 0, segment, next_band_end)
+                                    .is_err()
+                                    || bits.position() > next_band_end
+                                {
+                                    valid = false;
+                                    break;
+                                }
+                                let unused = next_band_end - bits.position();
+                                if unused > 32 || seek(&mut bits, next_band_end).is_err() {
+                                    valid = false;
+                                    break;
+                                }
+                                trailing_bits.push(unused);
+                                band_end = next_band_end;
+                            }
+                            if !valid {
+                                continue;
+                            }
+
+                            decoder.chs_filter_band_data(0);
+                            if scalable_lsbs {
+                                decoder.chs_assemble_msbs_lsbs(0);
+                            }
+                            let peaks = decoder.chset[0]
+                                .band
+                                .msb
+                                .iter()
+                                .map(|channel| {
+                                    channel
+                                        .iter()
+                                        .map(|&sample| sample.saturating_abs())
+                                        .max()
+                                        .unwrap_or_default()
+                                })
+                                .collect();
+                            let checksums = decoder.chset[0]
+                                .band
+                                .msb
+                                .iter()
+                                .map(|channel| channel.iter().map(|&sample| sample as i64).sum())
+                                .collect();
+                            candidates.push(DecodedChannelSetCandidate {
+                                segments,
+                                navigation_size_bits,
+                                header_size_bits,
+                                channel_mask_bits,
+                                channel_mask,
+                                scalable_lsbs,
+                                band_crc_present,
+                                navigation: navigation.clone(),
+                                trailing_bits,
+                                pcm_bit_res,
+                                header_tail_bits,
+                                peaks,
+                                checksums,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        candidates
+    }
+
+    #[test]
+    fn alternate_first_channel_set_is_not_a_direct_xll_segment() {
+        let Some(d0) = extension_payload_from_env(D0_CORPUS_PATH_ENV, 185) else {
+            eprintln!("skipping: alternate-extension corpus not present");
+            return;
+        };
+        let Some(d1) = extension_payload_from_env(D1_CORPUS_PATH_ENV, 190) else {
+            eprintln!("skipping: alternate-extension corpus not present");
+            return;
+        };
+
+        let d0_candidates = direct_single_segment_candidates(&d0, 62, 131, 1);
+        let d1_candidates = direct_single_segment_candidates(&d1, 63, 764, 2);
+        eprintln!("D0 corpus direct-segment candidates: {d0_candidates:?}");
+        eprintln!("D1 corpus direct-segment candidates: {d1_candidates:?}");
+        assert!(d0_candidates.is_empty());
+        assert!(d1_candidates.is_empty());
+    }
+
+    #[test]
+    fn alternate_d1_terminal_quartet_has_crc_valid_xll_navigation() {
+        let Some(d1) = extension_payload_from_env(D1_CORPUS_PATH_ENV, 190) else {
+            eprintln!("skipping: alternate-extension corpus not present");
+            return;
+        };
+        let d1_active =
+            extension_payload_from_env(D1_CORPUS_PATH_ENV, 192).expect("adjacent corpus frame");
+
+        let d1_candidates = immediate_navi_candidates(&d1, 764, 16, d1.len(), 16, None);
+        let d1_active_candidates = immediate_navi_candidates(
+            &d1_active,
+            1300,
+            18,
+            d1_active.len(),
+            16,
+            None,
+        );
+        eprintln!("D1 corpus terminal-quartet NAVI: {d1_candidates:?}");
+        eprintln!(
+            "D1 corpus active terminal-quartet NAVI: {d1_active_candidates:?}"
+        );
+        assert!(!d1_candidates.is_empty());
+        assert!(!d1_active_candidates.is_empty());
+    }
+
+    #[test]
+    fn alternate_d1_terminal_quartet_reaches_xll_pcm() {
+        let Some(d1) = extension_payload_from_env(D1_CORPUS_PATH_ENV, 192) else {
+            eprintln!("skipping: alternate-extension corpus not present");
+            return;
+        };
+        let candidates = decode_channel_set_candidates(
+            &d1,
+            1300,
+            18,
+            d1.len(),
+            4,
+            true,
+            false,
+            false,
+            512,
+            Some(2),
+            true,
+            Some((2, 8)),
+        );
+        let decoded = candidates.iter().find(|candidate| {
+            candidate.segments == 2
+                && candidate.navigation_size_bits == 8
+                && candidate.header_size_bits == 8
+                && candidate.channel_mask_bits == 1
+                && candidate.channel_mask == 0
+                && !candidate.scalable_lsbs
+                && candidate.band_crc_present == 0
+                && candidate.navigation == [158, 161]
+                && candidate.trailing_bits == [4, 3]
+                && candidate.pcm_bit_res == 20
+                && candidate.header_tail_bits == 59
+                && candidate.peaks == [0, 0, 7, 8]
+                && candidate.checksums == [0, 0, 14, -43]
+        });
+        assert!(decoded.is_some(), "D1 quartet did not reach stable XLL PCM");
+    }
+
+    #[test]
+    fn alternate_d1_prefix_mode_decodes_active_channel_set_run() {
+        let Some((payloads, runtime_results)) = extension_payloads_from_env(
+            D1_CORPUS_PATH_ENV,
+            9_000,
+            64 * 1024 * 1024,
+        )
+        else {
+            eprintln!("skipping: alternate-extension corpus not present");
+            return;
+        };
+        assert!(
+            runtime_results
+                .iter()
+                .all(|result| *result == (6, true, None)),
+            "D1 runtime decoder did not produce six complete sources"
+        );
+        let mut decoded_frames = [0usize; 2];
+        let mut self_consistent_frames = [0usize; 2];
+        let mut configuration_counts =
+            std::array::from_fn::<_, 2, _>(|_| std::collections::HashMap::new());
+        let mut geometry_counts =
+            std::array::from_fn::<_, 2, _>(|_| std::collections::HashMap::new());
+        let mut second_control_candidate_counts = std::collections::HashMap::new();
+        let mut first_control_candidate_counts = std::collections::HashMap::new();
+        for payload in payloads.iter().skip(191) {
+            let Some(
+                [
+                    (first_offset, first_header_size, first_channels),
+                    (second_offset, second_header_size, second_channels),
+                ],
+            ) = alternate_d1_header_candidates(payload)
+            else {
+                continue;
+            };
+            let first_geometries = alternate_d1_first_geometries(payload);
+            *first_control_candidate_counts
+                .entry(first_geometries.len())
+                .or_insert(0usize) += 1;
+            let second_geometries = alternate_d1_second_geometries(payload, second_offset);
+            *second_control_candidate_counts
+                .entry(second_geometries.len())
+                .or_insert(0usize) += 1;
+            assert_eq!(first_geometries.len(), 1, "ambiguous D1 first control");
+            assert_eq!(second_geometries.len(), 1, "ambiguous D1 second control");
+            let channel_sets = [
+                (
+                    first_offset,
+                    first_header_size,
+                    first_channels,
+                    second_offset,
+                ),
+                (
+                    second_offset,
+                    second_header_size,
+                    second_channels,
+                    payload.len(),
+                ),
+            ];
+            for (set, (offset, header_size, channels, boundary)) in
+                channel_sets.into_iter().enumerate()
+            {
+                let mut candidates = Vec::new();
+                let expected_geometries = if set == 0 {
+                    first_geometries.clone()
+                } else {
+                    second_geometries.clone()
+                };
+                for expected_geometry in expected_geometries {
+                    candidates.extend(
+                        decode_channel_set_candidates(
+                            payload,
+                            offset,
+                            header_size,
+                            boundary,
+                            channels,
+                            false,
+                            false,
+                            false,
+                            512,
+                            Some(2),
+                            true,
+                            Some(expected_geometry),
+                        )
+                        .into_iter()
+                        .map(|candidate| (512, candidate)),
+                    );
+                }
+                if !candidates.is_empty() {
+                    decoded_frames[set] += 1;
+                }
+                if candidates.iter().any(|(_, candidate)| {
+                    candidate.header_size_bits == candidate.navigation_size_bits
+                        && !candidate.scalable_lsbs
+                        && candidate.band_crc_present == 0
+                }) {
+                    self_consistent_frames[set] += 1;
+                }
+                let geometries = candidates
+                    .iter()
+                    .map(|(_, candidate)| (candidate.segments, candidate.navigation_size_bits))
+                    .collect::<std::collections::HashSet<_>>();
+                for geometry in geometries {
+                    *geometry_counts[set].entry(geometry).or_insert(0usize) += 1;
+                }
+                let configurations = candidates
+                    .iter()
+                    .map(|(frame_samples, candidate)| {
+                        (
+                            *frame_samples,
+                            candidate.segments,
+                            candidate.navigation_size_bits,
+                            candidate.header_size_bits,
+                            candidate.scalable_lsbs,
+                            candidate.band_crc_present,
+                        )
+                    })
+                    .collect::<std::collections::HashSet<_>>();
+                for configuration in configurations {
+                    *configuration_counts[set]
+                        .entry(configuration)
+                        .or_insert(0usize) += 1;
+                }
+            }
+        }
+        for (set, counts) in configuration_counts.into_iter().enumerate() {
+            let mut counts = counts.into_iter().collect::<Vec<_>>();
+            counts.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+            let mut geometries = std::mem::take(&mut geometry_counts[set])
+                .into_iter()
+                .collect::<Vec<_>>();
+            geometries.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+            eprintln!(
+                "D1 alternate-prefix set {set}: {}/{} active-run frames decoded, {} self-consistent; geometries: {:?}; top configurations: {:?}",
+                decoded_frames[set],
+                payloads.len().saturating_sub(191),
+                self_consistent_frames[set],
+                &geometries[..geometries.len().min(8)],
+                &counts[..counts.len().min(12)]
+            );
+            assert_eq!(
+                self_consistent_frames[set],
+                payloads.len().saturating_sub(191),
+                "not every active D1 channel set decoded"
+            );
+        }
+        eprintln!("D1 first-control geometry candidate counts: {first_control_candidate_counts:?}");
+        eprintln!(
+            "D1 second-control geometry candidate counts: {second_control_candidate_counts:?}"
+        );
+    }
+
+    #[test]
+    fn alternate_d1_c3_mode_decodes_both_channel_sets() {
+        let Some(payload) = extension_payload_from_env(D1_CORPUS_PATH_ENV, 16_277) else {
+            eprintln!("skipping: alternate-extension corpus not present");
+            return;
+        };
+        assert_eq!(payload.get(55), Some(&0xc3));
+        let layout = alternate_layout(&payload).expect("valid D1 c3 layout");
+        assert_eq!(layout.headers.map(|header| header.channels), [2, 4]);
+
+        let mut decoder = XllDecoder::new();
+        decoder
+            .try_decode_alternate_x_extension_audio(&payload)
+            .expect("decode complete D1 c3 payload");
+        assert_eq!(decoder.x_output.len(), 6);
+        assert!(
+            decoder
+                .x_output
+                .iter()
+                .all(|samples| samples.len() == XLL_X_ALT_FRAME_SAMPLES)
+        );
+    }
+
+    #[test]
+    fn alternate_d0_prefix_mode_decodes_active_channel_set_run() {
+        let Some((payloads, runtime_results)) = extension_payloads_from_env(
+            D0_CORPUS_PATH_ENV,
+            9_000,
+            64 * 1024 * 1024,
+        )
+        else {
+            eprintln!("skipping: alternate-extension corpus not present");
+            return;
+        };
+        assert!(
+            payloads
+                .iter()
+                .zip(&runtime_results)
+                .filter(|(payload, _)| payload.len() > 116)
+                .all(|(_, result)| *result == (5, true, None)),
+            "D0 runtime decoder did not produce five complete sources"
+        );
+        let mut active_frames = 0usize;
+        let mut decoded_frames = [0usize; 2];
+        let mut self_consistent_frames = [0usize; 2];
+        let mut configuration_counts =
+            std::array::from_fn::<_, 2, _>(|_| std::collections::HashMap::new());
+        let mut geometry_counts =
+            std::array::from_fn::<_, 2, _>(|_| std::collections::HashMap::new());
+        let mut control_candidate_counts =
+            std::array::from_fn::<_, 2, _>(|_| std::collections::HashMap::new());
+        for payload in payloads.iter().filter(|payload| payload.len() > 116) {
+            active_frames += 1;
+            let Some(
+                [
+                    (first_offset, first_header_size, first_channels),
+                    (second_offset, second_header_size, second_channels),
+                ],
+            ) = alternate_d0_header_candidates(payload)
+            else {
+                continue;
+            };
+            let channel_sets = [
+                (
+                    first_offset,
+                    first_header_size,
+                    first_channels,
+                    second_offset,
+                ),
+                (
+                    second_offset,
+                    second_header_size,
+                    second_channels,
+                    payload.len(),
+                ),
+            ];
+            for (set, (offset, header_size, channels, boundary)) in
+                channel_sets.into_iter().enumerate()
+            {
+                let control = if set == 0 {
+                    payload.get(54..first_offset)
+                } else {
+                    alternate_second_control(payload, second_offset)
+                };
+                let expected_geometries = control
+                    .map(|control| common_geometry_candidates_between(control, 18, 25))
+                    .unwrap_or_default();
+                *control_candidate_counts[set]
+                    .entry(expected_geometries.len())
+                    .or_insert(0usize) += 1;
+                assert_eq!(
+                    expected_geometries.len(),
+                    1,
+                    "ambiguous D0 channel-set control"
+                );
+                let mut candidates = Vec::new();
+                for expected_geometry in expected_geometries {
+                    candidates.extend(decode_channel_set_candidates(
+                        payload,
+                        offset,
+                        header_size,
+                        boundary,
+                        channels,
+                        false,
+                        false,
+                        false,
+                        512,
+                        Some(2),
+                        true,
+                        Some(expected_geometry),
+                    ));
+                }
+                if !candidates.is_empty() {
+                    decoded_frames[set] += 1;
+                }
+                if candidates.iter().any(|candidate| {
+                    candidate.header_size_bits == candidate.navigation_size_bits
+                        && !candidate.scalable_lsbs
+                        && candidate.band_crc_present == 0
+                }) {
+                    self_consistent_frames[set] += 1;
+                }
+                let geometries = candidates
+                    .iter()
+                    .map(|candidate| (candidate.segments, candidate.navigation_size_bits))
+                    .collect::<std::collections::HashSet<_>>();
+                for geometry in geometries {
+                    *geometry_counts[set].entry(geometry).or_insert(0usize) += 1;
+                }
+                let configurations = candidates
+                    .iter()
+                    .map(|candidate| {
+                        (
+                            candidate.segments,
+                            candidate.navigation_size_bits,
+                            candidate.header_size_bits,
+                            candidate.scalable_lsbs,
+                            candidate.band_crc_present,
+                        )
+                    })
+                    .collect::<std::collections::HashSet<_>>();
+                for configuration in configurations {
+                    *configuration_counts[set]
+                        .entry(configuration)
+                        .or_insert(0usize) += 1;
+                }
+            }
+        }
+        for (set, counts) in configuration_counts.into_iter().enumerate() {
+            let mut counts = counts.into_iter().collect::<Vec<_>>();
+            counts.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+            let mut geometries = std::mem::take(&mut geometry_counts[set])
+                .into_iter()
+                .collect::<Vec<_>>();
+            geometries.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+            eprintln!(
+                "D0 alternate-prefix set {set}: {}/{} active frames decoded, {} self-consistent; geometries: {:?}; top configurations: {:?}",
+                decoded_frames[set],
+                active_frames,
+                self_consistent_frames[set],
+                &geometries[..geometries.len().min(8)],
+                &counts[..counts.len().min(12)]
+            );
+            eprintln!(
+                "D0 alternate-prefix set {set} control geometry candidate counts: {:?}",
+                control_candidate_counts[set]
+            );
+            assert_eq!(
+                self_consistent_frames[set], active_frames,
+                "not every active D0 channel set decoded"
+            );
+        }
     }
 }

--- a/dca/src/hd.rs
+++ b/dca/src/hd.rs
@@ -44,13 +44,13 @@ pub struct HdFrame {
     pub x_payload: Vec<u8>,
     /// Byte offset of `x_payload` within the XLL frame.
     pub x_payload_offset: usize,
-    /// Four decoded DTS:X extension waveforms. The XLL channel-set header does
-    /// not assign these channels to speakers, so they are deliberately not
-    /// mixed into `samples` or `output_mask` yet.
+    /// Decoded, speaker-unmapped extension waveforms. The standard profile has
+    /// four; alternate profiles can carry five or six across two channel sets.
+    /// They are deliberately not mixed into `samples` or `output_mask` here.
     pub x_samples: Vec<Vec<f32>>,
     pub x_pcm_bit_res: usize,
-    /// Bit position reached after decoding the four extension waveforms,
-    /// relative to `x_payload`.
+    /// Bit position reached after decoding the extension waveforms, relative
+    /// to `x_payload`.
     pub x_bits_consumed: usize,
     /// Diagnostic failure kind from the optional extension decode
     /// (allocation-free). A failure here never invalidates the lossless 7.1
@@ -287,36 +287,46 @@ mod tests {
 
     #[test]
     fn xll_7_1_matches_ffmpeg_lossless() {
-        // Ex Machina (2014): 24-bit DTS-HD MA 7.1.
-        check_xll_lossless(
-            "/mnt/local/SSD_A-CT4000/DTS:X-Dumps/Ex.Machina.2014.dtsx.eng.dts",
-            "/home/user/dev/spatial-renderer/dumps/dtsx_ref8.f32",
-            8,
-        );
+        let Ok(dump) = std::env::var("HARLETTY_DTSX_STANDARD_CORPUS") else {
+            eprintln!("skipping: HARLETTY_DTSX_STANDARD_CORPUS is not set");
+            return;
+        };
+        let Ok(reference) = std::env::var("HARLETTY_DTSX_STANDARD_REFERENCE") else {
+            eprintln!("skipping: HARLETTY_DTSX_STANDARD_REFERENCE is not set");
+            return;
+        };
+        check_xll_lossless(&dump, &reference, 8);
     }
 
     #[test]
     fn xll_5_1_16bit_matches_ffmpeg_lossless() {
-        // Dark Crystal (1982): 16-bit DTS-HD MA 5.1. Regression guard for the
-        // 16-bit-storage output-scale bug (the bed was ~48 dB / 256x too quiet).
-        check_xll_lossless(
-            "/home/user/dev/spatial-renderer/dumps/darkcrystal_dts51_16b.dts",
-            "/home/user/dev/spatial-renderer/dumps/darkcrystal_ref6.f32",
-            6,
-        );
+        // Regression guard for the 16-bit-storage output-scale bug (the bed
+        // was ~48 dB / 256x too quiet).
+        let Ok(dump) = std::env::var("HARLETTY_DTSHD_16BIT_CORPUS") else {
+            eprintln!("skipping: HARLETTY_DTSHD_16BIT_CORPUS is not set");
+            return;
+        };
+        let Ok(reference) = std::env::var("HARLETTY_DTSHD_16BIT_REFERENCE") else {
+            eprintln!("skipping: HARLETTY_DTSHD_16BIT_REFERENCE is not set");
+            return;
+        };
+        check_xll_lossless(&dump, &reference, 6);
     }
 
     #[test]
     fn xll_x_decodes_four_unmapped_waveforms() {
         use std::io::Read;
 
-        const DUMP: &str = "/mnt/local/SSD_A-CT4000/DTS:X-Dumps/Ex.Machina.2014.dtsx.eng.dts";
-        if !std::path::Path::new(DUMP).exists() {
-            eprintln!("skipping: spatial-layer corpus not present ({DUMP})");
+        let Ok(dump) = std::env::var("HARLETTY_DTSX_STANDARD_CORPUS") else {
+            eprintln!("skipping: HARLETTY_DTSX_STANDARD_CORPUS is not set");
+            return;
+        };
+        if !std::path::Path::new(&dump).is_file() {
+            eprintln!("skipping: configured spatial-layer corpus is not readable");
             return;
         }
         let mut bytes = Vec::new();
-        std::fs::File::open(DUMP)
+        std::fs::File::open(dump)
             .unwrap()
             .take(2 * 1024 * 1024)
             .read_to_end(&mut bytes)

--- a/dca/tests/core_regression.rs
+++ b/dca/tests/core_regression.rs
@@ -5,21 +5,19 @@
 // derived from copyrighted content), so the test SKIPS when the files are
 // absent. Regenerate locally with:
 //
-//   SRC=<ExMachina.mkv>
+//   SRC=<input.mkv>
 //   ffmpeg -v error -y -i "$SRC" -map 0:4 -t 8 -c:a copy -f dts \
 //       dumps/dts51_core.dts
 //   ffmpeg -v error -y -i "$SRC" -map 0:4 -t 8 -f f32le -ac 6 \
 //       dumps/dts51_ref.f32
+//   export HARLETTY_DTS_CORE_CORPUS="$PWD/dumps/dts51_core.dts"
+//   export HARLETTY_DTS_CORE_REFERENCE="$PWD/dumps/dts51_ref.f32"
 //
-// (track 0:4 is Ex Machina's plain DTS 5.1 track — ffmpeg decodes it core-only,
+// (select a plain DTS 5.1 track that ffmpeg decodes core-only,
 // so it validates the core decoder without the XLL extension.)
-
-use std::path::Path;
 
 use dca::{BedChannel, Extractor, PcmDecoder};
 
-const DTS: &str = "/home/user/dev/spatial-renderer/dumps/dts51_core.dts";
-const REF: &str = "/home/user/dev/spatial-renderer/dumps/dts51_ref.f32";
 const CHANNELS: usize = 6;
 const RMSE_GATE: f64 = 5.0e-3;
 
@@ -36,12 +34,20 @@ fn wav_index(b: BedChannel) -> usize {
 
 #[test]
 fn dts_core_5_1_matches_ffmpeg() {
-    if !Path::new(DTS).exists() || !Path::new(REF).exists() {
-        eprintln!("skipping: DTS corpus not present ({DTS})");
+    let Ok(dts) = std::env::var("HARLETTY_DTS_CORE_CORPUS") else {
+        eprintln!("skipping: HARLETTY_DTS_CORE_CORPUS is not set");
+        return;
+    };
+    let Ok(reference) = std::env::var("HARLETTY_DTS_CORE_REFERENCE") else {
+        eprintln!("skipping: HARLETTY_DTS_CORE_REFERENCE is not set");
+        return;
+    };
+    if !std::path::Path::new(&dts).is_file() || !std::path::Path::new(&reference).is_file() {
+        eprintln!("skipping: configured DTS core corpus is not readable");
         return;
     }
 
-    let bytes = std::fs::read(DTS).unwrap();
+    let bytes = std::fs::read(dts).unwrap();
     let mut ex = Extractor::default();
     ex.push_bytes(&bytes);
     let mut dec = PcmDecoder::new();
@@ -68,7 +74,7 @@ fn dts_core_5_1_matches_ffmpeg() {
         }
     }
 
-    let rbytes = std::fs::read(REF).unwrap();
+    let rbytes = std::fs::read(reference).unwrap();
     let reference: Vec<f32> = rbytes
         .chunks_exact(4)
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))

--- a/docs/dtsx-d1-wide-audition.md
+++ b/docs/dtsx-d1-wide-audition.md
@@ -1,0 +1,777 @@
+# Alternate-profile experimental presentations
+
+This note records the evidence and reproduction steps for the experimental D0
+height and D1 wide-channel presentations. They are research, not normative
+format claims. Harletty now selects the standard four-source or inferred
+alternate presentation automatically from the decoded extension profile.
+
+## Corpus update
+
+The tracks added alongside and after the D0/D1 samples were probed over their
+first 128 MiB with `xll_corpus_probe`. All use the standard four-source XLL-X
+profile and decode without extension errors:
+
+| Track | Sources | PCM | Initial source activity |
+| --- | ---: | ---: | --- |
+| *standard-01* | 4 | 24-bit | all active, about 99% non-zero |
+| *standard-02* | 4 | 24-bit | all active, about 94–95% non-zero |
+| *standard-03* | 4 | 16-bit | all active, about 87% non-zero |
+| *standard-04* | 4 | 16-bit | all active, about 89% non-zero |
+| *standard-05* | 4 | 24-bit | all active, about 98% non-zero |
+| *standard-06* | 4 | 24-bit | all active, about 99% non-zero |
+| *standard-07* | 4 | 18-bit | all active, about 99% non-zero |
+| *standard-08* | 4 | 18-bit | X0/X1/X3 about 90%; X2 about 57% non-zero |
+| *standard-09* | 4 | 18-bit | X0/X1 about 80%; X2/X3 about 89% non-zero |
+| *standard-10* | 4 | 18-bit | X0/X1 about 82%; X2 about 79%; X3 about 91% non-zero |
+| *standard-11* | 4 | 18-bit | X0/X1/X2 about 87–89%; X3 about 93% non-zero |
+| *standard-12* | 4 | 18-bit | X0/X1/X2 about 76–77%; X3 about 95% non-zero |
+| *standard-13* | 4 | 18-bit | all active, about 89–93% non-zero |
+| *standard-14* | 4 | 18-bit | X0/X1 about 44%; X2 about 88%; X3 about 94% non-zero |
+| *standard-15* | 4 | 24-bit | all active, about 99% non-zero |
+| *standard-16* | 4 | 24-bit | X0/X1 fully active; X2/X3 silent in the opening range |
+| *standard-17* | 4 | 24-bit | all active, about 79% non-zero |
+| *standard-18* | 4 | 24-bit | all active, about 99% non-zero |
+| *standard-19* | 4 | 24-bit | all active, more than 99% non-zero |
+| *standard-20* | 4 | 24-bit | all active, 100% non-zero |
+| *standard-control-A* | 4 | 24-bit | X0/X1 about 72–73%; X2/X3 about 63% non-zero |
+| *standard-control-B* | 4 | 24-bit | X0/X1 about 89%; X2/X3 about 71% non-zero |
+| *standard-control-C* | 4 | 24-bit | all active, more than 99% non-zero |
+
+They strengthen the ordinary 7.1.4 regression corpus but add no new alternate
+layout. *D0 corpus A* and *D0 corpus B* provide two independent
+D0/five-source programmes. *D1 corpus B* is a second D1/six-source stream,
+with a longer CRC-delimited prefix than *D1 corpus A*.
+
+The eight related standard-07 through standard-14 tracks also retain the
+standard 22-byte prefix. The first four were scanned over 64 MiB each and the
+remaining four over 128 MiB, for 152,397 decoded extension frames in total:
+
+```text
+02 00 08 50 28 4b fa 71 0d 62 02 fa 02 dc 13 71 0d c8 37 3c f1 02
+```
+
+The three controlled clips retain that exact prefix over their complete
+elementary streams (17,642 frames total). Their source extractions are
+bit-identical to the streams in the downloaded containers. Despite the visible
+and audible moving material, neither *standard-control-B* nor *standard-control-C*
+introduces an alternate layout or a fifth extension waveform.
+
+The five later disk-inventory additions were sampled over 100–128 MiB near the
+start, middle and end of each programme. Every sampled frame remains a standard
+four-source, 24-bit XLL-X presentation with no extension decode error. Each
+range also retains the same 22-byte prefix shown above, locates its only
+four-channel XLL set at byte 22 and validates that channel-set header's
+CRC16-CCITT. They add fixed 7.1.4 programme material, not another D0/D1 layout
+or an encoded fifth object source.
+
+The fixed-height pan analysis nevertheless found useful listening controls:
+
+- *standard-17* has strongly coherent single-corner material around `00:36–00:40`,
+  moving between rear-left and the front-left/front-right height outputs.
+- *standard-20* has a front-height left-to-right transition around
+  `01:26:13–01:26:29`.
+- *standard-18* opens with an almost static four-height image whose compatible-bed
+  links reproduce the expected `+0.7071` fold on all four corners.
+- the sampled action ranges from *standard-16*, *standard-19* and
+  *standard-18* were predominantly diffuse at the conservative rank-one gate;
+  absence of a selected window is not proof that the full programme contains
+  no rendered motion.
+
+The extracted streams remain local corpus artifacts and are intentionally not
+identified by source title, path or content hash in this repository.
+
+## Second D0 encode control
+
+An alternate *D0 corpus A* encode is a second extraction of the same D0
+programme, not an independent five-source title. Its first 128 MiB contain
+15,797 D0 frames, all with five 24-bit sources and no decode error. X0 is
+nearly silent in that opening range (3.4% non-zero), while X1–X4 are each
+about 87% non-zero, matching the qualitative signature of the first dump.
+
+Both dumps retain the same layout over 20,000 frames:
+
+```text
+(profile D0, first set 1 channel/bits 0, second set 4 channels/bits 0)
+```
+
+Their fixed D0 prefixes are byte-identical and their only post-audio trailers
+are two to five zero bytes. A 16 MiB paired comparison aligns the alternate dump
+94 frames before the first dump; all 2,623 overlapping payloads, EXSS reserved
+words and decoded source RMS envelopes then match exactly (`r = 1.0`). The
+different whole-stream MD5 therefore reflects trim/framing, not a different
+spatial presentation.
+
+## D0 fixed-height working map
+
+The complete *D0 corpus B* stream is a second independent D0 programme:
+557,057 frames, five 24-bit sources per frame and no extension decode error.
+It has the same fixed D0 prefix and `1 + 4` channel-set structure as
+*D0 corpus A*.
+
+Across both programmes, X1–X4 retain the front-left, front-right, rear-left,
+rear-right top-quartet signature. X0 is sparse and front-centred. Its strongest
+global relations are with X1/X2 rather than X3/X4, and after controlling for the
+top quartet its compatible-bed relation remains concentrated in C/L/R rather
+than the rear channels. The current fixed working map is therefore:
+
+```text
+X0 = TFC
+X1 = TFL    X2 = TFR    X3 = TBL    X4 = TBR
+```
+
+`TFC` is the standard abbreviation for Top Front Center. This assignment is
+still an inference from programme material, not decoded speaker metadata.
+
+The apparent explained variance does not establish a fold coefficient. A
+whole-programme regression of X0 on all four tops explains about 32.2% of X0
+in *D0 corpus B* but only 11.4% in *D0 corpus A*. This is the fraction of X0
+predicted by correlated programme content, not the fraction of X0 embedded in
+TFL/TFR. Windowed X0-to-TFL/TFR fits confirm the distinction: even
+near-perfect-correlation windows produce gains ranging from nearly zero to
+multiple units, with different left/right gains and no common plateau across
+the two titles. Removing the top quartet from the compatible 7.1 bed also
+leaves only weak X0-to-bed partial correlations.
+
+Consequently the D0 presentation emits the five sources as fixed labeled
+channels and applies only a conservative partial subtraction: `0.5 * X0` from
+C and `0.707107 * X1..X4` from their corresponding compatible-bed channels.
+These values are experimental controls, not decoded metadata or a
+profile-exact D0 fold matrix. The partial subtraction deliberately leaves
+some material that may have been authored in both the lower and top feeds.
+
+## D1 system-identification result
+
+The compatible bed and the six decoded D1 sources were analyzed in 4096-sample
+windows. Windows were retained only when the left/right three-source predictor
+matrix had condition number at most 3 and all three corresponding bed channels
+had `R² >= 0.999`.
+
+Between 50 and 66 minutes of *D1 corpus A*, 66 left and 48 right windows
+passed the joint gate. The repeated X2/X3 contribution was:
+
+```text
+X2 -> L  ~= 1.183    X2 -> Ls ~= 0.209    X2 -> Lb ~= 0
+X3 -> R  ~= 1.183    X3 -> Rs ~= 0.209    X3 -> Rb ~= 0
+```
+
+The relation is sample-aligned and well described by scalar gains. No delay or
+frequency-dependent decorrelation filter was observed. The front-heavy,
+left/right-symmetric fold supports treating X2/X3 as `Lw/Rw` candidates.
+
+Program material alone cannot prove the exact coefficients: native bed content
+can be correlated with the extension sources and produces other apparently
+exact local matrices. *D1 corpus B* now supplies a second D1 stream, but the
+conditioned system-identification result above has not yet been reproduced on
+it. Cross-validation there, a synthetic encode, or native 9.1.4 output from a
+reference decoder is still required before this becomes a production
+presentation.
+
+## Extended D1 and D3 profiles
+
+The complete *D1 corpus B* elementary stream contains 6,392 D1 frames.
+The older parser assumed that every D1 outer suffix started after a 49-byte
+prefix. *D1 corpus B* instead has a 54-byte prefix:
+
+- the CRC16-CCITT over the first 54 bytes is zero;
+- the standard outer suffix follows immediately;
+- the outer control starts with `b2`;
+- the two CRC-valid XLL channel sets still contain `2 + 4` sources.
+
+The decoder now finds a unique outer suffix within a bounded 96-byte window and
+accepts it only when the preceding prefix has a valid CRC. Both known D1 prefix
+lengths therefore use the same relative control and channel-set parser.
+*D1 corpus B* decodes all 6,392 frames into six 24-bit sources without an
+extension error, clipped value or non-finite sample.
+
+*D3 corpus A* introduces syncword `f1 40 00 d3`, present once
+in every one of its 7,674 frames. D3 uses the same CRC-delimited outer and
+inner structure but carries two four-channel sets. All 7,674 frames decode as
+eight 24-bit sources without an extension error. The bridge exposes all eight
+unchanged sources as named objects. Their static positions are an inferred
+listening layout, not decoded metadata.
+
+The complete D3 source-to-bed correlations, measured over 3,929,088 aligned
+samples, show the strongest sample-level relations:
+
+| Source | Bed channel | Pearson `r` |
+| --- | --- | ---: |
+| X0 | Lb | 0.100 |
+| X1 | Rb | 0.095 |
+| X2 | Lb | 0.278 |
+| X3 | Rb | 0.269 |
+| X4 | Ls | 0.169 |
+| X5 | Rs | 0.165 |
+| X6 | Lb | 0.673 |
+| X7 | Rb | 0.683 |
+
+X6/X7 are strongly left/right-associated with the rear bed pair. X2/X3 show
+the same pairing more weakly; X4/X5 are broad left/right components spread
+across fronts, sides and backs. No extension source has a meaningful
+sample-level relation with LFE. Frame-RMS correlations for X6/X7 reach about
+0.83 against both rear channels because their activity envelopes commonly
+rise together; the sample correlations, not those envelope correlations,
+provide the left/right evidence.
+
+The still-uninterpreted D3 data in *D3 corpus A* separates into static and
+dynamic regions:
+
+| Region | Whole-stream observation |
+| --- | --- |
+| 73-byte D3 prefix | one byte-identical value in all 7,674 frames |
+| Channel topology and mapping bits | fixed `4 + 4`, mapping bits zero |
+| Outer control | 643 distinct sequences |
+| Inner control | 1,388 distinct sequences |
+| Header/audio layout | 2,837 size/offset configurations |
+| Post-audio trailer | one to four zero bytes only |
+| 91-bit EXSS descriptor tail | fixed length; 1,547 captured 64-bit words |
+
+The lower 32 bits of the captured descriptor word remain `70aa2220`; its upper
+32 bits vary. The fixed D3 prefix could contain a static layout or fold
+declaration, but the variable controls track channel-set sizes and XLL
+navigation closely enough that they should not be interpreted as dynamic gain
+or position metadata without further evidence.
+
+Five subsequently completed corpus entries confirm D3 as a recurring profile:
+
+| Demo | Frames | Sources | PCM | Distinct CRC-delimited prefixes |
+| --- | ---: | ---: | ---: | ---: |
+| *D3 corpus B* | 13,731 | 8 | 24-bit | 161 |
+| *D3 corpus C* | 10,986 | 8 | 24-bit | 451 |
+| *D3 corpus D* | 9,625 | 8 | 24-bit | 2 |
+| *D3 corpus E* | 14,888 | 8 | 24-bit | 27 |
+| *D3 corpus F* | 9,292 | 8 | 24-bit | 2 |
+
+All 58,522 new frames retain the same `4 + 4` topology and zero mapping bits.
+Four streams decoded immediately with the D3 parser. *D3 corpus E* contributed 94
+valid `c6` outer controls whose geometry field extends through bit 31 rather
+than the bit-25 limit sufficient for D0/D1 and the earlier D3 controls. The
+bounded D3 geometry search now covers that form; all 14,888 *D3 corpus E* frames
+decode without errors.
+
+Four further completed demos add 72,127 whole-stream D3 frames:
+
+| Demo | Frames | Prefixes | Header layouts | Outer controls | Inner controls |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| *D3 corpus G* | 22,975 | 2 | 10,780 | 2,085 | 1,785 |
+| *D3 corpus H* | 21,034 | 306 | 19,229 | 1,283 | 1,116 |
+| *D3 corpus I* | 15,369 | 1 | 7,232 | 1,174 | 1,897 |
+| *D3 corpus J* | 12,749 | 26 | 283 | 122 | 1,980 |
+
+Every frame again decodes as two four-channel, zero-mapping-bit sets of
+24-bit PCM without an extension error. The complete D3 corpus now contains
+138,323 decoded frames across ten demos, including *D3 corpus A*. The unknown
+regions are not uniformly static: *D3 corpus I* has one CRC-delimited prefix while
+*D3 corpus H* has 306, and all four streams have variable controls and
+header/audio offsets. Conversely, their topology, mapping bits and PCM
+resolution remain constant. Their post-audio regions contain only zero
+padding, from zero to six bytes depending on the stream. This reinforces the
+working interpretation that the varying controls and offsets are XLL
+framing/navigation data, not evidence of a changing source-to-speaker matrix.
+
+The new corpus also shows that a byte-identical 73-byte prefix is a property of
+*D3 corpus A*, not a general D3 rule. Prefix length remains CRC-delimited and
+bounded, while prefix content can change with the programme. Topology,
+channel-set mapping and PCM resolution remain fixed across those changes.
+
+Whole-stream source-to-bed correlations vary with programme content but repeat
+several directional signatures:
+
+- X6 is most often associated with Lb and X7 with Rb;
+- X4/X5 generally form a broad left/right side pair;
+- X2/X3 can behave as a front L/R pair (*D3 corpus B*) or a rear Lb/Rb pair
+  (*D3 corpus F*);
+- X0/X1 range from weak/sparse material to a strong rear pair in *D3 corpus E* and
+  duplicated left-heavy material in *D3 corpus D*.
+
+The four latest D3 streams reproduce that programme dependence:
+
+- *D3 corpus G* has X0/X1 weakly front-left/front-right, X2/X3 rear-associated,
+  and X6/X7 most strongly paired with Lb/Rb (`r = 0.608/0.575`);
+- *D3 corpus H* has a broad frontal X2/X3 pair and a very strong X6/Lb,
+  X7/Rb relation (`r = 0.768/0.800`);
+- *D3 corpus I* has X0/Lb and X1/Rb at `r = 0.458/0.545`, X2/X3 front-associated,
+  and X6/X7 rear-associated;
+- *D3 corpus J* makes X0/X1 and X2/X3 sparse, pairwise-identical
+  signals, while X4–X7 carry most of the extension activity.
+
+This programme dependence rules out assigning eight fixed speaker labels from
+global correlation alone. D3 is therefore presented as eight named objects at
+the inferred static defaults described below.
+
+### Conservative D3 bed-fold limits
+
+`scripts/analyze-dtsx-bed-fold-limits.py` tests every D3 extension source
+against every compatible-bed channel without fitting a free matrix. For each
+512-sample block where the extension source is within 60 dB of its peak block
+energy, it evaluates:
+
+```text
+E(B - gX) - E(B) = g² E(X) - 2g <B,X>
+```
+
+The reported limit is the largest positive `g` for which the right-hand side
+is negative in at least 95% of those active blocks. Exact-silence blocks are
+excluded: counting their unchanged energy as a successful decrease would let
+a sparse source pass the test at an arbitrary gain.
+
+The limit is not itself an estimated fold coefficient. If `B = aX` exactly,
+energy falls for `0 < g < 2a`; the maximum is `2a`. The report therefore also
+gives `p05_beta = limit / 2`, the corresponding fifth-percentile projection
+coefficient. This remains a conservative content measurement, not a decoded
+matrix.
+
+The ten D3 `4+4` streams give the following recurring results with
+the default 512-sample protocol:
+
+| Candidate | Streams passing 95% | Median limit | Median `p05_beta` | Pass at -3 dB | Pass at -6 dB |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| X6 -> Lb | 5/10 | 0.592 | 0.296 (-10.6 dB) | 1/10 | 3/10 |
+| X7 -> Rb | 4/10 | 0.511 | 0.256 (-11.8 dB) | 1/10 | 2/10 |
+| X2 -> Lb | 2/10 | 0.846 | 0.423 (-7.5 dB) | 1/10 | 2/10 |
+| X3 -> Rb | 2/10 | 0.733 | 0.366 (-8.7 dB) | 1/10 | 1/10 |
+| X4 -> any bed | 0/10 | - | - | 0/10 | 0/10 |
+| X5 -> any bed | 0/10 | - | - | 0/10 | 0/10 |
+
+X0/X1 have only isolated 512-sample candidates and no corpus-level gain.
+Longer blocks make the recurring rear relation clearer but also average away
+local energy increases: at 2,048 samples X6/Lb passes 7/10 and X7/Rb 4/10;
+at 4,800 samples they pass 8/10 and 5/10. Changing the activity gate from
+-60 to -40 dB leaves the 512-sample X6/X7 counts at 5/10 and 4/10.
+
+The defensible inference is directional, not a fold matrix: X6 is repeatedly
+rear-left-associated and X7 rear-right-associated. X2/X3 sometimes reproduce
+the same rear pairing, while X4/X5 consistently fail this conservative
+energy test. No positive gain satisfies the requested 95% condition for all
+ten programmes, and neither -3 nor -6 dB is corpus-wide safe under this
+criterion. Failure does not disprove a real authoring fold: independent or
+deliberately phase-opposed content can make a correct subtraction increase
+energy locally.
+
+Example:
+
+```console
+python3 scripts/analyze-dtsx-bed-fold-limits.py \
+  /path/to/extracted-audio \
+  --output /tmp/d3-bed-fold-limits.tsv \
+  --plot-dir /tmp/d3-bed-fold-coverage-maps \
+  --position-plot-dir /tmp/d3-bed-fold-positions \
+  --animation-dir /tmp/d3-bed-fold-animations \
+  --video-dir /path/to/original-video-directory \
+  --plot-gain 0.5
+```
+
+The optional plot directory receives one fixed-scale PNG per stream: bed
+channels on the horizontal axis, extension sources on the vertical axis and
+colour equal to the active-block coverage at the selected fixed gain.
+Supported plot gains are `0.5` (-6.02 dB), `0.707107` (-3.01 dB) and `1.0`
+(0 dB).
+
+The optional position plot uses the selected fixed-gain coverages as
+barycentric weights over the seven spatial bed coordinates. LFE is excluded
+because it has no spatial coordinate. Each stream receives one common-scale
+`x/y` PNG, and the exact derived positions are written to `positions.tsv`.
+
+The animation mode recomputes those coverage barycentres in a one-second
+sliding window and emits a real-time H.264 MP4 per stream. Original MKV audio
+start PTS and container duration are preserved: no points are shown during
+video pre-roll or after decoded DTS:X audio ends. Marker size and opacity
+track extension-source activity, a three-second trail shows recent movement,
+and `temporal-positions.tsv` retains the underlying coordinates. The video is
+a silent research visualization and does not claim decoded object motion.
+
+### D3 coordinate-field falsification
+
+`xll_d3_frame_features` exports the CRC-delimited prefix, outer and inner
+controls, EXSS descriptor tail and known layout quantities for every decoded
+D3 frame. `scripts/analyze-d3-coordinate-fields.py` aligns those values with
+the one-second coverage windows above. It tests Cartesian `x/y`, radius, and
+azimuth as `sin/cos` rather than correlating a wrapped angle directly.
+
+The scan includes every byte and bit of each region, plus every possible
+8-, 10- and 12-bit field in the still-unknown prefix. Each candidate prefix
+field is also interpreted cyclically as a possible quantized angle. Linear
+dependence on all eight extension activity envelopes and on the known payload,
+header, geometry and boundary quantities is removed before comparison. A
+candidate is selected on the first half of each programme and checked on the
+second half with block-shifted temporal controls.
+
+The corpus supplies important negative controls:
+
+- *D3 corpus I* has no Atmos position change after setup, yet its outer and inner
+  controls change on 7,275 and 14,853 of 15,368 frame boundaries;
+- *D3 corpus A* has one byte-identical prefix despite 1,683 Atmos position
+  changes;
+- *D3 corpus D* and *D3 corpus F* each have two prefix values and one
+  prefix transition despite 1,015 and 4,940 Atmos position changes;
+- *D3 corpus E* has 27 prefix values and 26 transitions despite 4,902 Atmos position
+  changes.
+
+No candidate in the unknown prefix repeats convincingly across programmes.
+The best same-direction counts are only 3/10 programmes for Cartesian `x`,
+`y`, radius and azimuth cosine, and 4/10 for azimuth sine. Their corresponding
+median absolute partial correlations are 0.021, 0.039, 0.105, 0.117 and
+0.011. No prefix field reaches five programmes with a median absolute partial
+correlation above 0.15. Large single-programme correlations do occur, up to
+almost one in a low-state-count *D3 corpus J* range, but disappear at
+the same bit offset in the other programmes and are compatible with section
+identity or estimator noise.
+
+Some outer-control bits look more repeatable in polar form, but the leading
+candidates are already structural. Outer bit 10 belongs to the encoded span
+that locates the second channel-set header. Bit 30 falls in that variable-width
+span or in the following segment geometry. Bit 36 is geometry when its detected
+offset is at least 24 and otherwise belongs to the still-uninterpreted trailing
+control bits, so it is not even a stable semantic position across layouts. The
+EXSS tail is likewise the already verified payload offset/size navigation
+word. Remaining inner/outer correlations change sign or source between
+programmes, and the fixed-position *D3 corpus I* control produces similarly large
+local correlations.
+
+There is therefore no current evidence for a dynamic Cartesian or polar
+coordinate in these regions. Polar conversion exposes more local correlation
+because it normalizes the noisy barycentre radius, but it does not reveal a
+stable field. This does not prove that D3 lacks spatial declarations: the
+piecewise-constant prefix may still describe a static layout or cluster
+configuration. Establishing a dynamic coordinate requires a controlled encode
+whose PCM is held constant while one known source is swept through position.
+
+### D3 prefix versus temporal bed-fold coverage
+
+The temporal analysis now retains the complete `X x bed` coverage tensor, not
+only its barycentre. `--temporal-coverage-output` writes the fixed-gain
+coverage, active-block count and validity for every video-time window.
+`scripts/analyze-d3-prefix-coverages.py` aligns those windows with the D3
+prefix observed over the same second and performs three tests:
+
+1. treat the exact prefix as a categorical state and measure explained
+   coverage variance;
+2. learn state means on the first half and predict only prefix states seen in
+   the second half;
+3. scan every possible 8-, 10- and 12-bit field after removing the verified
+   two-byte CRC, while partialling out extension activity and known navigation
+   quantities.
+
+The categorical result is dominated by programme segmentation:
+
+| Demo | Prefix states | Median in-sample `eta²` | Median holdout skill | Holdout states seen | Coverage RMS at/away from prefix transitions |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| *D3 corpus B* | 161 | 0.363 | 0.054 | 1.000 | 0.062 / 0.044 |
+| *D3 corpus H* | 306 | 0.904 | unavailable | 0.007 | 0.054 / 0.055 |
+| *D3 corpus C* | 451 | 0.408 | 0.055 | 0.595 | 0.066 / 0.090 |
+| Other seven D3 demos | 1--27 | at most 0.012 median | at most 0.003 median | - | no repeatable excess |
+
+*D3 corpus H* demonstrates the overfit directly: an exact prefix labels a
+short section well enough to explain about 90% of coverage variance in the
+same samples, but only 0.7% of the second-half windows reuse a state learned
+in the first half. Its coverage changes are no larger at prefix transitions
+than elsewhere. *D3 corpus B* has a real transition association, but only a small
+median predictive gain; *D3 corpus C* has no transition excess.
+
+The most suggestive exploratory field is the ten bits beginning at prefix bit
+299:
+
+```text
+value = ((prefix[37] & 0x1f) << 5) | (prefix[38] >> 3)
+```
+
+It repeatedly takes values such as 94, 542, 635 and 964. Mapping the value to
+`cos(2*pi*value/1024)` produces a front/rear-looking signature for X2/X3 in
+*D3 corpus B* and *D3 corpus C*. That relationship does not survive the independent
+programme control. Across all ten programmes, the programme-mean correlations
+are only `+0.186` for X2/L, `-0.217` for X2/Lb, `+0.176` for X3/R and `-0.236`
+for X3/Rb. More importantly, on the seven programmes outside the three where
+the clue was discovered, they become `-0.091`, `+0.073`, `-0.091` and
+`+0.059`: no front/rear prediction remains. In the second half, the field is
+constant in *D3 corpus B*, is weak and non-significant in *D3 corpus H*, and
+retains only the rear relation in *D3 corpus C*. No scanned field keeps the same
+coverage relationship across the corpus.
+
+Exact prefixes reused by different demos provide another control. Four shared
+prefix pairs have enough active coverage for comparison. Only the *D3 corpus G*
+versus *D3 corpus H* pair is more similar than most different-prefix pairs
+from the same programmes (91st percentile). The other shared pairs land at
+the 38th, 20th and 0th percentiles. An exact shared prefix therefore does not
+identify a reusable bed-fold matrix.
+
+The bounded conclusion is that prefix state and bed-fold coverage can be
+correlated inside a programme because both follow programme sections. The
+current corpus does not support interpreting the prefix, or bit 299, as a
+normative or programme-independent fold declaration. Bit 299 remains worth
+tracking as a structured configuration field, but its angular appearance is
+not yet a decoded coordinate.
+
+*paired standard D* is not D3: its complete 20,148-frame stream is the standard
+four-source, 24-bit profile, with all four sources active in about 95% of
+frames and no decode error. Its sample correlations most strongly associate
+X2 with Lb (`r = 0.773`) and X3 with Rb (`r = 0.764`); X0/X1 are broader,
+weaker left/right components. It expands the ordinary profile corpus but
+requires no parser change.
+
+## Paired Atmos comparison
+
+The matching Atmos editions of all fifteen corpus programmes were extracted as
+elementary TrueHD and decoded with the local `truehdd` 0.4.0 build. Every
+presentation contains sixteen 48 kHz PCM elements: an LFE-only bed and fifteen
+dynamic objects. The DAMF metadata and PCM were retained as
+`.atmos`, `.atmos.audio` and `.atmos.metadata` files.
+
+The alternate encodes were aligned on 512-sample total-power envelopes. The
+following table reports motion after the first matched programme second, so
+the common initial placeholder position is not counted. `Envelope r` measures
+programme-level temporal agreement. `PCM r` is the mean, over DTS bed and
+extension channels, of the strongest absolute sample correlation with any
+Atmos element in an active ten-second range.
+
+| Demo | DTS profile/sources | Moving Atmos objects | Position changes | Offset | Envelope `r` | Mean best PCM `|r|` |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| *D3 corpus A* | D3 / 8 | 15 | 1,683 | +4.981 s | 0.990 | 0.181 |
+| *paired standard A* | standard / 4 | 15 | 2,672 | -0.021 s | 0.983 | 0.184 |
+| *D1 corpus B* | D1 / 6 | 15 | 3,264 | +4.981 s | 0.902 | 0.201 |
+| *D3 corpus B* | D3 / 8 | 10 | 129 | +9.984 s | 0.967 | 0.164 |
+| *paired standard B* | standard / 4 | 15 | 777 | +9.984 s | 0.915 | 0.167 |
+| *paired standard C* | standard / 4 | 15 | 713 | +5.099 s | 0.933 | 0.376 |
+| *D3 corpus G* | D3 / 8 | 13 | 430 | +5.024 s | 0.659 | 0.048 |
+| *D3 corpus H* | D3 / 8 | 15 | 10,454 | +10.123 s | 0.799 | 0.238 |
+| *D3 corpus I* | D3 / 8 | 0 | 0 | +9.984 s | 0.949 | 0.285 |
+| *D3 corpus C* | D3 / 8 | 15 | 6,042 | +5.003 s | 0.961 | 0.209 |
+| *D3 corpus J* | D3 / 8 | 15 | 1,388 | +4.971 s | 0.926 | 0.342 |
+| *D3 corpus D* | D3 / 8 | 15 | 1,015 | +6.891 s | 0.980 | 0.221 |
+| *paired standard D* | standard / 4 | 15 | 2,768 | -0.021 s | 0.835 | 0.269 |
+| *D3 corpus E* | D3 / 8 | 15 | 4,902 | +4.939 s | 0.968 | 0.190 |
+| *D3 corpus F* | D3 / 8 | 15 | 4,940 | +9.984 s | 0.821 | 0.184 |
+
+Eleven pairs have total-power envelope correlation above 0.90, establishing
+that they contain the same timed programme rather than unrelated material.
+The weaker *D3 corpus G*, *D3 corpus H*, *paired standard D* and *D3 corpus F* results are
+consistent with different edits or more substantial format-specific mixing.
+
+The PCM is nevertheless not the same multichannel master copied or permuted
+between formats. This remains true for D3: its compatible 7.1 bed plus eight
+extension sources gives the same total of sixteen signals as the Atmos
+presentation, but the mean best sample correlations are only 0.048–0.342.
+A static least-squares matrix fitted over each active probe range explains
+almost none of the D3 extension PCM. The best exceptions are *paired standard C*
+(standard four-source, about 52% in-sample explained extension energy),
+*D3 corpus J* (about 30%), *D3 corpus I* (about 14%) and *D3 corpus H*
+(about 14%); those fits collapse on the second half of the range, so they are
+not stable fold matrices.
+
+Five-second power fits usually improve over a whole-programme fit, and the
+dominant Atmos predictor changes in roughly 41–87% of adjacent windows. This
+is compatible with a time-varying render or clustering, but it is not proof:
+the local fits remain weak enough that independently authored
+format-specific mixes can produce the same observation.
+
+The paired corpus therefore supports these bounded conclusions:
+
+- the Atmos editions are not generally fixed-object masters; most have
+  substantial movement, with *D3 corpus H*, *D3 corpus C*, *D3 corpus E* and
+  *D3 corpus F* especially dynamic;
+- *D3 corpus I* is a useful fixed control: after its setup event all fifteen Atmos
+  objects remain at fixed coordinates, while *D3 corpus B* is mostly fixed with
+  small local movements;
+- D3 is not a direct carriage of the fifteen Atmos object waveforms, despite
+  its matching sixteen-signal total;
+- the evidence is consistent with DTS:X using a different, possibly dynamic
+  clustering or renderer-domain allocation, but does not distinguish that
+  from a separately authored format-specific mix;
+- consequently neither the Atmos object IDs nor a correlation-derived
+  one-to-one speaker map should be assigned to D3 sources.
+
+### D3 corpus I fixed-layout control
+
+*D3 corpus I* permits a more constrained comparison because the Atmos presentation
+stops moving after its setup event. It is not a conventional 7.1.6 bed:
+the decoder reports an LFE-only bed and fifteen objects. Those objects settle
+at the following fixed normalized coordinates:
+
+| Atmos signal | Coordinate `(x, y, z)` | Nominal position |
+| --- | --- | --- |
+| O10 | `(-1, 1, 0)` | L |
+| O11 | `(1, 1, 0)` | R |
+| O12 | `(-1, 0.677, 0)` | Lw |
+| O13 | `(0, 1, 0)` | C |
+| O14 | `(-1, 0, 0)` | Ls |
+| O15 | `(-1, -1, 0)` | Lb |
+| O16 | `(-1, 1, 1)` | TFL |
+| O17 | `(1, 0.677, 0)` | Rw |
+| O18 | `(1, 0, 0)` | Rs |
+| O19 | `(-1, 0, 1)` | TML |
+| O20 | `(1, -1, 0)` | Rb |
+| O21 | `(-1, -1, 1)` | TBL |
+| O22 | `(1, 1, 1)` | TFR |
+| O23 | `(1, 0, 1)` | TMR |
+| O24 | `(1, -1, 1)` | TBR |
+
+The coordinates therefore contain positions matching every DTS 7.1 bed
+label, in addition to Lw/Rw and six top positions. Content matching is less
+direct. At the common fine alignment of about ten samples, only L and R retain
+strong whole-programme sample correlations with their namesakes
+(`|r| = 0.576/0.571`). In each DTS bed channel's most active ten seconds,
+with a bounded `+/-1024`-sample delay search:
+
+- L matches Atmos L first (`|r| = 0.732`); R matches Atmos R essentially
+  jointly with L (`|r| = 0.723`);
+- LFE matches LFE first, but only at `|r| = 0.275`;
+- Ls and Rs match their namesakes second at `|r| = 0.307/0.296`;
+- Lb matches Lb third at `|r| = 0.491`;
+- C and Rb do not select their nominal Atmos positions.
+
+This is compatible with matching physical positions whose programme content
+was allocated differently, but it does not establish a common 7.1 PCM bed.
+The useful source similarity groups are likewise many-to-many:
+
+- DTS L/R and Atmos L/R are the robust direct pair;
+- DTS X2/X3 are a robust left/right front-elevation pair. In their active
+  range, X2 matches TFL at `|r| = 0.877` and X3 matches TFR at `|r| = 0.864`,
+  but the same Atmos range has Rw/TFR correlation `0.993` and Lw/TFL
+  correlation `0.991`. X2/X3 therefore identify the correlated
+  front/high-left and front/high-right groups, not unique speaker labels;
+- X0/X1 are sparse and weak at sample level; X4/X5 follow broad
+  front-left/front-right material; X6/X7 remain broad and ambiguous.
+
+A bounded folding test used `corrected bed = bed - f * X`, with a shared
+left/right coefficient, `0 <= f <= 1`, and no unconstrained gain compensation.
+It measured the whole programme and independent five-second windows:
+
+| Bed pair and source pair | Best `f` | Level | Baseline `|r|` | Best `|r|` | Median window gain |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| L/R minus X4/X5 | 0.765 | -2.33 dB | 0.5731 | 0.5792 | +0.0014 |
+| Ls/Rs minus X2/X3 | 1.000 | 0.00 dB | 0.0256 | 0.0855 | +0.0000 |
+| Lb/Rb minus X2/X3 | 1.000 | 0.00 dB | 0.0597 | 0.0858 | +0.0000 |
+
+The first result has a plausible coefficient but an insignificant effect:
+only seven of 33 windows gain at least 0.01 even when each window is allowed
+to choose its own coefficient, and those local optima have an interquartile
+range of `0.77/1.00/1.00`. The other apparent gains start from almost
+uncorrelated signals and stop at the allowed boundary, while their median
+window gains are zero. Testing every X source against C improves its global
+correlation by at most 0.0011. No measured fold is therefore stable or useful
+enough to adopt as a D3 presentation rule.
+
+Run the reproducible fixed-layout analysis after producing aligned 16-channel
+`f32le` files:
+
+```console
+python3 scripts/analyze-dtsx-fixed-layout-fold.py DTSX.f32le ATMOS.f32le
+```
+
+## Automatic bridge presentations
+
+There is no presentation switch. Once the extension has decoded successfully,
+Harletty selects its output from the observed source count:
+
+| Profile | Automatic presentation |
+| --- | --- |
+| Standard four-source | fixed 7.1.4 `TFL,TFR,TBL,TBR`, with the configured height fold removed from the compatible bed |
+| D0, five-source | fixed `TFC,TFL,TFR,TBL,TBR`, with the configured experimental partial unfolds |
+| D1, six-source | fixed `TFL,TFR,Lw,Rw,TBL,TBR`, with the configured experimental partial unfolds |
+| D3, eight-source | unchanged named objects X0–X7 at the inferred defaults below; no bed subtraction |
+
+Fixed standard/D0/D1 channels carry no object labels, fabricated positions or
+metadata, and do not set `has_objects`. D3 does because it is the only current
+alternate presentation emitted through object channels.
+
+The D1 operation is:
+
+```text
+L  -= 0.707107 * X0 + 1.183 * X2
+Ls -= 0.209 * X2
+Lb -= 0.707107 * X4
+TFL = X0
+TBL = X4
+Lw  = X2
+
+R  -= 0.707107 * X1 + 1.183 * X3
+Rs -= 0.209 * X3
+Rb -= 0.707107 * X5
+TFR = X1
+TBR = X5
+Rw  = X3
+```
+
+All six D1 sources are exposed as fixed labeled channels; no
+objects or fabricated metadata are emitted. The decisions are hoisted per
+channel; the sample loop performs only the required multiply/subtracts. No
+adaptive decorrelator or per-sample allocation is introduced. The wide gains
+are inferred from *D1 corpus A* alone and remain experimental pending
+cross-validation on *D1 corpus B* or reference-decoder confirmation.
+
+The D3 presentation deliberately performs no subtraction from the
+compatible bed: neither the existence nor the coefficients of a D3 fold have
+been established. It keeps the eight extension waveforms unchanged and emits
+the following static object defaults:
+
+| Source | Experimental role | Cartesian position |
+| --- | --- | --- |
+| X0 | left wide | `[-1.0, 0.5, 0.0]` |
+| X1 | right wide | `[1.0, 0.5, 0.0]` |
+| X2 | top front left | `[-1.0, 1.0, 1.0]` |
+| X3 | top front right | `[1.0, 1.0, 1.0]` |
+| X4 | top side left | `[-1.0, 0.0, 1.0]` |
+| X5 | top side right | `[1.0, 0.0, 1.0]` |
+| X6 | top back left | `[-1.0, -1.0, 1.0]` |
+| X7 | top back right | `[1.0, -1.0, 1.0]` |
+
+The left/right ordering is repeatable in the D3 corpus. X6/X7 have the
+strongest recurring rear-bed association, X2/X3 match the front-elevation
+group in the paired *D3 corpus I* Atmos control, and X4/X5 form the broad side
+pair. X0/X1 are assigned to the wides by elimination and have the weakest
+positional evidence. These events are explicitly fabricated presentation defaults,
+not stream coordinates; their names and object declarations are emitted
+sparsely, and `has_objects` reflects the latest frame where this D3
+presentation is emitted.
+
+## Reproduction tools
+
+- `dca/examples/xll_corpus_probe.rs`: bounded profile/source/activity survey.
+- `dca/examples/xll_pcm_range.rs`: extract interleaved bed plus extension PCM
+  for a selected time range.
+- `dca/examples/xll_alt_layout_probe.rs`: validate D0/D1/D3 channel-set
+  headers, CRC-delimited prefixes, controls, layouts and post-audio padding.
+- `dca/examples/xll_bed_correlation.rs`: whole-stream sample and frame-RMS
+  correlation matrices between alternate sources and the lossless 7.1 bed.
+- `dca/examples/xll_rms_envelope.rs`: compact per-frame RMS extraction for
+  aligning alternate encodes without writing their complete decoded PCM.
+- `scripts/analyze-dtsx-atmos-pairs.py`: align paired DTS:X/Atmos
+  editions, survey Atmos object motion and test fixed versus windowed
+  cross-format mixture hypotheses.
+- `scripts/analyze-dtsx-system-id.py`: scalar delay/gain/frequency response
+  analysis, including the known height-fold calibration paths.
+- `scripts/analyze-dtsx-matrix-id.py`: conditioned multichannel matrix fit and
+  coefficient-plateau report.
+- `scripts/analyze-dtsx-fixed-pan.py`: local height-plane rank-one/gain-vector
+  analysis for finding coherent pans in a decoded fixed 7.1.4 presentation.
+- `scripts/compare-dtsx-bed.py`: auto-match the eight compatible-bed channels
+  from `xll_pcm_range` to an ffmpeg f32le reference and enforce a lossless RMSE
+  gate. Use `--skip-seconds 1` for independently seeked snippets that lack XLL
+  pre-roll.
+
+Example:
+
+```sh
+cargo run -p dca --release --example xll_pcm_range -- \
+  /path/to/d1-corpus.dts \
+  /tmp/d1-50-66.f32le 3000 3960
+
+python3 scripts/analyze-dtsx-matrix-id.py \
+  /tmp/d1-50-66.f32le --extensions 6 --window 4096
+
+scripts/compare-dtsx-bed.py \
+  /tmp/decoded-bed-plus-x.f32le /tmp/ffmpeg-7.1.f32le \
+  --skip-seconds 1
+```
+
+The extractor prints the active DCA speaker order. The Python tools currently
+expect the eight-channel order used by this corpus:
+`C,L,R,Ls,Rs,LFE,Lb,Rb`, followed by the extension sources.
+
+## Promotion gate
+
+These automatic experimental presentations must not be merged to `main`
+without:
+
+1. quantitative confirmation on *D1 corpus B* or a reference-decoder capture;
+2. local corpus tests that demonstrably ran;
+3. lossless-bed regression against ffmpeg;
+4. explicit compatible-bed-versus-spatial-presentation A/B listening sign-off.

--- a/docs/dtsx-objects-campaign.md
+++ b/docs/dtsx-objects-campaign.md
@@ -1,6 +1,6 @@
 # Spatial object layer reverse-engineering notes
 
-Date: 2026-07-20 (research campaign) / 2026-07-21 (landing)
+Date: 2026-07-20 (research campaign) / 2026-07-22 (alternate-profile follow-up)
 
 Status: **landed as twelve labeled fixed channels** — see Omniphony
 `docs/channel-object-contract.md`. The original campaign fabricated an
@@ -25,7 +25,7 @@ the reconstructed fixed 7.1.4 presentation without double-rendering height
 content onto the lower plane. The reconstruction remains intentionally isolated
 from the lossless decoder.
 
-Validated on prefixes from all nine currently available tracks:
+Validated on prefixes from the original nine standard-profile tracks:
 
 - 4,206/4,206 XLL-X frames decoded in the 2 MiB cross-corpus pass;
 - channel-set header CRC valid in every frame;
@@ -34,6 +34,195 @@ Validated on prefixes from all nine currently available tracks:
   signals; no core reconstruction is required);
 - 24-bit storage, with title-dependent source PCM resolutions of 16, 18 or
   24 bits.
+
+The twenty-three later-added standard-profile tracks, including all eight
+the standard-07 through standard-14 series, standard-15, and five later
+disk-inventory additions
+and three controlled clips, retain
+the same fixed 22-byte prefix and still contain
+exactly one four-channel XLL set, so they remain fixed 7.1.4 presentations
+rather than candidates for additional objects. The common prefix is unchanged:
+
+```text
+02 00 08 50 28 4b fa 71 0d 62 02 fa 02 dc 13 71 0d c8 37 3c f1 02
+```
+
+## Alternate `0xF14000D0/D1` extension profile
+
+Two newer corpus entries use a second extension envelope that the regular
+`0x02000850` path does not decode yet:
+
+- *D0 corpus A* uses `0xF14000D0`;
+- *D1 corpus A* uses `0xF14000D1`.
+
+This profile is not a wholly different audio codec. The initial discovery scan
+found exactly two byte-aligned XLL channel-set headers per frame, each protected
+by a valid CRC16-CCITT. The bounded control-derived resolver described below now
+reproduces those boundaries without scanning the whole payload:
+
+| Stream | First set | Second set | Active frames decoded in 64 MiB |
+| --- | --- | --- | ---: |
+| `D0` | 1 channel, PCM/storage 24/24, residual mask `0x1` | 4 channels, PCM/storage 24/24, residual mask `0xf` | 8,356/8,356 |
+| `D1` | 2 channels, PCM/storage 20/24, residual mask `0x3` | 4 channels, PCM/storage 20/24, residual mask `0xf` | 7,293/7,293 |
+
+The first header starts at byte 61 or 62 for `D0`; `D1` starts at byte 62 for
+its 7-byte `b2` control and byte 63 for its 8-byte `c3/c4/c5` controls. The
+second header moves with the compressed size of the first set. A
+compact 7- or 8-byte control word between the fixed profile prefix and the first
+header encodes both its NAVI geometry and the field needed to predict that
+boundary.
+
+Each channel set has its own CRC-valid XLL-shaped NAVI table; the two sets do
+not necessarily share segment geometry. Exact active-frame examples now show:
+
+- `D0` frame 187: a four-entry, 6-bit first-set candidate followed by a
+  two-segment, 8-bit terminal quartet (`160 + 114` bytes);
+- `D1` frame 191: four 10-bit first-set segments (`223, 253, 274, 286` bytes);
+- `D1` frame 192: two 8-bit terminal-quartet segments (`158 + 161` bytes).
+
+This corrects the earlier `D0 = 8 active segments` hypothesis, which came from
+a transition/sparse frame and does not describe the active quartet.
+
+The apparent varying channel-mask width was a false interpretation. After the
+36-bit standard XLL channel-set base, this profile carries exactly two
+profile-specific bits instead of the ordinary one-to-one speaker-mapping block.
+Skipping those two bits and resuming at the standard decorrelation/prediction
+syntax parses both headers in every frame of the measured 8 MiB samples (1,621
+D0 frames and 1,028 D1 frames), including a unique original-channel
+permutation. The rest of the lossless codec is unchanged.
+
+The D1 `b2/c3/c4/c5` control families expose the first channel set's segment
+geometry in a 13-bit XLL common-header prefix. Its start moves between control
+bits 18 and 25; the dominant `c5` form starts at bit 24. Across 7,293 active
+frames in the measured 64 MiB prefix it selects:
+
+- 7,130 frames with two segments and 10-bit NAVI sizes;
+- 119 with four segments and 10-bit NAVI sizes;
+- 32 with two segments and 9-bit sizes;
+- nine with two segments and 11-bit sizes;
+- two with four segments and 9-bit sizes;
+- one with eight segments and 10-bit sizes.
+
+The selector uniquely identifies an immediate CRC-valid NAVI geometry for
+7,293/7,293 first sets. The earlier 425/837 result was an artifact of allowing
+at most 16 bytes between the first set's NAVI-sized audio data and the second
+header. The actual interstitial span is 14..18 bytes; no trailing NAVI is
+present.
+
+The D1 channel-set boundaries can also be resolved without a full-payload CRC
+scan. If the first common prefix begins at control bit `C`, its preceding size
+field has width `C - 14`, starts at bit 9, and predicts
+`second_offset = field * 2 + 67`. The probe tests that byte and the single
+preceding byte, accepting only a structurally valid, CRC-protected four-channel
+XLL header. This bounded rule finds every measured D1 header, including the
+7-byte `b2`, shifted `c3/c4` and rare 11-bit `c5` forms.
+
+The bytes between the first set and terminal quartet are not arbitrary padding.
+They contain zero to three alignment bytes, the same constant six-byte suffix
+`02 34 38 8c 4f 00`, then a second 8- or 9-byte compact control word. Its own
+13-bit common prefix starts between bits 19 and 26 and uniquely selects the
+terminal quartet's geometry in 7,293/7,293 active D1 frames. The resulting
+distribution is 4,148 at 2 x 10 bits, 2,273 at 2 x 11, 823 at 4 x 10, 40 at
+4 x 11, four at 8 x 11, two at 2 x 8, and one each at 2 x 6, 4 x 9 and
+8 x 10.
+
+D0 uses the same two-control organization. Its first selector starts between
+bits 18 and 25 of the 7- or 8-byte outer control; its second selector occupies
+bits 20..26 of the interstitial 8- or 9-byte control. Each selector yields
+exactly one geometry on all 8,356 active frames. This removes the false
+dominant `2 x 6` first-set candidate: the control selects `2 x 5` on 7,791
+frames. D0's first header follows its control at byte 61 or 62. Its second
+header is predicted by the same field-width rule as D1, using
+`second_offset = field * 2 + 66` and the single preceding byte as the bounded
+CRC-validated alternative.
+
+The existing XLL primitives now reach PCM well beyond a one-frame probe. With
+the two-bit alternate header mode and self-consistent common parameters
+(`header size width = NAVI width`, band CRC 0, non-scalable LSBs), corpus-gated
+tests report:
+
+| Stream / measured run | First set | Terminal quartet |
+| --- | ---: | ---: |
+| D0, 8,356 active frames in 64 MiB | 8,356 | 8,356 |
+| D1, 7,293 active frames in 64 MiB | 7,293 | 7,293 |
+
+These counts include header CRC, NAVI CRC, bounded entropy decode, prediction,
+decorrelation and PCM reconstruction. They are not yet a reference comparison
+and do not establish speaker or object identity.
+
+Both alternate profiles now resolve both headers with bounded candidates and
+select exactly one NAVI geometry per channel set from their compact controls.
+The decoder path uses these rules directly: fixed-size layout/NAVI state,
+checked arithmetic, prefix/header/NAVI CRC validation, a maximum 24-byte suffix
+search and no full-payload header scan or segment/size enumeration. Malformed
+or truncated extension data clears only the optional extension output and does
+not invalidate the lossless bed.
+
+At the high-level decoder boundary, every frame of all three complete elementary
+streams now produces five speaker-unmapped sources for D0 or six for D1:
+
+| Complete stream | Frames | Sources per frame | PCM resolution | Decode errors |
+| --- | ---: | ---: | ---: | ---: |
+| *D0 corpus A* (`D0`) | 697,447 | 5 x 512 samples | 24 bits | 0 |
+| *D0 corpus B* (`D0`) | 557,057 | 5 x 512 samples | 24 bits | 0 |
+| *D1 corpus A* (`D1`) | 863,769 | 6 x 512 samples | 20 bits | 0 |
+
+The bounded-memory validation read both complete D0 streams (5,437,706,120 and
+3,930,678,152 bytes) and all 7,070,742,004 D1 bytes with no pending frame,
+non-finite sample or out-of-range PCM value. Ordinary inter-sample and
+frame-boundary RMS differences remain on the same scale; no gross
+mode-transition discontinuity was observed. The full runs include the D0 `c5`,
+D1 `b2/c3/c4/c5`, and rare internal `d6` controls.
+
+The bridge selects a presentation automatically after the extension profile
+has decoded successfully. There is no environment or bridge-configuration
+switch:
+
+- D0 emits X0–X4 as fixed `TFC,TFL,TFR,TBL,TBR` channels and applies only the
+  configured, explicitly experimental partial unfolds;
+- D1 emits all six sources as fixed `TFL,TFR,Lw,Rw,TBL,TBR` channels and
+  applies its configured partial unfolds;
+- D3 performs no bed subtraction and emits unchanged named objects X0–X7 at
+  the inferred two-wide plus six-top layout documented in
+  `dtsx-d1-wide-audition.md`.
+
+The D3 object-to-channel and name declarations are emitted sparsely and reset
+on seek or pipeline reset. A static position heartbeat is emitted twice per
+second so a newly registered Studio OSC client receives a complete spatial
+frame without a startup flood when one input packet contains many decoded
+audio frames. The renderer's OSC sender still delta-compresses unchanged
+object details. `has_objects` becomes true only after a frame containing
+actual object channels is emitted; fixed D0/D1 do not set it.
+
+The assignments remain experimental until reference decoding and the requested
+listening sign-off establish the exact profile matrices and confirm the
+inferred fixed-channel identities.
+
+It is nevertheless not yet safe to promote these experimental assignments to
+the normal presentation. Full-stream PCM range and coarse continuity are
+validated, but the channel semantics and fold matrices are inferred rather
+than carried by decoded mapping metadata. Reference decoding and A/B sign-off
+remain promotion gates.
+
+The CRC-protected fixed profile prefix is constant for every observed frame.
+For `D0`, bytes `0..48` have a zero CRC16 and are followed by the six-byte tail
+`03 34 38 8c 4f 00`; for `D1`, the zero-CRC range is `0..49` and the same tail
+follows. The compact control word then begins at byte 54 (`D0`) or 55 (`D1`).
+
+The public DTS-UHD organization is a useful structural analogy: ETSI TS
+103 491 defines persistent XLL frame-header chunks and XLL audio chunks that
+carry channel-set headers, data and navigation. It is not byte-for-byte the
+same wrapper, so its chunk ordering must not be imposed on these frames without
+corpus validation. In particular, a shared CRC-valid NAVI table at the payload
+end appears only on sparse/transition material (247/8,541 D0 frames and
+197/1,028 D1 frames) and does not describe the active corpus; the two immediate
+per-set NAVI tables remain the supported structural hypothesis.
+
+No presentation contract is inferred from `1 + 4` or `2 + 4`. Until the
+waveforms are decoded across the corpus and mapping metadata is understood,
+these remain extra source-channel candidates. They are not exposed to the
+renderer as labeled speakers or objects; all alternate-profile PCM work remains
+research-only and corpus-gated.
 
 ## Correct XLL-X payload structure
 
@@ -69,7 +258,7 @@ The optional final argument limits input to MiB. Classic RIFF output is capped
 below 4 GiB. A smoke test produced a valid 48 kHz, four-channel `pcm_f32le` WAV
 with 960/960 frames and no failures.
 
-The paired French/English *La La Land* analysis is also decisive: 564 initial
+The paired French/English the paired language control analysis is also decisive: 564 initial
 silent frames have bit-identical extension payloads, while the decoded
 waveforms then diverge with the two mixes. The block therefore carries real
 audio, not only spatial coordinates.
@@ -99,7 +288,7 @@ bounds and syncword and retaining the legacy aligned band-end probe as a
 fallback. This makes extension extraction more robust, but supplies neither a
 gain curve nor an object trajectory.
 
-Before analysis of the Object Emulator control clip, the remaining spatial
+Before analysis of standard pan control A, the remaining spatial
 question was whether the four waveforms were:
 
 1. fixed height feeds (most economical explanation);
@@ -123,7 +312,7 @@ particularly useful counterexamples to four independent height feeds:
 
 - *Apollo 13*: channels 2 and 3 are exactly silent for 7,501 frames (about
   80 seconds), leaving only two active extension waveforms;
-- *La La Land* English: channels 2 and 3 are sample-identical in aggregate and
+- *paired language control* English: channels 2 and 3 are sample-identical in aggregate and
   exactly zero after the shared 564-frame introduction, for the rest of the
   13,223-frame prefix (about 141 seconds);
 - *The Mummy* (1999): channels 0/3 and 1/2 have sample correlations of 0.9981
@@ -135,7 +324,7 @@ or duplicate content. A first time-local coherence test finds the two *Mummy*
 pairs in 6,388/6,582 and 6,362/6,582 frames respectively. Their normalized
 second-channel gain occupies narrow 10th-to-90th percentile ranges of
 0.5063..0.5189 and 0.4412..0.4599. This favours static duplicated stems over a
-moving pan in that prefix. The silent *La La Land* feeds carry zero PCM, not a
+moving pan in that prefix. The silent the paired language control feeds carry zero PCM, not a
 frame-wise DC control value.
 
 The next test is frequency-local rather than whole-frame: isolate coherent
@@ -147,16 +336,16 @@ would instead support fixed channels or static multichannel stems. This can
 recover only a rendered direction, not necessarily the original object
 coordinates, distance or spread.
 
-The paired *La La Land* language tracks provide a control: spatial gain
+Paired language variants provide a control: spatial gain
 trajectories belonging to shared music and effects should agree despite the
 different dialogue mix. A second useful comparison is coherence between the
 four extension waveforms and the 7.1 bed; strong shared components would be
 consistent with a pre-rendered 12-channel bus, while independent components
 would better support separately carried object waveforms.
 
-### DTS:X Object Emulator control
+### Standard pan control A
 
-The public DTS-authored *DTS:X Object Emulator* test clip is a much stronger
+The controlled *standard-control-A* clip is a much stronger
 control than a feature-film soundtrack because its picture explicitly shows a
 moving source, labels the signal as using 3D coordinates, and then illustrates
 several playback layouts. It does not print numerical azimuth, elevation or
@@ -255,11 +444,44 @@ coordinates instead of the undisclosed 3D animation coordinates. They are
 nevertheless strong enough to confirm that the visible trajectory and decoded
 speaker gains are synchronized.
 
+### Additional movement controls
+
+The complete *standard-control-B* and *standard-control-C* elementary streams add
+two more controlled clips with explicitly animated spatial motion. They retain
+the same representation as the standard pan control A:
+
+- all 3,117 *standard-control-B* frames and all 5,623 *standard-control-C* frames use
+  the standard four-source profile at 48 kHz/24-bit, with no decode error;
+- every frame retains the same fixed 22-byte prefix used by the film corpus
+  and standard pan control A;
+- the extracted elementary streams are bit-identical to the audio tracks in
+  their source containers;
+- after the decoded audio, every payload has only two to five zero bytes of
+  trailer/alignment padding;
+- no fifth waveform, D0/D1 layout, or payload-side coordinate record appears.
+
+A height-only 100 ms covariance analysis finds locally coherent, changing
+gain vectors in both clips. *standard-control-B* has 111 reliable windows with a
+median dominant-source share of 0.9648 and a four-corner separability residual
+of 0.0053. *standard-control-C* has 94 such windows, a median share of 0.9481 and
+a residual of 0.0267. In both, the reliable gain centroids span nearly the
+whole left/right and front/back height plane, normally using two of the four
+height feeds. Useful listening/inspection points are:
+
+- *standard-control-B*: 7.7 s, 9.5 s, 19.6 s, 21.6 s and 28.8–30.2 s;
+- *standard-control-C*: 16.7 s, 19.7 s, 23.9 s, 34.3–36.4 s and 54.8 s.
+
+These clips therefore provide excellent audible motion regressions, but not
+positive controls for retained object metadata. Their motion is observable as
+time-varying gains in the four fixed height waveforms. The analysis tool is
+`scripts/analyze-dtsx-fixed-pan.py`; it deliberately reports a rendered gain
+trajectory rather than calling that trajectory an authoring object.
+
 ### Embedded 7.1 compatibility downmix
 
 The regular 7.1 presentation is not the final lower speaker plane when XLL-X is
 decoded. It contains a backward-compatible copy of each height feed mixed into
-the corresponding lower corner at -3 dB. The Object Emulator exposes this
+the corresponding lower corner at -3 dB. The standard pan control A exposes this
 particularly clearly because it contains isolated single-source pans.
 
 The dominant lower/height gain ratio is `23170 / 32768 = 0.707092285`. This is
@@ -313,17 +535,17 @@ consumer encode carries the result rendered to twelve fixed feeds.
 
 It does not prove that the profile can never append genuine dynamic objects.
 DTS stated at launch that an embedded object can be extracted, and independent
-technical reports identify the US Blu-ray of *Ip Man 3* as an unusual
+technical reports identify an unusual published disc as a
 `7.1.4 + five dynamic objects` encode. A second forum source calls it the
 first DTS:X Blu-ray not locked to 7.1.4. These are useful acquisition leads,
 not primary-source proof. A dump from that exact US disc, or from the reported
-`7.1.4 + one object` *Independence Day* encode, is now the highest-value
+`7.1.4 + one object` *D1 corpus A* encode, is now the highest-value
 comparison: it should contain a structural element absent from both the nine
-films and the Object Emulator if the reports are accurate.
+films and the standard pan control A if the reports are accurate.
 
 Relevant public links:
 
-- Kodi test catalogue and Object Emulator link:
+- Public test catalogue:
   <https://kodi.wiki/view/Samples#HD/object-based_Audio_Test_Clips>
 - DTS patent application describing both a 7.1-channel presentation plus four
   separate height inputs and an alternate 11.1-channel representation:
@@ -331,18 +553,15 @@ Relevant public links:
 - DTS launch statement distinguishing content rendered from channels from
   objects that are actually embedded and extractable:
   <https://dts.com/insights/welcome-to-dtsx-open-immersive-and-flexible-object-based-audio-coming-to-cinema-and-home/>
-- report of five dynamic objects on the US *Ip Man 3* disc:
+- report of five dynamic objects on the unusual disc:
   <https://www.avforums.com/threads/lyngdorf-discussion.1580956/page-592>
-- independent recollection that *Ip Man 3* was the first non-locked DTS:X
+- independent recollection that it was the first non-locked DTS:X
   Blu-ray:
   <https://forum.blu-ray.com/showthread.php?p=20520575>
 
-By contrast, DTS's *Ex Machina* announcement says that DTS:X moves sound
-objects through mixer-selected locations, but it does not state that this
-specific disc retains time-varying object metadata. The local *Ex Machina*
-bitstream has the same fixed four-waveform structure, so that press wording is
-not sufficient evidence of dynamic objects in the title:
-<https://dts.com/insights/lionsgates-ex-machina-blu-ray-disc-is-first-to-feature-dtsx-audio/>.
+Format launch material says that DTS:X moves sound objects through
+mixer-selected locations, but that wording alone does not establish that a
+particular consumer bitstream retains time-varying object metadata.
 
 ## Public specifications used
 
@@ -363,10 +582,13 @@ of the XLL frame; it does not parse this channel set.
 
 - `xll_x_audio.rs`: decode the four waveforms to WAV;
 - `xll_x_chs.rs`: prove/characterize the bare XLL channel set and CRC;
+- `xll_alt_nav.rs`: map the compact control word and channel-set boundaries in
+  the alternate `D0/D1` profile (`[max_mb] quick` skips the expensive header
+  syntax enumeration for full-corpus control statistics);
 - `xll_x_meta.rs`: analyze the reserved 64-bit EXSS descriptor field;
 - `xll_x_pair.rs`: compare aligned language variants;
 - `xll_x_mda.rs`: bit-aligned MDA signature and URI scan;
-- `analyze-dtsx-object-emulator.py`: rank-one gain, raw-FOA, layout activity
+- `analyze-dtsx-pan-control.py`: rank-one gain, raw-FOA, layout activity
   and optional picture/audio trajectory tests for the public control clip;
 - older `xll_x_probe`, `xll_x_rice` and `xll_x_scan` diagnostics remain useful
   as historical/raw-payload tools, but their object-count hypothesis is
@@ -375,22 +597,29 @@ of the XLL frame; it does not parse this channel set.
 Run the control analysis after extracting the regular bed and XLL-X WAVs:
 
 ```sh
-python3 scripts/analyze-dtsx-object-emulator.py \
-  --bed /tmp/dtsx-object-emulator-bed.wav \
-  --height /tmp/dtsx-object-emulator-x.wav \
-  --video /tmp/dtsx-object-emulator.mkv
+python3 scripts/analyze-dtsx-pan-control.py \
+  --bed /tmp/pan-control-bed.wav \
+  --height /tmp/pan-control-x.wav \
+  --video /tmp/input.mkv
 ```
 
 ## Corpus
 
-Re-extracted elementary streams are in:
+The local corpus contains 34 elementary streams: 31 programme tracks plus
+three controlled clips. Source titles, source-container paths and staging
+locations are intentionally not recorded in the repository. Corpus-gated
+tests receive their inputs through environment variables:
 
-```text
-/mnt/local/SSD_A-CT4000/DTS:X-Dumps/
-```
+- `HARLETTY_DTSX_STANDARD_CORPUS`: standard four-source elementary stream;
+- `HARLETTY_D0_CORPUS`, `HARLETTY_D1_CORPUS`, `HARLETTY_D3_CORPUS`:
+  alternate-profile elementary streams;
+- `HARLETTY_DTS_CORE_CORPUS` and `HARLETTY_DTS_CORE_REFERENCE`: DTS core
+  stream and matching interleaved f32le reference;
+- `HARLETTY_DTSX_STANDARD_REFERENCE`: interleaved f32le reference used by the
+  standard lossless-bed regression;
+- `HARLETTY_DTSHD_16BIT_CORPUS` and `HARLETTY_DTSHD_16BIT_REFERENCE`:
+  optional 16-bit lossless-scale regression pair.
 
-Available: *Apollo 13*, *Carlito's Way*, *Ex Machina*, *Gladiator*, *La La
-Land* (English and French), *The Mummy* (1999), *The Mummy Returns*, and *The
-Mummy* (2008). `ffprobe` identifies every track as `DTS-HD MA + DTS:X`, 48 kHz,
-8-channel bed. The previously used *Harry Potter and the Deathly Hallows: Part
-1* source was not found and has not been re-extracted.
+The later D1 wide-fold system-identification experiment, retained tooling and
+automatic experimental presentations are documented in
+[`dtsx-d1-wide-audition.md`](dtsx-d1-wide-audition.md).

--- a/dts-fold.yaml
+++ b/dts-fold.yaml
@@ -1,0 +1,22 @@
+# Experimental compatibility folds. Entries are applied in this order.
+sources:
+  - source: TFL
+    routes: [{target: L, gain_db: -3.0104780234}]
+  - source: TFR
+    routes: [{target: R, gain_db: -3.0104780234}]
+  - source: TBL
+    routes: [{target: Lb, gain_db: -3.0104780234}]
+  - source: TBR
+    routes: [{target: Rb, gain_db: -3.0104780234}]
+  - source: X0
+    routes: [{target: C, gain_db: -6.0206}, {target: L, gain_db: -3.0104780234}]
+  - source: X1
+    routes: [{target: L, gain_db: -3.0104780234}, {target: R, gain_db: -3.0104780234}]
+  - source: X2
+    routes: [{target: R, gain_db: -3.0104780234}, {target: Ls, gain_db: -3.0104780234}, {target: L, gain_db: -3.0104780234}]
+  - source: X3
+    routes: [{target: Lb, gain_db: -3.0104780234}, {target: Rs, gain_db: -3.0104780234}, {target: R, gain_db: -3.0104780234}]
+  - source: X4
+    routes: [{target: Rb, gain_db: -3.0104780234}, {target: Lb, gain_db: -3.0104780234}]
+  - source: X5
+    routes: [{target: Rb, gain_db: -3.0104780234}]

--- a/dts-fold.yaml.example
+++ b/dts-fold.yaml.example
@@ -1,0 +1,22 @@
+# Entries are applied in YAML order. Gains are dB amplitude values.
+sources:
+  - source: TFL
+    routes: [{target: L, gain_db: -3.0104780234}]
+  - source: TFR
+    routes: [{target: R, gain_db: -3.0104780234}]
+  - source: TBL
+    routes: [{target: Lb, gain_db: -3.0104780234}]
+  - source: TBR
+    routes: [{target: Rb, gain_db: -3.0104780234}]
+  - source: X0
+    routes: [{target: C, gain_db: -6.0206}, {target: L, gain_db: -3.0104780234}]
+  - source: X1
+    routes: [{target: L, gain_db: -3.0104780234}, {target: R, gain_db: -3.0104780234}]
+  - source: X2
+    routes: [{target: R, gain_db: -3.0104780234}, {target: Ls, gain_db: -3.0104780234}, {target: L, gain_db: -3.0104780234}]
+  - source: X3
+    routes: [{target: Lb, gain_db: -3.0104780234}, {target: Rs, gain_db: -3.0104780234}, {target: R, gain_db: -3.0104780234}]
+  - source: X4
+    routes: [{target: Rb, gain_db: -3.0104780234}, {target: Lb, gain_db: -3.0104780234}]
+  - source: X5
+    routes: [{target: Rb, gain_db: -3.0104780234}]

--- a/eac3/examples/compare_pcm.rs
+++ b/eac3/examples/compare_pcm.rs
@@ -18,7 +18,7 @@
 //!
 //! Streaming: reads ~16384 samples per channel at a time from each file,
 //! computes diffs incrementally, never materialises the full vectors.
-//! Each pairing is a single pass over both files. The full 2h Dune track
+//! Each pairing is a single pass over both files. A full two-hour witness
 //! produces 11.5 GB f32 files, which would OOM a 60 GB box if loaded
 //! whole for all three pairings (34 GB Vec<f32> peak).
 //!

--- a/eac3/examples/spx_probe.rs
+++ b/eac3/examples/spx_probe.rs
@@ -4,12 +4,12 @@
 //! PcmDecoder and tallies the `spxinu` / `chinspx[ch]` flags after each
 //! frame. Useful when picking content for validating SPX-related
 //! decoder changes (e.g. the `fix/eac3-spx-coordinate-parse` branch),
-//! since not all DDP+ tracks exercise SPX — Dune Part Two's main bed
+//! since not all DDP+ tracks exercise SPX — use a witness known to activate it.
 //! never activates it.
 //!
 //! Usage:
 //!     # From an MKV via ffmpeg:
-//!     ffmpeg -i film.mkv -map 0:a:0 -c:a copy -f eac3 - 2>/dev/null \
+//!     ffmpeg -i input.mkv -map 0:a:0 -c:a copy -f eac3 - 2>/dev/null \
 //!         | cargo run --release --example spx_probe -p eac3 -- -
 //!
 //!     # From a pre-extracted .eac3 file:

--- a/eac3/tests/data/regression-manifest.toml
+++ b/eac3/tests/data/regression-manifest.toml
@@ -14,11 +14,11 @@
 # skips gracefully so CI without NAS access still passes.
 
 [[track]]
-id = "dune-part-two-vff-t1"
+id = "eac3-witness"
 role = "witness"
-source = "/mnt/nas/backup/Videos/EAC3_Atmos/Dune.Part.Two.2024.MULTi.VFF.2160p.UHD.BluRay.REMUX.HEVC.Dolby Vision.HDR.TrueHD Atmos.DDP Atmos-1544.mkv"
+source = "/path/to/eac3-witness.mkv"
 
 [[track]]
-id = "dune-2021-vff"
+id = "eac3-baseline"
 role = "failing"
-source = "/mnt/nas/backup/Videos/EAC3_Atmos/Dune.2021.MULTi.VFF.2160p.UHD.BluRay.REMUX.HEVC.Dolby Vision.HDR.TrueHD Atmos.DDP Atmos-1544.mkv"
+source = "/path/to/eac3-baseline.mkv"

--- a/eac3/tests/mkv_corpus_regression.rs
+++ b/eac3/tests/mkv_corpus_regression.rs
@@ -166,7 +166,7 @@ impl TrackSummary {
         }
         // E-AC-3 PCM at full bitstream scale (no dialnorm, no DRC, no
         // limiter) can legitimately peak well above 1.0 — observed 2.23
-        // on Dune Part Two's main track. FFmpeg with `-drc_scale 0` and
+        // on the main witness track. FFmpeg with `-drc_scale 0` and
         // Cavern (raw decoder, pre-Listener normalizer) peak similarly
         // (1.80 and 1.89 respectively). 4.0 is a sanity ceiling for
         // catastrophic over-range / NaN-like garbage, not a content cap.
@@ -246,7 +246,7 @@ fn run_track(
 ) -> Result<TrackSummary, String> {
     // Prefer the bootstrap-cached harletty PCM (corpus_root/harletty-pcm/<id>.f32).
     // Falling back to an on-the-fly decode would write 11.5 GB to /tmp,
-    // which is tmpfs (RAM-backed) on most systems — the full 2 h Dune
+    // which is tmpfs (RAM-backed) on most systems — a full two-hour
     // track immediately OOM-pressures a 60 GB box. The on-the-fly path
     // is kept for users running the test without bootstrap caches.
     let (harletty_pcm_path, decoded, owned_temp) = if cached_harletty_pcm.exists() {
@@ -255,7 +255,7 @@ fn run_track(
         (cached_harletty_pcm.to_path_buf(), stats, None)
     } else {
         let tmp_path = std::env::temp_dir().join(format!(
-            "eac3-mkv-test-{}.f32",
+            "eac3-mkv-corpus-test-{}.f32",
             eac3_path
                 .file_stem()
                 .and_then(|s| s.to_str())

--- a/scripts/analyze-d3-coordinate-fields.py
+++ b/scripts/analyze-d3-coordinate-fields.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Test whether variable D3 framing fields follow inferred X positions.
+
+The position input is the temporal TSV emitted by
+``analyze-dtsx-bed-fold-limits.py``.  The feature inputs are frame TSV files
+emitted by the ``xll_d3_frame_features`` research example.  Correlations are
+reported both directly and after removing linear dependence on extension
+activity and known navigation/layout quantities.
+
+This is a falsification aid, not a metadata decoder.  In particular, the
+coverage barycentres are content-derived estimates and may move even when the
+authoring coordinates are fixed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+
+WINDOW_SECONDS = 1.0
+NAVIGATION_COLUMNS = [
+    "payload_size",
+    "x_payload_offset",
+    "x_payload_size",
+    "prefix_len",
+    "outer_len",
+    "outer_geometry",
+    "first_offset",
+    "first_size",
+    "inner_len",
+    "inner_geometry",
+    "second_offset",
+    "second_size",
+    "consumed_bytes",
+    "trailer_len",
+]
+HEX_FIELDS = ["descriptor", "prefix", "outer", "inner"]
+COMPONENTS = ["x", "y", "radius", "azimuth_sin", "azimuth_cos"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--features-dir", type=Path, required=True)
+    parser.add_argument("--positions", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--robust-output",
+        type=Path,
+        required=True,
+        help="cross-programme repeatability TSV",
+    )
+    return parser.parse_args()
+
+
+def canonical_title(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower()).replace(
+        "larepeater", "lerepeater"
+    )
+
+
+def read_positions(
+    path: Path,
+) -> dict[str, dict[str, np.ndarray | str]]:
+    grouped: dict[str, list[dict[str, str]]] = defaultdict(list)
+    with path.open(newline="") as source:
+        for row in csv.DictReader(source, dialect="excel-tab"):
+            grouped[canonical_title(row["title"])].append(row)
+
+    result = {}
+    for key, rows in grouped.items():
+        extensions = sorted(
+            {row["extension"] for row in rows},
+            key=lambda value: int(value[1:]),
+        )
+        times = sorted({float(row["audio_time"]) for row in rows})
+        time_index = {value: index for index, value in enumerate(times)}
+        extension_index = {
+            value: index for index, value in enumerate(extensions)
+        }
+        coordinates = np.full((len(times), len(extensions), 2), np.nan)
+        activity = np.zeros((len(times), len(extensions)))
+        for row in rows:
+            time = time_index[float(row["audio_time"])]
+            extension = extension_index[row["extension"]]
+            activity[time, extension] = float(row["activity"])
+            if row["valid"] == "1":
+                coordinates[time, extension] = (
+                    float(row["x"]),
+                    float(row["y"]),
+                )
+        result[key] = {
+            "title": rows[0]["title"],
+            "times": np.asarray(times),
+            "extensions": np.asarray(extensions),
+            "coordinates": coordinates,
+            "activity": activity,
+        }
+    return result
+
+
+def read_feature_rows(
+    path: Path,
+) -> tuple[np.ndarray, list[str], np.ndarray, list[bytes]]:
+    with path.open(newline="") as source:
+        rows = list(csv.DictReader(source, dialect="excel-tab"))
+    if not rows:
+        raise ValueError(f"no D3 frames in {path}")
+
+    names = list(NAVIGATION_COLUMNS)
+    columns = [
+        np.asarray([float(row[name]) for row in rows])
+        for name in NAVIGATION_COLUMNS
+    ]
+    for field in HEX_FIELDS:
+        values = [bytes.fromhex(row[f"{field}_hex"]) for row in rows]
+        width = max(map(len, values))
+        for byte in range(width):
+            byte_values = np.asarray(
+                [value[byte] if byte < len(value) else 0 for value in values],
+                dtype=np.float64,
+            )
+            names.append(f"{field}.byte{byte}")
+            columns.append(byte_values)
+            for bit in range(8):
+                names.append(f"{field}.bit{byte * 8 + bit}")
+                columns.append(
+                    ((byte_values.astype(np.uint8) >> (7 - bit)) & 1).astype(
+                        np.float64
+                    )
+                )
+    return (
+        np.asarray([float(row["time"]) for row in rows]),
+        names,
+        np.column_stack(columns),
+        [bytes.fromhex(row["prefix_hex"]) for row in rows],
+    )
+
+
+def window_means(
+    frame_times: np.ndarray,
+    values: np.ndarray,
+    target_times: np.ndarray,
+) -> np.ndarray:
+    cumulative = np.vstack(
+        (np.zeros((1, values.shape[1])), np.cumsum(values, axis=0))
+    )
+    half = WINDOW_SECONDS / 2.0
+    starts = np.searchsorted(frame_times, target_times - half, side="left")
+    ends = np.searchsorted(frame_times, target_times + half, side="right")
+    counts = np.maximum(ends - starts, 1)
+    return (cumulative[ends] - cumulative[starts]) / counts[:, None]
+
+
+def prefix_bitfield_means(
+    prefixes: list[bytes],
+    frame_times: np.ndarray,
+    target_times: np.ndarray,
+) -> tuple[list[str], np.ndarray]:
+    states = sorted(set(prefixes))
+    state_index = {value: index for index, value in enumerate(states)}
+    assignments = np.asarray([state_index[value] for value in prefixes])
+    width = max(map(len, states))
+    padded = np.zeros((len(states), width), dtype=np.uint8)
+    for index, value in enumerate(states):
+        padded[index, : len(value)] = np.frombuffer(value, dtype=np.uint8)
+    bits = np.unpackbits(padded, axis=1)
+
+    names = []
+    state_features = []
+    for field_width in [8, 10, 12]:
+        windows = np.lib.stride_tricks.sliding_window_view(
+            bits, field_width, axis=1
+        )
+        weights = 1 << np.arange(field_width - 1, -1, -1)
+        unsigned = windows @ weights
+        phase = 2.0 * np.pi * unsigned / (1 << field_width)
+        for offset in range(unsigned.shape[1]):
+            names.extend(
+                [
+                    f"prefix.u{field_width}.bit{offset}",
+                    f"prefix.phase_sin.u{field_width}.bit{offset}",
+                    f"prefix.phase_cos.u{field_width}.bit{offset}",
+                ]
+            )
+            state_features.extend(
+                [
+                    unsigned[:, offset],
+                    np.sin(phase[:, offset]),
+                    np.cos(phase[:, offset]),
+                ]
+            )
+    state_features_array = np.column_stack(state_features)
+
+    half = WINDOW_SECONDS / 2.0
+    starts = np.searchsorted(frame_times, target_times - half, side="left")
+    ends = np.searchsorted(frame_times, target_times + half, side="right")
+    counts = np.zeros((len(target_times), len(states)))
+    for row, (start, end) in enumerate(zip(starts, ends)):
+        counts[row] = np.bincount(
+            assignments[start:end], minlength=len(states)
+        )
+    totals = np.maximum(np.sum(counts, axis=1), 1.0)
+    return names, (counts @ state_features_array) / totals[:, None]
+
+
+def residualize(values: np.ndarray, controls: np.ndarray) -> np.ndarray:
+    finite = np.all(np.isfinite(controls), axis=1)
+    result = np.full_like(values, np.nan, dtype=np.float64)
+    if np.count_nonzero(finite) <= controls.shape[1]:
+        return result
+    design = np.column_stack((np.ones(np.count_nonzero(finite)), controls[finite]))
+    coefficient, *_ = np.linalg.lstsq(design, values[finite], rcond=None)
+    result[finite] = values[finite] - design @ coefficient
+    return result
+
+
+def correlations(features: np.ndarray, target: np.ndarray) -> np.ndarray:
+    x = features - np.mean(features, axis=0)
+    y = target - np.mean(target)
+    x_norm = np.linalg.norm(x, axis=0)
+    y_norm = np.linalg.norm(y)
+    denominator = x_norm * y_norm
+    return np.divide(
+        x.T @ y,
+        denominator,
+        out=np.zeros(features.shape[1]),
+        where=(x_norm > 1e-8) & (y_norm > 1e-8),
+    )
+
+
+def target_components(coordinates: np.ndarray) -> np.ndarray:
+    x = coordinates[:, 0]
+    y = coordinates[:, 1]
+    radius = np.hypot(x, y)
+    azimuth_sin = np.divide(
+        x, radius, out=np.zeros_like(x), where=radius > 1e-12
+    )
+    azimuth_cos = np.divide(
+        y, radius, out=np.zeros_like(y), where=radius > 1e-12
+    )
+    return np.column_stack((x, y, radius, azimuth_sin, azimuth_cos))
+
+
+def block_shift_pvalue(
+    feature: np.ndarray, target: np.ndarray, observed: float
+) -> float:
+    count = len(target)
+    if count < 20:
+        return float("nan")
+    shifts = np.unique(np.linspace(count // 10, 9 * count // 10, 32).astype(int))
+    null = [
+        abs(float(correlations(feature[:, None], np.roll(target, shift))[0]))
+        for shift in shifts
+    ]
+    return (1.0 + sum(value >= observed for value in null)) / (
+        1.0 + len(null)
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    positions = read_positions(args.positions)
+    observations = []
+    repeated: dict[tuple[str, str, str], list[tuple[str, float]]] = defaultdict(
+        list
+    )
+    seen_titles = set()
+
+    for path in sorted(args.features_dir.glob("*.tsv")):
+        key = canonical_title(path.stem)
+        if key not in positions or key in seen_titles:
+            continue
+        seen_titles.add(key)
+        position = positions[key]
+        (
+            frame_times,
+            feature_names,
+            frame_features,
+            prefixes,
+        ) = read_feature_rows(path)
+        times = position["times"]
+        features = window_means(frame_times, frame_features, times)
+        bitfield_names, bitfield_features = prefix_bitfield_means(
+            prefixes, frame_times, times
+        )
+        feature_names.extend(bitfield_names)
+        features = np.column_stack((features, bitfield_features))
+        activities = np.log10(np.asarray(position["activity"]) + 1e-15)
+        activities = np.maximum(activities, np.max(activities, axis=0) - 8.0)
+        navigation = features[:, : len(NAVIGATION_COLUMNS)]
+        controls = np.column_stack((activities, navigation))
+        residual_features = residualize(features, controls)
+
+        for extension_index, extension in enumerate(position["extensions"]):
+            components = target_components(
+                position["coordinates"][:, extension_index]
+            )
+            for component_index, component in enumerate(COMPONENTS):
+                target = components[:, component_index]
+                valid = np.isfinite(target)
+                if np.count_nonzero(valid) < 40:
+                    continue
+                raw = correlations(features[valid], target[valid])
+                residual_target = residualize(
+                    target[valid, None], controls[valid]
+                )[:, 0]
+                selected_features = residual_features[valid]
+                finite = np.isfinite(residual_target)
+                if np.count_nonzero(finite) < 40:
+                    continue
+                partial = correlations(
+                    selected_features[finite], residual_target[finite]
+                )
+                candidate_start = len(NAVIGATION_COLUMNS)
+                midpoint = np.count_nonzero(finite) // 2
+                training = correlations(
+                    selected_features[finite][:midpoint],
+                    residual_target[finite][:midpoint],
+                )
+                candidate = candidate_start + int(
+                    np.argmax(np.abs(training[candidate_start:]))
+                )
+                holdout = float(
+                    correlations(
+                        selected_features[finite][midpoint:, candidate, None],
+                        residual_target[finite][midpoint:],
+                    )[0]
+                )
+                pvalue = block_shift_pvalue(
+                    selected_features[finite][midpoint:, candidate],
+                    residual_target[finite][midpoint:],
+                    abs(holdout),
+                )
+                observations.append(
+                    {
+                        "title": position["title"],
+                        "extension": extension,
+                        "component": component,
+                        "valid_windows": int(np.count_nonzero(valid)),
+                        "feature": feature_names[candidate],
+                        "raw_r": f"{raw[candidate]:.6f}",
+                        "partial_r": f"{partial[candidate]:.6f}",
+                        "holdout_partial_r": f"{holdout:.6f}",
+                        "holdout_block_shift_p": f"{pvalue:.6f}",
+                    }
+                )
+                for feature_index in range(candidate_start, len(feature_names)):
+                    repeated[
+                        (feature_names[feature_index], str(extension), component)
+                    ].append(
+                        (str(position["title"]), float(partial[feature_index]))
+                    )
+
+    fields = [
+        "title",
+        "extension",
+        "component",
+        "valid_windows",
+        "feature",
+        "raw_r",
+        "partial_r",
+        "holdout_partial_r",
+        "holdout_block_shift_p",
+    ]
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", newline="") as target:
+        writer = csv.DictWriter(target, fields, dialect="excel-tab")
+        writer.writeheader()
+        writer.writerows(observations)
+
+    robust_rows = []
+    for (feature, extension, component), values in repeated.items():
+        if len(values) < 5:
+            continue
+        coefficients = np.asarray([value for _, value in values])
+        positive = int(np.count_nonzero(coefficients > 0.15))
+        negative = int(np.count_nonzero(coefficients < -0.15))
+        robust_rows.append(
+            {
+                "feature": feature,
+                "extension": extension,
+                "component": component,
+                "programmes": len(values),
+                "median_abs_partial_r": float(np.median(np.abs(coefficients))),
+                "positive_above_0.15": positive,
+                "negative_below_-0.15": negative,
+                "maximum_same_sign": max(positive, negative),
+                "coefficients": ",".join(
+                    f"{title}:{coefficient:+.3f}"
+                    for title, coefficient in values
+                ),
+            }
+        )
+    robust_rows.sort(
+        key=lambda row: (
+            row["maximum_same_sign"],
+            row["median_abs_partial_r"],
+        ),
+        reverse=True,
+    )
+    robust_fields = [
+        "feature",
+        "extension",
+        "component",
+        "programmes",
+        "median_abs_partial_r",
+        "positive_above_0.15",
+        "negative_below_-0.15",
+        "maximum_same_sign",
+        "coefficients",
+    ]
+    args.robust_output.parent.mkdir(parents=True, exist_ok=True)
+    with args.robust_output.open("w", newline="") as target:
+        writer = csv.DictWriter(target, robust_fields, dialect="excel-tab")
+        writer.writeheader()
+        writer.writerows(robust_rows)
+
+    significant = sum(
+        math.isfinite(float(row["holdout_block_shift_p"]))
+        and float(row["holdout_block_shift_p"]) <= 0.05
+        for row in observations
+    )
+    print(
+        f"tests={len(observations)} significant_holdout_block_shift={significant}"
+    )
+    print(f"details={args.output}")
+    print(f"repeatability={args.robust_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze-d3-prefix-coverages.py
+++ b/scripts/analyze-d3-prefix-coverages.py
@@ -1,0 +1,850 @@
+#!/usr/bin/env python3
+"""Test whether D3 prefix states or fields predict temporal bed-fold coverage.
+
+The prefix TSV inputs come from ``xll_d3_frame_features``.  The coverage TSV
+comes from ``analyze-dtsx-bed-fold-limits.py --temporal-coverage-output``.
+The final two prefix bytes are verified CRC-16/IBM-3740 values and are removed
+before scanning possible 8-, 10- and 12-bit fields.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+
+WINDOW_SECONDS = 1.0
+BED_NAMES = ("C", "L", "R", "Ls", "Rs", "LFE", "Lb", "Rb")
+NAVIGATION_COLUMNS = (
+    "payload_size",
+    "x_payload_offset",
+    "x_payload_size",
+    "prefix_len",
+    "outer_len",
+    "outer_geometry",
+    "first_offset",
+    "first_size",
+    "inner_len",
+    "inner_geometry",
+    "second_offset",
+    "second_size",
+    "consumed_bytes",
+    "trailer_len",
+)
+
+
+@dataclass
+class CoverageTrack:
+    title: str
+    times: np.ndarray
+    coverages: np.ndarray
+    active_blocks: np.ndarray
+
+
+@dataclass
+class PrefixTrack:
+    times: np.ndarray
+    navigation: np.ndarray
+    prefixes: list[bytes]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--features-dir", type=Path, required=True)
+    parser.add_argument("--coverages", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--discovery-title",
+        dest="discovery_titles",
+        action="append",
+        default=[],
+        help=(
+            "programme title assigned to the discovery subset; repeat for "
+            "multiple titles (default: first three titles in lexical order)"
+        ),
+    )
+    return parser.parse_args()
+
+
+def canonical_title(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower()).replace(
+        "larepeater", "lerepeater"
+    )
+
+
+def read_coverages(path: Path) -> dict[str, CoverageTrack]:
+    grouped: dict[str, list[dict[str, str]]] = defaultdict(list)
+    with path.open(newline="") as source:
+        for row in csv.DictReader(source, dialect="excel-tab"):
+            grouped[canonical_title(row["title"])].append(row)
+
+    tracks = {}
+    for key, rows in grouped.items():
+        times = sorted({float(row["audio_time"]) for row in rows})
+        extensions = sorted(
+            {row["extension"] for row in rows},
+            key=lambda value: int(value[1:]),
+        )
+        time_index = {value: index for index, value in enumerate(times)}
+        extension_index = {
+            value: index for index, value in enumerate(extensions)
+        }
+        bed_index = {value: index for index, value in enumerate(BED_NAMES)}
+        coverages = np.full(
+            (len(times), len(extensions), len(BED_NAMES)), np.nan
+        )
+        active_blocks = np.zeros((len(times), len(extensions)))
+        for row in rows:
+            time = time_index[float(row["audio_time"])]
+            extension = extension_index[row["extension"]]
+            active_blocks[time, extension] = float(row["active_blocks"])
+            if row["valid"] == "1":
+                coverages[time, extension, bed_index[row["bed"]]] = float(
+                    row["coverage"]
+                )
+        tracks[key] = CoverageTrack(
+            title=rows[0]["title"],
+            times=np.asarray(times),
+            coverages=coverages,
+            active_blocks=active_blocks,
+        )
+    return tracks
+
+
+def read_prefix_track(path: Path) -> PrefixTrack:
+    with path.open(newline="") as source:
+        rows = list(csv.DictReader(source, dialect="excel-tab"))
+    return PrefixTrack(
+        times=np.asarray([float(row["time"]) for row in rows]),
+        navigation=np.column_stack(
+            [
+                np.asarray([float(row[name]) for row in rows])
+                for name in NAVIGATION_COLUMNS
+            ]
+        ),
+        prefixes=[bytes.fromhex(row["prefix_hex"]) for row in rows],
+    )
+
+
+def window_bounds(
+    frame_times: np.ndarray, target_times: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    half = WINDOW_SECONDS / 2.0
+    return (
+        np.searchsorted(frame_times, target_times - half, side="left"),
+        np.searchsorted(frame_times, target_times + half, side="right"),
+    )
+
+
+def window_means(
+    frame_times: np.ndarray,
+    values: np.ndarray,
+    target_times: np.ndarray,
+) -> np.ndarray:
+    cumulative = np.vstack(
+        (np.zeros((1, values.shape[1])), np.cumsum(values, axis=0))
+    )
+    starts, ends = window_bounds(frame_times, target_times)
+    counts = np.maximum(ends - starts, 1)
+    return (cumulative[ends] - cumulative[starts]) / counts[:, None]
+
+
+def prefix_window_data(
+    track: PrefixTrack, target_times: np.ndarray
+) -> tuple[list[bytes], np.ndarray, list[str], np.ndarray]:
+    states = sorted(set(track.prefixes))
+    state_index = {value: index for index, value in enumerate(states)}
+    assignments = np.asarray(
+        [state_index[value] for value in track.prefixes]
+    )
+    starts, ends = window_bounds(track.times, target_times)
+    proportions = np.zeros((len(target_times), len(states)))
+    for row, (start, end) in enumerate(zip(starts, ends)):
+        proportions[row] = np.bincount(
+            assignments[start:end], minlength=len(states)
+        )
+    totals = np.maximum(np.sum(proportions, axis=1), 1.0)
+    proportions /= totals[:, None]
+    dominant = np.argmax(proportions, axis=1)
+
+    bodies = [value[:-2] for value in states]
+    width = max(map(len, bodies))
+    padded = np.zeros((len(states), width), dtype=np.uint8)
+    for index, value in enumerate(bodies):
+        padded[index, : len(value)] = np.frombuffer(value, dtype=np.uint8)
+    bits = np.unpackbits(padded, axis=1)
+
+    names = []
+    state_features = []
+    for field_width in (8, 10, 12):
+        windows = np.lib.stride_tricks.sliding_window_view(
+            bits, field_width, axis=1
+        )
+        weights = 1 << np.arange(field_width - 1, -1, -1)
+        unsigned = windows @ weights
+        phase = 2.0 * np.pi * unsigned / (1 << field_width)
+        for offset in range(unsigned.shape[1]):
+            names.extend(
+                (
+                    f"u{field_width}.bit{offset}",
+                    f"phase_sin.u{field_width}.bit{offset}",
+                    f"phase_cos.u{field_width}.bit{offset}",
+                )
+            )
+            state_features.extend(
+                (
+                    unsigned[:, offset],
+                    np.sin(phase[:, offset]),
+                    np.cos(phase[:, offset]),
+                )
+            )
+    features = proportions @ np.column_stack(state_features)
+    return states, dominant, names, features
+
+
+def residualize(values: np.ndarray, controls: np.ndarray) -> np.ndarray:
+    result = np.full_like(values, np.nan, dtype=np.float64)
+    finite = np.all(np.isfinite(controls), axis=1)
+    if np.count_nonzero(finite) <= controls.shape[1]:
+        return result
+    design = np.column_stack((np.ones(np.count_nonzero(finite)), controls[finite]))
+    coefficient, *_ = np.linalg.lstsq(design, values[finite], rcond=None)
+    result[finite] = values[finite] - design @ coefficient
+    return result
+
+
+def correlations(features: np.ndarray, target: np.ndarray) -> np.ndarray:
+    x = features - np.mean(features, axis=0)
+    y = target - np.mean(target)
+    x_norm = np.linalg.norm(x, axis=0)
+    y_norm = np.linalg.norm(y)
+    denominator = x_norm * y_norm
+    return np.divide(
+        x.T @ y,
+        denominator,
+        out=np.zeros(features.shape[1]),
+        where=(x_norm > 1e-8) & (y_norm > 1e-8),
+    )
+
+
+def block_shift_pvalue(
+    feature: np.ndarray, target: np.ndarray, observed: float
+) -> float:
+    count = len(target)
+    if count < 20:
+        return float("nan")
+    shifts = np.unique(np.linspace(count // 10, 9 * count // 10, 32).astype(int))
+    null = [
+        abs(float(correlations(feature[:, None], np.roll(target, shift))[0]))
+        for shift in shifts
+    ]
+    return (1.0 + sum(value >= observed for value in null)) / (
+        1.0 + len(null)
+    )
+
+
+def categorical_metrics(
+    labels: np.ndarray, target: np.ndarray
+) -> tuple[float, float, float, float]:
+    valid = np.isfinite(target)
+    if np.count_nonzero(valid) < 40:
+        return (float("nan"),) * 4
+    values = target[valid]
+    variance = float(np.var(values))
+    if variance <= 1e-12:
+        return 0.0, 0.0, 1.0, 1.0
+    valid_labels = labels[valid]
+    means = {
+        state: float(np.mean(values[valid_labels == state]))
+        for state in np.unique(valid_labels)
+    }
+    prediction = np.asarray([means[state] for state in valid_labels])
+    eta_squared = 1.0 - float(
+        np.mean((values - prediction) ** 2) / variance
+    )
+    null = []
+    for shift in np.unique(
+        np.linspace(
+            len(valid_labels) // 10,
+            9 * len(valid_labels) // 10,
+            32,
+        ).astype(int)
+    ):
+        shifted = np.roll(valid_labels, shift)
+        shifted_means = {
+            state: float(np.mean(values[shifted == state]))
+            for state in np.unique(shifted)
+        }
+        shifted_prediction = np.asarray(
+            [shifted_means[state] for state in shifted]
+        )
+        null.append(
+            1.0
+            - float(
+                np.mean((values - shifted_prediction) ** 2) / variance
+            )
+        )
+    pvalue = (1.0 + sum(value >= eta_squared for value in null)) / (
+        1.0 + len(null)
+    )
+
+    midpoint = len(target) // 2
+    train = valid & (np.arange(len(target)) < midpoint)
+    test = valid & (np.arange(len(target)) >= midpoint)
+    if np.count_nonzero(train) == 0 or np.count_nonzero(test) == 0:
+        return eta_squared, float("nan"), 0.0, pvalue
+    baseline = float(np.mean(target[train]))
+    state_means = {
+        state: float(np.mean(target[train & (labels == state)]))
+        for state in np.unique(labels[train])
+    }
+    seen = test & np.isin(labels, list(state_means))
+    seen_fraction = np.count_nonzero(seen) / np.count_nonzero(test)
+    if np.count_nonzero(seen) < 20:
+        return eta_squared, float("nan"), seen_fraction, pvalue
+    predicted = np.asarray([state_means[state] for state in labels[seen]])
+    model_error = float(np.mean((target[seen] - predicted) ** 2))
+    baseline_error = float(np.mean((target[seen] - baseline) ** 2))
+    skill = (
+        1.0 - model_error / baseline_error
+        if baseline_error > 1e-12
+        else 0.0
+    )
+
+    return eta_squared, skill, seen_fraction, pvalue
+
+
+def transition_metrics(
+    labels: np.ndarray, coverages: np.ndarray
+) -> tuple[int, float, float, float]:
+    flattened = coverages.reshape(len(coverages), -1)
+    transition = np.flatnonzero(labels[1:] != labels[:-1]) + 1
+    candidates = np.arange(1, len(labels) - 1)
+    scores = np.full(len(labels), np.nan)
+    for index in candidates:
+        a = flattened[index - 1]
+        b = flattened[index + 1]
+        valid = np.isfinite(a) & np.isfinite(b)
+        if np.count_nonzero(valid) >= 8:
+            scores[index] = float(
+                np.sqrt(np.mean((b[valid] - a[valid]) ** 2))
+            )
+    actual = scores[transition]
+    actual = actual[np.isfinite(actual)]
+    other = scores[np.setdiff1d(candidates, transition)]
+    other = other[np.isfinite(other)]
+    if actual.size == 0 or other.size == 0:
+        return len(transition), float("nan"), float("nan"), float("nan")
+    actual_median = float(np.median(actual))
+    other_median = float(np.median(other))
+    random = np.random.default_rng(0)
+    null = [
+        float(
+            np.median(
+                random.choice(
+                    other,
+                    size=min(len(actual), len(other)),
+                    replace=False,
+                )
+            )
+        )
+        for _ in range(1000)
+    ]
+    pvalue = (1.0 + sum(value >= actual_median for value in null)) / 1001.0
+    return len(transition), actual_median, other_median, pvalue
+
+
+def vector_correlation(a: np.ndarray, b: np.ndarray) -> float:
+    valid = np.isfinite(a) & np.isfinite(b)
+    if np.count_nonzero(valid) < 8:
+        return float("nan")
+    x = a[valid] - np.mean(a[valid])
+    y = b[valid] - np.mean(b[valid])
+    denominator = np.linalg.norm(x) * np.linalg.norm(y)
+    return float(np.dot(x, y) / denominator) if denominator > 1e-12 else float(
+        "nan"
+    )
+
+
+def write_rows(path: Path, fields: list[str], rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as target:
+        writer = csv.DictWriter(target, fields, dialect="excel-tab")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    args = parse_args()
+    coverage_tracks = read_coverages(args.coverages)
+    categorical_rows = []
+    field_rows = []
+    summary_rows = []
+    bit299_programme_rows = []
+    correlations_by_title = {}
+    state_vectors_by_title: dict[str, dict[bytes, np.ndarray]] = {}
+
+    seen_titles = set()
+    for path in sorted(args.features_dir.glob("*.tsv")):
+        key = canonical_title(path.stem)
+        if key not in coverage_tracks or key in seen_titles:
+            continue
+        seen_titles.add(key)
+        coverage = coverage_tracks[key]
+        prefix = read_prefix_track(path)
+        states, labels, feature_names, features = prefix_window_data(
+            prefix, coverage.times
+        )
+        bit299_index = feature_names.index("phase_cos.u10.bit299")
+        for extension in range(coverage.coverages.shape[1]):
+            for bed, bed_name in enumerate(BED_NAMES):
+                target = coverage.coverages[:, extension, bed]
+                valid = np.isfinite(target)
+                if not np.any(valid):
+                    continue
+                bit299_programme_rows.append(
+                    {
+                        "title": coverage.title,
+                        "extension": f"X{extension}",
+                        "bed": bed_name,
+                        "field_mean": f"{np.mean(features[valid, bit299_index]):.9f}",
+                        "coverage_mean": f"{np.mean(target[valid]):.9f}",
+                    }
+                )
+        navigation = window_means(
+            prefix.times, prefix.navigation, coverage.times
+        )
+        activity = np.log1p(coverage.active_blocks)
+        controls = np.column_stack((activity, navigation))
+        title_correlations = np.zeros(
+            (len(feature_names), coverage.coverages.shape[1], len(BED_NAMES))
+        )
+        title_holdout_correlations = np.zeros_like(title_correlations)
+        flattened_coverages = coverage.coverages.reshape(
+            len(coverage.times), -1
+        )
+        state_vectors = {}
+        for state_index, state in enumerate(states):
+            selected = labels == state_index
+            if np.count_nonzero(selected) < 2:
+                continue
+            values = flattened_coverages[selected]
+            finite = np.isfinite(values)
+            counts = np.sum(finite, axis=0)
+            vector = np.divide(
+                np.nansum(values, axis=0),
+                counts,
+                out=np.full(values.shape[1], np.nan),
+                where=counts > 0,
+            )
+            if np.count_nonzero(np.isfinite(vector)) >= 8:
+                state_vectors[state] = vector
+        state_vectors_by_title[coverage.title] = state_vectors
+
+        eta_values = []
+        skill_values = []
+        seen_values = []
+        significant_categories = 0
+        for extension in range(coverage.coverages.shape[1]):
+            extension_valid = np.all(
+                np.isfinite(coverage.coverages[:, extension]), axis=1
+            )
+            valid_count = np.count_nonzero(extension_valid)
+            extension_features = features[extension_valid]
+            extension_controls = controls[extension_valid]
+            midpoint = valid_count // 2
+            if valid_count >= 40:
+                full_residual_features = residualize(
+                    extension_features, extension_controls
+                )
+                training_residual_features = residualize(
+                    extension_features[:midpoint],
+                    extension_controls[:midpoint],
+                )
+                holdout_residual_features = residualize(
+                    extension_features[midpoint:],
+                    extension_controls[midpoint:],
+                )
+            for bed, bed_name in enumerate(BED_NAMES):
+                target = coverage.coverages[:, extension, bed]
+                eta, skill, seen, category_p = categorical_metrics(
+                    labels, target
+                )
+                categorical_rows.append(
+                    {
+                        "title": coverage.title,
+                        "extension": f"X{extension}",
+                        "bed": bed_name,
+                        "prefix_states": len(set(prefix.prefixes)),
+                        "eta_squared": f"{eta:.6f}",
+                        "holdout_skill": f"{skill:.6f}",
+                        "holdout_seen_fraction": f"{seen:.6f}",
+                        "block_shift_p": f"{category_p:.6f}",
+                    }
+                )
+                if math.isfinite(eta):
+                    eta_values.append(eta)
+                if math.isfinite(skill):
+                    skill_values.append(skill)
+                if math.isfinite(seen):
+                    seen_values.append(seen)
+                if math.isfinite(category_p) and category_p <= 0.05:
+                    significant_categories += 1
+
+                if valid_count < 40:
+                    continue
+                extension_target = target[extension_valid]
+                full_residual_target = residualize(
+                    extension_target[:, None], extension_controls
+                )[:, 0]
+                if np.count_nonzero(np.isfinite(full_residual_target)) < 40:
+                    continue
+                full_correlation = correlations(
+                    full_residual_features, full_residual_target
+                )
+                title_correlations[:, extension, bed] = full_correlation
+                training_residual_target = residualize(
+                    extension_target[:midpoint, None],
+                    extension_controls[:midpoint],
+                )[:, 0]
+                holdout_residual_target = residualize(
+                    extension_target[midpoint:, None],
+                    extension_controls[midpoint:],
+                )[:, 0]
+                training = correlations(
+                    training_residual_features,
+                    training_residual_target,
+                )
+                candidate = int(np.argmax(np.abs(training)))
+                holdout_correlations = correlations(
+                    holdout_residual_features,
+                    holdout_residual_target,
+                )
+                title_holdout_correlations[:, extension, bed] = (
+                    holdout_correlations
+                )
+                holdout = float(holdout_correlations[candidate])
+                pvalue = block_shift_pvalue(
+                    holdout_residual_features[:, candidate],
+                    holdout_residual_target,
+                    abs(holdout),
+                )
+                field_rows.append(
+                    {
+                        "title": coverage.title,
+                        "extension": f"X{extension}",
+                        "bed": bed_name,
+                        "feature": feature_names[candidate],
+                        "partial_r": f"{full_correlation[candidate]:.6f}",
+                        "holdout_partial_r": f"{holdout:.6f}",
+                        "holdout_block_shift_p": f"{pvalue:.6f}",
+                    }
+                )
+
+        (
+            transition_count,
+            transition_median,
+            ordinary_median,
+            transition_p,
+        ) = transition_metrics(labels, coverage.coverages)
+        summary_rows.append(
+            {
+                "title": coverage.title,
+                "prefix_states": len(set(prefix.prefixes)),
+                "window_transitions": transition_count,
+                "median_eta_squared": f"{np.nanmedian(eta_values):.6f}",
+                "maximum_eta_squared": f"{np.nanmax(eta_values):.6f}",
+                "median_holdout_skill": (
+                    f"{np.nanmedian(skill_values):.6f}"
+                    if skill_values
+                    else ""
+                ),
+                "positive_holdout_targets": sum(
+                    value > 0.0 for value in skill_values
+                ),
+                "median_seen_fraction": f"{np.nanmedian(seen_values):.6f}",
+                "significant_categorical_targets": significant_categories,
+                "transition_coverage_rms": f"{transition_median:.6f}",
+                "ordinary_coverage_rms": f"{ordinary_median:.6f}",
+                "transition_p": f"{transition_p:.6f}",
+            }
+        )
+        correlations_by_title[coverage.title] = (
+            {
+                feature: index
+                for index, feature in enumerate(feature_names)
+            },
+            title_correlations,
+            title_holdout_correlations,
+        )
+
+    common_features = set.intersection(
+        *(
+            set(feature_indices)
+            for feature_indices, _, _ in correlations_by_title.values()
+        )
+    )
+    common_features = sorted(common_features)
+    repeatability_rows = []
+    for feature in common_features:
+        values = []
+        for title, (
+            feature_indices,
+            title_correlations,
+            title_holdout_correlations,
+        ) in (
+            correlations_by_title.items()
+        ):
+            index = feature_indices[feature]
+            values.append(
+                (
+                    title,
+                    title_correlations[index],
+                    title_holdout_correlations[index],
+                )
+            )
+        for extension in range(8):
+            for bed, bed_name in enumerate(BED_NAMES):
+                coefficients = np.asarray(
+                    [matrix[extension, bed] for _, matrix, _ in values]
+                )
+                holdout_coefficients = np.asarray(
+                    [matrix[extension, bed] for _, _, matrix in values]
+                )
+                varying = np.abs(coefficients) > 1e-12
+                positive = int(np.count_nonzero(coefficients > 0.15))
+                negative = int(np.count_nonzero(coefficients < -0.15))
+                same_sign = max(positive, negative)
+                median = (
+                    float(np.median(np.abs(coefficients[varying])))
+                    if np.any(varying)
+                    else 0.0
+                )
+                if same_sign < 3 and median < 0.15:
+                    continue
+                repeatability_rows.append(
+                    {
+                        "feature": feature,
+                        "extension": f"X{extension}",
+                        "bed": bed_name,
+                        "programmes": len(values),
+                        "varying_programmes": int(np.count_nonzero(varying)),
+                        "median_abs_partial_r": f"{median:.6f}",
+                        "positive_above_0.15": positive,
+                        "negative_below_-0.15": negative,
+                        "maximum_same_sign": same_sign,
+                        "coefficients": ",".join(
+                            f"{title}:{matrix[extension, bed]:+.3f}"
+                            for title, matrix, _ in values
+                        ),
+                        "holdout_coefficients": ",".join(
+                            f"{title}:{matrix[extension, bed]:+.3f}"
+                            for title, _, matrix in values
+                        ),
+                    }
+                )
+    repeatability_rows.sort(
+        key=lambda row: (
+            row["maximum_same_sign"],
+            float(row["median_abs_partial_r"]),
+        ),
+        reverse=True,
+    )
+
+    shared_state_rows = []
+    titles = sorted(state_vectors_by_title)
+    for left_index, left_title in enumerate(titles):
+        left = state_vectors_by_title[left_title]
+        for right_title in titles[left_index + 1 :]:
+            right = state_vectors_by_title[right_title]
+            for state in set(left) & set(right):
+                observed = vector_correlation(left[state], right[state])
+                if not math.isfinite(observed):
+                    continue
+                null = [
+                    vector_correlation(left_vector, right_vector)
+                    for left_state, left_vector in left.items()
+                    for right_state, right_vector in right.items()
+                    if left_state != right_state
+                ]
+                null = [value for value in null if math.isfinite(value)]
+                percentile = (
+                    float(np.mean(np.asarray(null) <= observed))
+                    if null
+                    else float("nan")
+                )
+                shared_state_rows.append(
+                    {
+                        "left_title": left_title,
+                        "right_title": right_title,
+                        "prefix_len": len(state),
+                        "prefix_hex": state.hex(),
+                        "coverage_vector_r": f"{observed:.6f}",
+                        "different_prefix_median_r": (
+                            f"{np.median(null):.6f}" if null else ""
+                        ),
+                        "within_pair_percentile": f"{percentile:.6f}",
+                        "different_prefix_pairs": len(null),
+                    }
+                )
+
+    bit299_summary_rows = []
+    discovery_titles = set(args.discovery_titles)
+    if not discovery_titles:
+        discovery_titles = set(titles[:3])
+    for group, selected_titles in (
+        ("all", set(titles)),
+        ("discovery", discovery_titles),
+        ("validation", set(titles) - discovery_titles),
+    ):
+        for extension in range(8):
+            for bed_name in BED_NAMES:
+                selected = [
+                    row
+                    for row in bit299_programme_rows
+                    if row["title"] in selected_titles
+                    and row["extension"] == f"X{extension}"
+                    and row["bed"] == bed_name
+                ]
+                x = np.asarray(
+                    [float(row["field_mean"]) for row in selected]
+                )
+                y = np.asarray(
+                    [float(row["coverage_mean"]) for row in selected]
+                )
+                correlation = (
+                    float(np.corrcoef(x, y)[0, 1])
+                    if len(selected) >= 3
+                    and np.std(x) > 1e-12
+                    and np.std(y) > 1e-12
+                    else float("nan")
+                )
+                bit299_summary_rows.append(
+                    {
+                        "group": group,
+                        "programmes": len(selected),
+                        "extension": f"X{extension}",
+                        "bed": bed_name,
+                        "programme_mean_r": f"{correlation:.6f}",
+                    }
+                )
+
+    write_rows(
+        args.output_dir / "categorical.tsv",
+        [
+            "title",
+            "extension",
+            "bed",
+            "prefix_states",
+            "eta_squared",
+            "holdout_skill",
+            "holdout_seen_fraction",
+            "block_shift_p",
+        ],
+        categorical_rows,
+    )
+    write_rows(
+        args.output_dir / "field-tests.tsv",
+        [
+            "title",
+            "extension",
+            "bed",
+            "feature",
+            "partial_r",
+            "holdout_partial_r",
+            "holdout_block_shift_p",
+        ],
+        field_rows,
+    )
+    write_rows(
+        args.output_dir / "field-repeatability.tsv",
+        [
+            "feature",
+            "extension",
+            "bed",
+            "programmes",
+            "varying_programmes",
+            "median_abs_partial_r",
+            "positive_above_0.15",
+            "negative_below_-0.15",
+            "maximum_same_sign",
+            "coefficients",
+            "holdout_coefficients",
+        ],
+        repeatability_rows,
+    )
+    write_rows(
+        args.output_dir / "summary.tsv",
+        [
+            "title",
+            "prefix_states",
+            "window_transitions",
+            "median_eta_squared",
+            "maximum_eta_squared",
+            "median_holdout_skill",
+            "positive_holdout_targets",
+            "median_seen_fraction",
+            "significant_categorical_targets",
+            "transition_coverage_rms",
+            "ordinary_coverage_rms",
+            "transition_p",
+        ],
+        summary_rows,
+    )
+    write_rows(
+        args.output_dir / "shared-prefixes.tsv",
+        [
+            "left_title",
+            "right_title",
+            "prefix_len",
+            "prefix_hex",
+            "coverage_vector_r",
+            "different_prefix_median_r",
+            "within_pair_percentile",
+            "different_prefix_pairs",
+        ],
+        shared_state_rows,
+    )
+    write_rows(
+        args.output_dir / "bit299-programmes.tsv",
+        [
+            "title",
+            "extension",
+            "bed",
+            "field_mean",
+            "coverage_mean",
+        ],
+        bit299_programme_rows,
+    )
+    write_rows(
+        args.output_dir / "bit299-summary.tsv",
+        [
+            "group",
+            "programmes",
+            "extension",
+            "bed",
+            "programme_mean_r",
+        ],
+        bit299_summary_rows,
+    )
+    print(f"titles={len(summary_rows)}")
+    print(f"summary={args.output_dir / 'summary.tsv'}")
+    print(f"categorical={args.output_dir / 'categorical.tsv'}")
+    print(f"field_tests={args.output_dir / 'field-tests.tsv'}")
+    print(
+        f"field_repeatability="
+        f"{args.output_dir / 'field-repeatability.tsv'}"
+    )
+    print(f"shared_prefixes={args.output_dir / 'shared-prefixes.tsv'}")
+    print(f"bit299_summary={args.output_dir / 'bit299-summary.tsv'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze-dtsx-atmos-pairs.py
+++ b/scripts/analyze-dtsx-atmos-pairs.py
@@ -1,0 +1,769 @@
+#!/usr/bin/env python3
+"""Compare aligned DTS:X and TrueHD Atmos programme envelopes.
+
+This research script consumes frame-RMS files produced by the
+``xll_rms_envelope`` example and the DAMF files produced by ``truehdd``.  It
+aligns alternate encodes by their total-power envelopes, measures
+channel-to-channel activity correspondence, and fits a non-negative static
+power mixture for each DTS channel.  It does not claim to decode DTS:X object
+metadata or a normative clustering matrix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import yaml
+from scipy.optimize import nnls
+from scipy.signal import correlate, correlation_lags
+
+
+FRAME_SAMPLES = 512
+SAMPLE_RATE = 48_000
+FRAME_SECONDS = FRAME_SAMPLES / SAMPLE_RATE
+ATMOS_CHANNELS = 16
+
+
+@dataclass
+class DtsxEnvelope:
+    values: np.ndarray
+    names: list[str]
+
+
+@dataclass
+class ObjectMotion:
+    object_id: int
+    unique_positions: int
+    changes: int
+    displacement: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--atmos-dir",
+        type=Path,
+        required=True,
+        help="directory containing truehdd .atmos.audio/.metadata outputs",
+    )
+    parser.add_argument(
+        "--dtsx-rms-dir",
+        type=Path,
+        required=True,
+        help="directory containing <title>.dtsx-rms.f32le/.txt files",
+    )
+    parser.add_argument(
+        "--dtsx-audio-dir",
+        type=Path,
+        help="directory containing the extracted DTS elementary streams",
+    )
+    parser.add_argument(
+        "--xll-pcm-range",
+        type=Path,
+        help="compiled dca xll_pcm_range example for waveform checks",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        required=True,
+        help="directory for compact Atmos RMS caches",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="TSV summary output",
+    )
+    parser.add_argument(
+        "--max-lag-seconds",
+        type=float,
+        default=60.0,
+        help="maximum absolute alignment offset",
+    )
+    parser.add_argument(
+        "--waveform-seconds",
+        type=float,
+        default=10.0,
+        help="active programme duration used for sample-level checks",
+    )
+    return parser.parse_args()
+
+
+def read_dtsx_envelope(directory: Path, title: str) -> DtsxEnvelope:
+    info_path = directory / f"{title}.dtsx-rms.txt"
+    pcm_path = directory / f"{title}.dtsx-rms.f32le"
+    info = info_path.read_text()
+    names_match = re.search(r"^channel_order=(.+)$", info, re.MULTILINE)
+    if names_match is None:
+        raise ValueError(f"missing channel order in {info_path}")
+    names = names_match.group(1).split(",")
+    values = np.fromfile(pcm_path, dtype="<f4")
+    if values.size % len(names):
+        raise ValueError(f"partial RMS row in {pcm_path}")
+    return DtsxEnvelope(values.reshape(-1, len(names)), names)
+
+
+def write_atmos_envelope(audio_path: Path, output_path: Path) -> None:
+    command = [
+        "ffmpeg",
+        "-loglevel",
+        "quiet",
+        "-i",
+        str(audio_path),
+        "-map",
+        "0:a:0",
+        "-c:a",
+        "pcm_f32le",
+        "-f",
+        "f32le",
+        "-",
+    ]
+    process = subprocess.Popen(command, stdout=subprocess.PIPE)
+    assert process.stdout is not None
+    frame_bytes = FRAME_SAMPLES * ATMOS_CHANNELS * 4
+    pending = bytearray()
+    rows: list[np.ndarray] = []
+    while chunk := process.stdout.read(1024 * 1024):
+        pending.extend(chunk)
+        complete = len(pending) // frame_bytes
+        if complete == 0:
+            continue
+        byte_count = complete * frame_bytes
+        samples = np.frombuffer(
+            memoryview(pending)[:byte_count], dtype="<f4"
+        ).copy()
+        samples = samples.reshape(complete, FRAME_SAMPLES, ATMOS_CHANNELS)
+        rows.append(np.sqrt(np.mean(samples.astype(np.float64) ** 2, axis=1)))
+        del pending[:byte_count]
+    return_code = process.wait()
+    if return_code:
+        raise RuntimeError(f"ffmpeg failed for {audio_path}: {return_code}")
+    if pending:
+        sample_bytes = ATMOS_CHANNELS * 4
+        complete_samples = len(pending) // sample_bytes
+        if complete_samples:
+            samples = np.frombuffer(
+                memoryview(pending)[: complete_samples * sample_bytes],
+                dtype="<f4",
+            ).copy()
+            samples = samples.reshape(complete_samples, ATMOS_CHANNELS)
+            rows.append(
+                np.sqrt(
+                    np.mean(samples.astype(np.float64) ** 2, axis=0)
+                )[None, :]
+            )
+    envelope = np.concatenate(rows).astype("<f4", copy=False)
+    envelope.tofile(output_path)
+
+
+def read_atmos_envelope(
+    audio_path: Path, cache_path: Path
+) -> np.ndarray:
+    if not cache_path.is_file():
+        print(f"atmos-rms\t{audio_path.stem.removesuffix('.atmos')}")
+        write_atmos_envelope(audio_path, cache_path)
+    values = np.fromfile(cache_path, dtype="<f4")
+    if values.size % ATMOS_CHANNELS:
+        raise ValueError(f"partial Atmos RMS row in {cache_path}")
+    return values.reshape(-1, ATMOS_CHANNELS)
+
+
+def overlap_slices(
+    atmosphere: np.ndarray, dtsx: np.ndarray, lag: int
+) -> tuple[np.ndarray, np.ndarray]:
+    if lag >= 0:
+        count = min(len(dtsx), len(atmosphere) - lag)
+        return atmosphere[lag : lag + count], dtsx[:count]
+    count = min(len(atmosphere), len(dtsx) + lag)
+    return atmosphere[:count], dtsx[-lag : -lag + count]
+
+
+def pearson(x: np.ndarray, y: np.ndarray) -> float:
+    x = x.astype(np.float64, copy=False)
+    y = y.astype(np.float64, copy=False)
+    x = x - np.mean(x)
+    y = y - np.mean(y)
+    denominator = np.linalg.norm(x) * np.linalg.norm(y)
+    return float(np.dot(x, y) / denominator) if denominator else float("nan")
+
+
+def normalized_lag_score(
+    atmosphere: np.ndarray, dtsx: np.ndarray, max_lag: int
+) -> tuple[int, float]:
+    atmosphere = atmosphere.astype(np.float64, copy=False)
+    dtsx = dtsx.astype(np.float64, copy=False)
+    cross = correlate(atmosphere, dtsx, mode="full", method="fft")
+    lags = correlation_lags(len(atmosphere), len(dtsx), mode="full")
+    keep = np.flatnonzero(np.abs(lags) <= max_lag)
+    best_lag = 0
+    best_score = -np.inf
+    for index in keep:
+        lag = int(lags[index])
+        a, d = overlap_slices(atmosphere, dtsx, lag)
+        if len(a) < 100:
+            continue
+        numerator = (
+            cross[index]
+            - float(np.sum(a)) * float(np.sum(d)) / len(a)
+        )
+        a_var = float(np.dot(a, a) - np.sum(a) ** 2 / len(a))
+        d_var = float(np.dot(d, d) - np.sum(d) ** 2 / len(d))
+        if a_var <= 0.0 or d_var <= 0.0:
+            continue
+        score = numerator / np.sqrt(a_var * d_var)
+        if score > best_score:
+            best_lag = lag
+            best_score = score
+    return best_lag, float(best_score)
+
+
+def correlation_matrix(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+    x = x.astype(np.float64, copy=False)
+    y = y.astype(np.float64, copy=False)
+    x = x - np.mean(x, axis=0)
+    y = y - np.mean(y, axis=0)
+    denominator = np.sqrt(
+        np.sum(x * x, axis=0)[:, None] * np.sum(y * y, axis=0)[None, :]
+    )
+    return np.divide(
+        x.T @ y,
+        denominator,
+        out=np.zeros((x.shape[1], y.shape[1])),
+        where=denominator > 0.0,
+    )
+
+
+def fit_power_mixtures(
+    atmosphere_rms: np.ndarray, dtsx_rms: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    atmosphere_power = atmosphere_rms.astype(np.float64) ** 2
+    dtsx_power = dtsx_rms.astype(np.float64) ** 2
+    scale = np.sqrt(np.mean(atmosphere_power * atmosphere_power, axis=0))
+    scale[scale == 0.0] = 1.0
+    design = atmosphere_power / scale
+    weights = np.zeros((dtsx_power.shape[1], ATMOS_CHANNELS))
+    r_squared = np.zeros(dtsx_power.shape[1])
+    for channel in range(dtsx_power.shape[1]):
+        target = dtsx_power[:, channel]
+        coefficient, _ = nnls(design, target)
+        prediction = design @ coefficient
+        residual = np.sum((target - prediction) ** 2)
+        total = np.sum((target - np.mean(target)) ** 2)
+        r_squared[channel] = 1.0 - residual / total if total > 0 else 0.0
+        weights[channel] = coefficient / scale
+    return r_squared, weights
+
+
+def fit_windowed_power_mixtures(
+    atmosphere_rms: np.ndarray,
+    dtsx_rms: np.ndarray,
+    extension_start: int,
+    window_seconds: float = 5.0,
+) -> tuple[float, float, float]:
+    window_frames = max(100, round(window_seconds / FRAME_SECONDS))
+    scores = []
+    dominants: list[np.ndarray] = []
+    for start in range(0, len(dtsx_rms), window_frames):
+        end = min(start + window_frames, len(dtsx_rms))
+        if end - start < 100:
+            continue
+        r_squared, weights = fit_power_mixtures(
+            atmosphere_rms[start:end], dtsx_rms[start:end]
+        )
+        scores.extend(np.clip(r_squared[extension_start:], 0.0, 1.0))
+        dominants.append(
+            np.argmax(weights[extension_start:], axis=1)
+        )
+    if not dominants:
+        return float("nan"), float("nan"), float("nan")
+    dominant_matrix = np.stack(dominants)
+    unique_dominants = float(
+        np.mean(
+            [
+                len(np.unique(dominant_matrix[:, channel]))
+                for channel in range(dominant_matrix.shape[1])
+            ]
+        )
+    )
+    if len(dominants) < 2:
+        switch_rate = 0.0
+    else:
+        switch_rate = float(
+            np.mean(dominant_matrix[1:] != dominant_matrix[:-1])
+        )
+    return float(np.mean(scores)), unique_dominants, switch_rate
+
+
+def read_motion(
+    metadata_path: Path, start_sample: int = 0
+) -> dict[int, ObjectMotion]:
+    data = yaml.safe_load(metadata_path.read_text())
+    positions: dict[int, list[tuple[int, tuple[float, float, float]]]] = (
+        collections.defaultdict(list)
+    )
+    for event in data.get("events", []):
+        if "pos" not in event:
+            continue
+        positions[int(event["ID"])].append(
+            (
+                int(event.get("samplePos", 0)),
+                tuple(float(value) for value in event["pos"]),
+            )
+        )
+    result = {}
+    for object_id, events in positions.items():
+        baseline = None
+        points = []
+        for sample, point in events:
+            if sample <= start_sample:
+                baseline = point
+            else:
+                if baseline is not None and not points:
+                    points.append(baseline)
+                points.append(point)
+        if not points and baseline is not None:
+            points = [baseline]
+        if not points:
+            points = [events[0][1]]
+        changes = sum(a != b for a, b in zip(points, points[1:]))
+        displacement = sum(
+            float(np.linalg.norm(np.subtract(b, a)))
+            for a, b in zip(points, points[1:])
+        )
+        result[object_id] = ObjectMotion(
+            object_id=object_id,
+            unique_positions=len(set(points)),
+            changes=changes,
+            displacement=displacement,
+        )
+    return result
+
+
+def atmosphere_signal_names(motion: dict[int, ObjectMotion]) -> list[str]:
+    # truehdd writes the active elements contiguously: the sole LFE bed signal
+    # first, followed by dynamic objects in DAMF ID order. DAMF ID 3 is the
+    # semantic speaker ID, not a sparse index into this 16-channel PCM file.
+    object_ids = sorted(motion)
+    return ["LFE", *(f"O{object_id}" for object_id in object_ids)]
+
+
+def weight_summary(weights: np.ndarray, names: list[str]) -> str:
+    if not np.any(weights > 0.0):
+        return "-"
+    order = np.argsort(weights)[::-1]
+    total = float(np.sum(weights))
+    selected = []
+    accumulated = 0.0
+    for index in order:
+        share = float(weights[index] / total)
+        if share < 0.05 and selected:
+            break
+        selected.append(f"{names[index]}:{share:.2f}")
+        accumulated += share
+        if accumulated >= 0.9:
+            break
+    return ",".join(selected)
+
+
+def locate_dtsx_stream(directory: Path, title: str) -> Path:
+    expected = re.sub(r"[^a-z0-9]+", "", title.lower())
+    candidates = [
+        path
+        for path in directory.glob("* - DTS-X*.dts")
+        if re.sub(
+            r"[^a-z0-9]+",
+            "",
+            path.name.split(" - DTS-X", maxsplit=1)[0].lower(),
+        )
+        == expected
+    ]
+    if len(candidates) != 1:
+        raise ValueError(f"expected one DTS stream for {title}: {candidates}")
+    return candidates[0]
+
+
+def select_waveform_window(
+    atmosphere_rms: np.ndarray,
+    dtsx_rms: np.ndarray,
+    lag: int,
+    duration_seconds: float,
+) -> tuple[float, float, float]:
+    aligned_atmosphere, aligned_dtsx = overlap_slices(
+        atmosphere_rms, dtsx_rms, lag
+    )
+    frames = max(1, round(duration_seconds / FRAME_SECONDS))
+    frames = min(frames, len(aligned_dtsx))
+    joint_power = np.sum(aligned_atmosphere.astype(np.float64) ** 2, axis=1)
+    joint_power += np.sum(aligned_dtsx.astype(np.float64) ** 2, axis=1)
+    if frames == len(joint_power):
+        aligned_start = 0
+    else:
+        cumulative = np.concatenate(([0.0], np.cumsum(joint_power)))
+        energy = cumulative[frames:] - cumulative[:-frames]
+        aligned_start = int(np.argmax(energy))
+    if lag >= 0:
+        dtsx_frame = aligned_start
+        atmosphere_frame = aligned_start + lag
+    else:
+        dtsx_frame = aligned_start - lag
+        atmosphere_frame = aligned_start
+    return (
+        dtsx_frame * FRAME_SECONDS,
+        atmosphere_frame * FRAME_SECONDS,
+        frames * FRAME_SECONDS,
+    )
+
+
+def read_waveform(
+    title: str,
+    dtsx_stream: Path,
+    atmosphere_audio: Path,
+    dtsx_channels: int,
+    dtsx_start: float,
+    atmosphere_start: float,
+    duration: float,
+    xll_pcm_range: Path,
+    temporary_dir: Path,
+) -> tuple[np.ndarray, np.ndarray]:
+    safe_title = re.sub(r"[^A-Za-z0-9_.-]+", "_", title)
+    dtsx_path = temporary_dir / f"{safe_title}.dtsx-wave.f32le"
+    atmosphere_path = temporary_dir / f"{safe_title}.atmos-wave.f32le"
+    subprocess.run(
+        [
+            str(xll_pcm_range),
+            str(dtsx_stream),
+            str(dtsx_path),
+            f"{dtsx_start:.9f}",
+            f"{dtsx_start + duration:.9f}",
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-loglevel",
+            "quiet",
+            "-i",
+            str(atmosphere_audio),
+            "-ss",
+            f"{atmosphere_start:.9f}",
+            "-t",
+            f"{duration:.9f}",
+            "-map",
+            "0:a:0",
+            "-c:a",
+            "pcm_f32le",
+            "-f",
+            "f32le",
+            str(atmosphere_path),
+            "-y",
+        ],
+        check=True,
+    )
+    dtsx = np.fromfile(dtsx_path, dtype="<f4").reshape(-1, dtsx_channels)
+    atmosphere = np.fromfile(atmosphere_path, dtype="<f4").reshape(
+        -1, ATMOS_CHANNELS
+    )
+    dtsx_path.unlink()
+    atmosphere_path.unlink()
+    return atmosphere, dtsx
+
+
+def fine_waveform_alignment(
+    atmosphere: np.ndarray,
+    dtsx: np.ndarray,
+    rms_correlation: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, int, float, tuple[int, int]]:
+    candidates = set()
+    for dtsx_channel in range(dtsx.shape[1]):
+        order = np.argsort(np.abs(rms_correlation[dtsx_channel]))[::-1]
+        for atmosphere_channel in order[:3]:
+            candidates.add((dtsx_channel, int(atmosphere_channel)))
+    candidates.add((5, 0))
+
+    fine_lag = 0
+    peak_correlation = 0.0
+    peak_pair = (0, 0)
+    for dtsx_channel, atmosphere_channel in sorted(candidates):
+        atmosphere_samples = atmosphere[:, atmosphere_channel].astype(
+            np.float64
+        )
+        dtsx_samples = dtsx[:, dtsx_channel].astype(np.float64)
+        cross = correlate(
+            atmosphere_samples, dtsx_samples, mode="full", method="fft"
+        )
+        lags = correlation_lags(
+            len(atmosphere_samples), len(dtsx_samples), mode="full"
+        )
+        keep = np.abs(lags) <= FRAME_SAMPLES * 2
+        selected = np.flatnonzero(keep)
+        denominator = np.linalg.norm(atmosphere_samples) * np.linalg.norm(
+            dtsx_samples
+        )
+        if denominator == 0.0:
+            continue
+        local = cross[selected] / denominator
+        index = int(np.argmax(np.abs(local)))
+        if abs(local[index]) > abs(peak_correlation):
+            peak_correlation = float(local[index])
+            fine_lag = int(lags[selected[index]])
+            peak_pair = (dtsx_channel, atmosphere_channel)
+    aligned_atmosphere, aligned_dtsx = overlap_slices(
+        atmosphere, dtsx, fine_lag
+    )
+    return (
+        aligned_atmosphere,
+        aligned_dtsx,
+        fine_lag,
+        peak_correlation,
+        peak_pair,
+    )
+
+
+def energy_fit_score(target: np.ndarray, prediction: np.ndarray) -> np.ndarray:
+    residual = np.sum((target - prediction) ** 2, axis=0)
+    total = np.sum(target * target, axis=0)
+    score = np.divide(
+        residual,
+        total,
+        out=np.ones_like(total),
+        where=total > 0.0,
+    )
+    return np.clip(1.0 - score, 0.0, 1.0)
+
+
+def ridge_fit(design: np.ndarray, target: np.ndarray) -> np.ndarray:
+    covariance = design.T @ design
+    ridge = max(float(np.trace(covariance)) / design.shape[1] * 1e-4, 1e-12)
+    return np.linalg.solve(
+        covariance + np.eye(design.shape[1]) * ridge,
+        design.T @ target,
+    )
+
+
+def waveform_static_fit(
+    atmosphere: np.ndarray, dtsx: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    count = min(len(atmosphere), len(dtsx))
+    midpoint = count // 2
+    stride = max(1, midpoint // 100_000)
+    full_x = atmosphere[::stride].astype(np.float64)
+    full_y = dtsx[::stride].astype(np.float64)
+    train_x = atmosphere[:midpoint:stride].astype(np.float64)
+    train_y = dtsx[:midpoint:stride].astype(np.float64)
+    test_x = atmosphere[midpoint::stride].astype(np.float64)
+    test_y = dtsx[midpoint::stride].astype(np.float64)
+    full_coefficient = ridge_fit(full_x, full_y)
+    full_score = energy_fit_score(full_y, full_x @ full_coefficient)
+    train_coefficient = ridge_fit(train_x, train_y)
+    test_score = energy_fit_score(test_y, test_x @ train_coefficient)
+    return full_score, test_score
+
+
+def main() -> None:
+    args = parse_args()
+    args.cache_dir.mkdir(parents=True, exist_ok=True)
+    titles = sorted(
+        path.name.removesuffix(".dtsx-rms.txt")
+        for path in args.dtsx_rms_dir.glob("*.dtsx-rms.txt")
+    )
+    fieldnames = [
+        "title",
+        "dtsx_channels",
+        "dtsx_extensions",
+        "atmos_objects",
+        "moving_objects",
+        "position_changes",
+        "position_displacement",
+        "offset_seconds",
+        "power_envelope_r",
+        "mean_best_rms_r",
+        "mean_power_fit_r2",
+        "extension_power_fit_r2",
+        "windowed_extension_power_fit_r2",
+        "mean_unique_window_dominants",
+        "window_dominant_switch_rate",
+        "fine_lag_samples",
+        "fine_alignment_peak_r",
+        "fine_alignment_pair",
+        "mean_best_sample_r",
+        "sample_static_fit_r2",
+        "extension_sample_fit_r2",
+        "sample_static_cv_r2",
+        "extension_sample_cv_r2",
+        "extension_mappings",
+    ]
+    with args.output.open("w", newline="") as output:
+        writer = csv.DictWriter(
+            output, fieldnames=fieldnames, dialect="excel-tab"
+        )
+        writer.writeheader()
+        for title in titles:
+            dtsx = read_dtsx_envelope(args.dtsx_rms_dir, title)
+            audio_path = args.atmos_dir / f"{title}.atmos.audio"
+            metadata_path = args.atmos_dir / f"{title}.atmos.metadata"
+            atmosphere = read_atmos_envelope(
+                audio_path, args.cache_dir / f"{title}.atmos-rms.f32le"
+            )
+            all_motion = read_motion(metadata_path)
+            atmosphere_names = atmosphere_signal_names(all_motion)
+
+            atmosphere_power = np.sum(atmosphere.astype(np.float64) ** 2, axis=1)
+            dtsx_power = np.sum(dtsx.values.astype(np.float64) ** 2, axis=1)
+            atmosphere_level = np.log10(
+                atmosphere_power
+                + max(float(np.percentile(atmosphere_power, 10)), 1e-14)
+            )
+            dtsx_level = np.log10(
+                dtsx_power + max(float(np.percentile(dtsx_power, 10)), 1e-14)
+            )
+            lag, envelope_r = normalized_lag_score(
+                atmosphere_level,
+                dtsx_level,
+                round(args.max_lag_seconds / FRAME_SECONDS),
+            )
+            aligned_atmosphere, aligned_dtsx = overlap_slices(
+                atmosphere, dtsx.values, lag
+            )
+            # Ignore the first matched second, which several files use to
+            # replace a common placeholder coordinate with their actual
+            # programme layout.
+            motion = read_motion(
+                metadata_path,
+                max(0, lag * FRAME_SAMPLES) + SAMPLE_RATE,
+            )
+            rms_correlation = correlation_matrix(
+                aligned_dtsx, aligned_atmosphere
+            )
+            best_rms = np.max(rms_correlation, axis=1)
+            fit_r2, weights = fit_power_mixtures(
+                aligned_atmosphere, aligned_dtsx
+            )
+            extension_start = 8
+            (
+                windowed_extension_fit,
+                unique_window_dominants,
+                window_dominant_switch_rate,
+            ) = fit_windowed_power_mixtures(
+                aligned_atmosphere,
+                aligned_dtsx,
+                extension_start,
+            )
+            fine_lag = 0
+            fine_peak = float("nan")
+            fine_pair = "-"
+            mean_best_sample = float("nan")
+            sample_fit_mean = float("nan")
+            extension_sample_fit = float("nan")
+            sample_cv_mean = float("nan")
+            extension_sample_cv = float("nan")
+            if args.dtsx_audio_dir and args.xll_pcm_range:
+                dtsx_start, atmosphere_start, duration = (
+                    select_waveform_window(
+                        atmosphere,
+                        dtsx.values,
+                        lag,
+                        args.waveform_seconds,
+                    )
+                )
+                waveform_atmosphere, waveform_dtsx = read_waveform(
+                    title,
+                    locate_dtsx_stream(args.dtsx_audio_dir, title),
+                    audio_path,
+                    len(dtsx.names),
+                    dtsx_start,
+                    atmosphere_start,
+                    duration,
+                    args.xll_pcm_range,
+                    args.cache_dir,
+                )
+                (
+                    waveform_atmosphere,
+                    waveform_dtsx,
+                    fine_lag,
+                    fine_peak,
+                    fine_pair_indices,
+                ) = (
+                    fine_waveform_alignment(
+                        waveform_atmosphere,
+                        waveform_dtsx,
+                        rms_correlation,
+                    )
+                )
+                fine_pair = (
+                    f"{dtsx.names[fine_pair_indices[0]]}~"
+                    f"{atmosphere_names[fine_pair_indices[1]]}"
+                )
+                sample_correlation = correlation_matrix(
+                    waveform_dtsx, waveform_atmosphere
+                )
+                mean_best_sample = float(
+                    np.mean(np.max(np.abs(sample_correlation), axis=1))
+                )
+                sample_fit, sample_cv = waveform_static_fit(
+                    waveform_atmosphere, waveform_dtsx
+                )
+                sample_fit_mean = float(np.nanmean(sample_fit))
+                extension_sample_fit = float(
+                    np.nanmean(sample_fit[extension_start:])
+                )
+                sample_cv_mean = float(np.nanmean(sample_cv))
+                extension_sample_cv = float(
+                    np.nanmean(sample_cv[extension_start:])
+                )
+            extension_mappings = ";".join(
+                f"{dtsx.names[channel]}="
+                f"{weight_summary(weights[channel], atmosphere_names)}"
+                for channel in range(extension_start, len(dtsx.names))
+            )
+            moving = [item for item in motion.values() if item.changes > 0]
+            writer.writerow(
+                {
+                    "title": title,
+                    "dtsx_channels": len(dtsx.names),
+                    "dtsx_extensions": len(dtsx.names) - extension_start,
+                    "atmos_objects": len(motion),
+                    "moving_objects": len(moving),
+                    "position_changes": sum(
+                        item.changes for item in motion.values()
+                    ),
+                    "position_displacement": f"{sum(item.displacement for item in motion.values()):.3f}",
+                    "offset_seconds": f"{lag * FRAME_SECONDS:.3f}",
+                    "power_envelope_r": f"{envelope_r:.4f}",
+                    "mean_best_rms_r": f"{float(np.mean(best_rms)):.4f}",
+                    "mean_power_fit_r2": f"{float(np.mean(fit_r2)):.4f}",
+                    "extension_power_fit_r2": f"{float(np.mean(fit_r2[extension_start:])):.4f}",
+                    "windowed_extension_power_fit_r2": f"{windowed_extension_fit:.4f}",
+                    "mean_unique_window_dominants": f"{unique_window_dominants:.2f}",
+                    "window_dominant_switch_rate": f"{window_dominant_switch_rate:.4f}",
+                    "fine_lag_samples": fine_lag,
+                    "fine_alignment_peak_r": f"{fine_peak:.4f}",
+                    "fine_alignment_pair": fine_pair,
+                    "mean_best_sample_r": f"{mean_best_sample:.4f}",
+                    "sample_static_fit_r2": f"{sample_fit_mean:.4f}",
+                    "extension_sample_fit_r2": f"{extension_sample_fit:.4f}",
+                    "sample_static_cv_r2": f"{sample_cv_mean:.4f}",
+                    "extension_sample_cv_r2": f"{extension_sample_cv:.4f}",
+                    "extension_mappings": extension_mappings,
+                }
+            )
+            print(
+                f"pair\t{title}\toffset={lag * FRAME_SECONDS:+.3f}s"
+                f"\tenvelope_r={envelope_r:.3f}"
+                f"\trms_r={np.mean(best_rms):.3f}"
+                f"\tfit_r2={np.mean(fit_r2):.3f}"
+                f"\tsample_r={mean_best_sample:.3f}"
+                f"\tsample_fit={sample_fit_mean:.3f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze-dtsx-bed-fold-limits.py
+++ b/scripts/analyze-dtsx-bed-fold-limits.py
@@ -1,0 +1,1640 @@
+#!/usr/bin/env python3
+"""Measure conservative extension-to-bed subtraction limits.
+
+For every extension source X and compatible-bed channel B, this tool finds
+the largest positive gain g for which
+
+    energy(B - g * X) < energy(B)
+
+in at least the requested fraction of blocks where X is active.  The block
+condition is solved analytically; no gain grid or regression is involved.
+The result is evidence about a possible fold, not a normative decoder matrix.
+
+Inputs are CAF ``*.dtsx.audio`` files containing the eight compatible-bed
+channels in DCA order followed by extension sources.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+
+BED_NAMES = ("C", "L", "R", "Ls", "Rs", "LFE", "Lb", "Rb")
+BED_COORDINATES = {
+    "C": (0.0, 1.0),
+    "L": (-1.0, 1.0),
+    "R": (1.0, 1.0),
+    "Ls": (-1.0, 0.0),
+    "Rs": (1.0, 0.0),
+    "Lb": (-1.0, -1.0),
+    "Rb": (1.0, -1.0),
+}
+FIXED_GAINS = (0.5, 1.0 / math.sqrt(2.0), 1.0)
+
+
+@dataclass(frozen=True)
+class AudioInfo:
+    channels: int
+    sample_rate: int
+    frames: int
+
+
+@dataclass(frozen=True)
+class VideoInfo:
+    path: Path
+    duration: float
+    audio_start: float
+
+
+@dataclass(frozen=True)
+class BlockStatistics:
+    bed_energy: np.ndarray
+    extension_energy: np.ndarray
+    cross_energy: np.ndarray
+
+
+@dataclass(frozen=True)
+class FoldLimit:
+    title: str
+    path: Path
+    bed: str
+    extension: str
+    blocks: int
+    active_blocks: int
+    positive_fraction: float
+    max_gain: float
+    max_gain_db: float
+    projection_gain: float
+    projection_gain_db: float
+    fixed_coverages: tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class BedBarycenter:
+    title: str
+    extension: str
+    x: float
+    y: float
+    weight_sum: float
+    maximum_coverage: float
+    dominant_bed: str
+
+
+@dataclass(frozen=True)
+class TemporalBarycenters:
+    title: str
+    video: VideoInfo
+    fps: float
+    encoding_fps: float
+    times: np.ndarray
+    positions: np.ndarray
+    coverages: np.ndarray
+    active_blocks: np.ndarray
+    activity: np.ndarray
+    valid: np.ndarray
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "inputs",
+        type=Path,
+        nargs="+",
+        help="CAF files or directories searched for *.dtsx.audio",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="optional long-form TSV result",
+    )
+    parser.add_argument(
+        "--plot-dir",
+        type=Path,
+        help="optional directory for one fixed-gain coverage PNG per stream",
+    )
+    parser.add_argument(
+        "--plot-gain",
+        type=float,
+        default=0.5,
+        help="plotted subtraction gain: 0.5, 0.707107 or 1.0",
+    )
+    parser.add_argument(
+        "--position-plot-dir",
+        type=Path,
+        help=(
+            "optional directory for coverage-weighted bed barycentre "
+            "PNGs and positions.tsv"
+        ),
+    )
+    parser.add_argument(
+        "--animation-dir",
+        type=Path,
+        help="optional directory for real-time temporal-position MP4s",
+    )
+    parser.add_argument(
+        "--temporal-coverage-output",
+        type=Path,
+        help=(
+            "optional long-form TSV containing every temporal X-to-bed "
+            "fixed-gain coverage"
+        ),
+    )
+    parser.add_argument(
+        "--video-dir",
+        type=Path,
+        help="original MKV directory used for animation PTS and duration",
+    )
+    parser.add_argument(
+        "--animation-fps",
+        type=float,
+        default=5.0,
+        help="target animation frame rate (default: 5)",
+    )
+    parser.add_argument(
+        "--temporal-window-seconds",
+        type=float,
+        default=1.0,
+        help="sliding coverage window duration (default: 1 second)",
+    )
+    parser.add_argument(
+        "--trail-seconds",
+        type=float,
+        default=3.0,
+        help="visible temporal-position trail (default: 3 seconds)",
+    )
+    parser.add_argument(
+        "--minimum-active-blocks",
+        type=int,
+        default=3,
+        help="minimum active X blocks needed for a temporal position",
+    )
+    parser.add_argument(
+        "--block-samples",
+        type=int,
+        default=512,
+        help="non-overlapping energy block size (default: 512)",
+    )
+    parser.add_argument(
+        "--coverage",
+        type=float,
+        default=0.95,
+        help="required active-block energy-decrease fraction",
+    )
+    parser.add_argument(
+        "--activity-db",
+        type=float,
+        default=-60.0,
+        help="X block-energy gate relative to that source's peak",
+    )
+    parser.add_argument(
+        "--extensions",
+        type=int,
+        default=8,
+        help="required extension-source count (default: D3 4+4 = 8)",
+    )
+    return parser.parse_args()
+
+
+def discover(inputs: list[Path]) -> list[Path]:
+    paths: set[Path] = set()
+    for item in inputs:
+        if item.is_dir():
+            paths.update(item.glob("*.dtsx.audio"))
+        elif item.is_file():
+            paths.add(item)
+        else:
+            raise FileNotFoundError(item)
+    return sorted(paths)
+
+
+def probe(path: Path) -> AudioInfo:
+    process = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=channels,sample_rate,nb_frames",
+            "-of",
+            "json",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    streams = json.loads(process.stdout).get("streams", [])
+    if len(streams) != 1:
+        raise ValueError(f"{path}: expected one audio stream")
+    stream = streams[0]
+    return AudioInfo(
+        channels=int(stream["channels"]),
+        sample_rate=int(stream["sample_rate"]),
+        frames=int(stream["nb_frames"]),
+    )
+
+
+def probe_video(directory: Path, title: str) -> VideoInfo:
+    candidates = sorted(directory.glob(f"{title} - DTS-X*.mkv"))
+    if len(candidates) != 1:
+        raise ValueError(
+            f"{title}: expected one original MKV in {directory}, "
+            f"found {candidates}"
+        )
+    path = candidates[0]
+    process = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=start_time:format=duration",
+            "-of",
+            "json",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    data = json.loads(process.stdout)
+    streams = data.get("streams", [])
+    if len(streams) != 1:
+        raise ValueError(f"{path}: expected one selected audio stream")
+    duration = float(data["format"]["duration"])
+    audio_start = float(streams[0].get("start_time", 0.0))
+    if duration <= 0.0 or audio_start < 0.0:
+        raise ValueError(
+            f"{path}: invalid duration/start {duration}/{audio_start}"
+        )
+    return VideoInfo(
+        path=path,
+        duration=duration,
+        audio_start=audio_start,
+    )
+
+
+def append_block_statistics(
+    samples: np.ndarray,
+    bed_energy: list[np.ndarray],
+    extension_energy: list[np.ndarray],
+    cross_energy: list[np.ndarray],
+) -> None:
+    bed = samples[:, :, : len(BED_NAMES)].astype(np.float64)
+    extension = samples[:, :, len(BED_NAMES) :].astype(np.float64)
+    bed_energy.append(np.einsum("nsi,nsi->ni", bed, bed))
+    extension_energy.append(
+        np.einsum("nsj,nsj->nj", extension, extension)
+    )
+    cross_energy.append(np.einsum("nsi,nsj->nij", bed, extension))
+
+
+def read_block_statistics(
+    path: Path,
+    channels: int,
+    block_samples: int,
+) -> BlockStatistics:
+    process = subprocess.Popen(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-map",
+            "0:a:0",
+            "-c:a",
+            "pcm_f32le",
+            "-f",
+            "f32le",
+            "-",
+        ],
+        stdout=subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    block_bytes = block_samples * channels * 4
+    pending = bytearray()
+    bed_energy: list[np.ndarray] = []
+    extension_energy: list[np.ndarray] = []
+    cross_energy: list[np.ndarray] = []
+    while chunk := process.stdout.read(1024 * 1024):
+        pending.extend(chunk)
+        blocks = len(pending) // block_bytes
+        if blocks == 0:
+            continue
+        byte_count = blocks * block_bytes
+        samples = np.frombuffer(
+            memoryview(pending)[:byte_count], dtype="<f4"
+        ).copy()
+        samples = samples.reshape(blocks, block_samples, channels)
+        append_block_statistics(
+            samples, bed_energy, extension_energy, cross_energy
+        )
+        del pending[:byte_count]
+    return_code = process.wait()
+    if return_code:
+        raise RuntimeError(f"ffmpeg failed for {path}: {return_code}")
+    sample_bytes = channels * 4
+    tail_samples = len(pending) // sample_bytes
+    if tail_samples:
+        samples = np.frombuffer(
+            memoryview(pending)[: tail_samples * sample_bytes],
+            dtype="<f4",
+        ).copy()
+        samples = samples.reshape(1, tail_samples, channels)
+        append_block_statistics(
+            samples, bed_energy, extension_energy, cross_energy
+        )
+    return BlockStatistics(
+        bed_energy=np.concatenate(bed_energy),
+        extension_energy=np.concatenate(extension_energy),
+        cross_energy=np.concatenate(cross_energy),
+    )
+
+
+def maximum_gain(
+    thresholds: np.ndarray, coverage: float
+) -> tuple[float, float]:
+    positive_fraction = float(np.mean(thresholds > 0.0))
+    required = math.ceil(coverage * len(thresholds))
+    index = len(thresholds) - required
+    boundary = float(np.partition(thresholds, index)[index])
+    if boundary <= 0.0:
+        return 0.0, positive_fraction
+    # The mathematical maximum is an open boundary for strict energy
+    # decrease. Return the closest representable value below it.
+    return float(np.nextafter(boundary, 0.0)), positive_fraction
+
+
+def analyze_file(
+    path: Path,
+    info: AudioInfo,
+    block_samples: int,
+    coverage: float,
+    activity_db: float,
+    statistics: BlockStatistics | None = None,
+) -> list[FoldLimit]:
+    if statistics is None:
+        statistics = read_block_statistics(
+            path, info.channels, block_samples
+        )
+    extension_energy = statistics.extension_energy
+    cross_energy = statistics.cross_energy
+    extension_count = info.channels - len(BED_NAMES)
+    title = path.name.removesuffix(".dtsx.audio")
+    results: list[FoldLimit] = []
+    activity_ratio = 10.0 ** (activity_db / 10.0)
+    for extension_index in range(extension_count):
+        x_energy = extension_energy[:, extension_index]
+        peak = float(np.max(x_energy))
+        active = (x_energy > 0.0) & (x_energy >= peak * activity_ratio)
+        active_count = int(np.count_nonzero(active))
+        if active_count == 0:
+            continue
+        selected_x_energy = x_energy[active]
+        for bed_index, bed_name in enumerate(BED_NAMES):
+            thresholds = (
+                2.0
+                * cross_energy[active, bed_index, extension_index]
+                / selected_x_energy
+            )
+            gain, positive_fraction = maximum_gain(
+                thresholds, coverage
+            )
+            gain_db = (
+                20.0 * math.log10(gain)
+                if gain > 0.0
+                else float("-inf")
+            )
+            projection_gain = gain / 2.0
+            projection_gain_db = (
+                20.0 * math.log10(projection_gain)
+                if projection_gain > 0.0
+                else float("-inf")
+            )
+            fixed_coverages = tuple(
+                float(np.mean(thresholds > fixed_gain))
+                for fixed_gain in FIXED_GAINS
+            )
+            results.append(
+                FoldLimit(
+                    title=title,
+                    path=path,
+                    bed=bed_name,
+                    extension=f"X{extension_index}",
+                    blocks=len(x_energy),
+                    active_blocks=active_count,
+                    positive_fraction=positive_fraction,
+                    max_gain=gain,
+                    max_gain_db=gain_db,
+                    projection_gain=projection_gain,
+                    projection_gain_db=projection_gain_db,
+                    fixed_coverages=fixed_coverages,
+                )
+            )
+    return results
+
+
+def format_gain(gain: float, gain_db: float) -> str:
+    if gain <= 0.0:
+        return "-"
+    return f"{gain:.4f} ({gain_db:+.2f} dB)"
+
+
+def print_file_summary(
+    title: str, results: list[FoldLimit]
+) -> None:
+    print(f"file\t{title}")
+    extensions = sorted({result.extension for result in results})
+    for extension in extensions:
+        candidates = [
+            result
+            for result in results
+            if result.extension == extension and result.max_gain > 0.0
+        ]
+        if not candidates:
+            print(f"  {extension}: no bed reaches requested coverage")
+            continue
+        candidates.sort(key=lambda result: result.max_gain, reverse=True)
+        text = ", ".join(
+            f"{item.bed} limit="
+            f"{format_gain(item.max_gain, item.max_gain_db)} "
+            f"p05_beta="
+            f"{format_gain(item.projection_gain, item.projection_gain_db)}"
+            for item in candidates[:3]
+        )
+        print(f"  {extension}: {text}")
+
+
+def print_corpus_summary(
+    results: list[FoldLimit], title_count: int, coverage: float
+) -> None:
+    print("corpus_consensus:")
+    extensions = sorted({result.extension for result in results})
+    for extension in extensions:
+        candidates = []
+        for bed in BED_NAMES:
+            selected = [
+                result
+                for result in results
+                if result.extension == extension
+                and result.bed == bed
+                and result.max_gain > 0.0
+            ]
+            if not selected:
+                continue
+            gains = np.array(
+                [result.max_gain for result in selected], dtype=np.float64
+            )
+            at_minus_3 = sum(
+                result.fixed_coverages[1] >= coverage
+                for result in selected
+            )
+            at_minus_6 = sum(
+                result.fixed_coverages[0] >= coverage
+                for result in selected
+            )
+            candidates.append(
+                (
+                    len(selected),
+                    float(np.median(gains)),
+                    bed,
+                    float(np.min(gains)),
+                    at_minus_3,
+                    at_minus_6,
+                )
+            )
+        candidates.sort(reverse=True)
+        if not candidates:
+            print(f"  {extension}: no positive candidate")
+            continue
+        text = "; ".join(
+            f"{bed} valid={valid}/{title_count} "
+            f"median_limit={median:.4f} "
+            f"median_p05_beta={median / 2.0:.4f} "
+            f"min_limit={minimum:.4f} "
+            f"-3dB={at_minus_3}/{title_count} "
+            f"-6dB={at_minus_6}/{title_count}"
+            for valid, median, bed, minimum, at_minus_3, at_minus_6
+            in candidates[:3]
+        )
+        print(f"  {extension}: {text}")
+
+
+def write_tsv(path: Path, results: list[FoldLimit]) -> None:
+    fields = [
+        "title",
+        "path",
+        "bed",
+        "extension",
+        "blocks",
+        "active_blocks",
+        "positive_fraction",
+        "max_gain",
+        "max_gain_db",
+        "p05_projection_gain",
+        "p05_projection_gain_db",
+        "coverage_at_0.5",
+        "coverage_at_0.707107",
+        "coverage_at_1.0",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as output:
+        writer = csv.DictWriter(
+            output, fieldnames=fields, dialect="excel-tab"
+        )
+        writer.writeheader()
+        for result in results:
+            writer.writerow(
+                {
+                    "title": result.title,
+                    "path": result.path,
+                    "bed": result.bed,
+                    "extension": result.extension,
+                    "blocks": result.blocks,
+                    "active_blocks": result.active_blocks,
+                    "positive_fraction": (
+                        f"{result.positive_fraction:.6f}"
+                    ),
+                    "max_gain": f"{result.max_gain:.9g}",
+                    "max_gain_db": (
+                        f"{result.max_gain_db:.6f}"
+                        if math.isfinite(result.max_gain_db)
+                        else "-inf"
+                    ),
+                    "p05_projection_gain": (
+                        f"{result.projection_gain:.9g}"
+                    ),
+                    "p05_projection_gain_db": (
+                        f"{result.projection_gain_db:.6f}"
+                        if math.isfinite(result.projection_gain_db)
+                        else "-inf"
+                    ),
+                    "coverage_at_0.5": (
+                        f"{result.fixed_coverages[0]:.6f}"
+                    ),
+                    "coverage_at_0.707107": (
+                        f"{result.fixed_coverages[1]:.6f}"
+                    ),
+                    "coverage_at_1.0": (
+                        f"{result.fixed_coverages[2]:.6f}"
+                    ),
+                }
+            )
+
+
+def write_coverage_plots(
+    directory: Path,
+    results: list[FoldLimit],
+    required_coverage: float,
+    block_samples: int,
+    activity_db: float,
+    plot_gain: float,
+    fixed_gain_index: int,
+) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
+    from matplotlib.ticker import PercentFormatter
+
+    directory.mkdir(parents=True, exist_ok=True)
+    gain_label = (
+        f"{plot_gain:.1f}"
+        if plot_gain.is_integer()
+        else f"{plot_gain:.6f}".rstrip("0")
+    )
+    gain_db = 20.0 * math.log10(plot_gain)
+    titles = sorted({result.title for result in results})
+    for title in titles:
+        selected = [
+            result for result in results if result.title == title
+        ]
+        extensions = sorted(
+            {result.extension for result in selected},
+            key=lambda name: int(name.removeprefix("X")),
+        )
+        matrix = np.full((len(extensions), len(BED_NAMES)), np.nan)
+        for result in selected:
+            row = extensions.index(result.extension)
+            column = BED_NAMES.index(result.bed)
+            matrix[row, column] = result.fixed_coverages[
+                fixed_gain_index
+            ]
+
+        figure, axis = plt.subplots(figsize=(10.0, 8.0))
+        image = axis.imshow(
+            matrix,
+            vmin=0.0,
+            vmax=1.0,
+            cmap="viridis",
+            interpolation="nearest",
+            aspect="auto",
+        )
+        axis.set_xticks(range(len(BED_NAMES)), BED_NAMES)
+        axis.set_yticks(range(len(extensions)), extensions)
+        axis.set_xlabel("Compatible bed channel")
+        axis.set_ylabel("Extension source")
+        axis.set_title(
+            f"{title}\n"
+            "Energy-decrease coverage for bed - "
+            f"{gain_label} X ({gain_db:+.2f} dB)"
+        )
+        axis.set_xticks(
+            np.arange(-0.5, len(BED_NAMES), 1.0), minor=True
+        )
+        axis.set_yticks(
+            np.arange(-0.5, len(extensions), 1.0), minor=True
+        )
+        axis.grid(which="minor", color="white", linewidth=0.6, alpha=0.5)
+        axis.tick_params(which="minor", bottom=False, left=False)
+
+        for row in range(len(extensions)):
+            for column in range(len(BED_NAMES)):
+                value = matrix[row, column]
+                if not np.isfinite(value):
+                    continue
+                text_color = "white" if value < 0.55 else "black"
+                axis.text(
+                    column,
+                    row,
+                    f"{value:.1%}",
+                    ha="center",
+                    va="center",
+                    color=text_color,
+                    fontsize=9,
+                )
+                if value >= required_coverage:
+                    axis.add_patch(
+                        Rectangle(
+                            (column - 0.48, row - 0.48),
+                            0.96,
+                            0.96,
+                            fill=False,
+                            edgecolor="#ff2d55",
+                            linewidth=2.5,
+                        )
+                    )
+
+        colorbar = figure.colorbar(image, ax=axis, pad=0.025)
+        colorbar.set_label("Active-block coverage")
+        colorbar.ax.yaxis.set_major_formatter(PercentFormatter(1.0))
+        figure.text(
+            0.5,
+            0.015,
+            f"{block_samples}-sample blocks; X activity gate "
+            f"{activity_db:g} dB; red outline >= "
+            f"{required_coverage:.0%}",
+            ha="center",
+            fontsize=9,
+        )
+        figure.tight_layout(rect=(0.0, 0.035, 1.0, 1.0))
+        safe_title = re.sub(r"[^A-Za-z0-9_.-]+", "_", title)
+        output = (
+            directory
+            / f"{safe_title}.coverage-{gain_label}.png"
+        )
+        figure.savefig(output, dpi=160, facecolor="white")
+        plt.close(figure)
+        print(f"plot\t{output}")
+
+
+def calculate_bed_barycenters(
+    results: list[FoldLimit],
+    fixed_gain_index: int,
+) -> list[BedBarycenter]:
+    barycenters = []
+    titles = sorted({result.title for result in results})
+    for title in titles:
+        extensions = sorted(
+            {
+                result.extension
+                for result in results
+                if result.title == title
+            },
+            key=lambda name: int(name.removeprefix("X")),
+        )
+        for extension in extensions:
+            selected = [
+                result
+                for result in results
+                if result.title == title
+                and result.extension == extension
+                and result.bed in BED_COORDINATES
+            ]
+            weights = np.array(
+                [
+                    result.fixed_coverages[fixed_gain_index]
+                    for result in selected
+                ],
+                dtype=np.float64,
+            )
+            weight_sum = float(np.sum(weights))
+            if weight_sum <= 0.0:
+                continue
+            coordinates = np.array(
+                [BED_COORDINATES[result.bed] for result in selected],
+                dtype=np.float64,
+            )
+            position = np.sum(
+                coordinates * weights[:, None], axis=0
+            ) / weight_sum
+            dominant = selected[int(np.argmax(weights))]
+            barycenters.append(
+                BedBarycenter(
+                    title=title,
+                    extension=extension,
+                    x=float(position[0]),
+                    y=float(position[1]),
+                    weight_sum=weight_sum,
+                    maximum_coverage=float(np.max(weights)),
+                    dominant_bed=dominant.bed,
+                )
+            )
+    return barycenters
+
+
+def write_barycenter_tsv(
+    path: Path, barycenters: list[BedBarycenter]
+) -> None:
+    fields = [
+        "title",
+        "extension",
+        "x",
+        "y",
+        "spatial_weight_sum",
+        "maximum_coverage",
+        "dominant_bed",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as output:
+        writer = csv.DictWriter(
+            output, fieldnames=fields, dialect="excel-tab"
+        )
+        writer.writeheader()
+        for item in barycenters:
+            writer.writerow(
+                {
+                    "title": item.title,
+                    "extension": item.extension,
+                    "x": f"{item.x:.9f}",
+                    "y": f"{item.y:.9f}",
+                    "spatial_weight_sum": f"{item.weight_sum:.9f}",
+                    "maximum_coverage": (
+                        f"{item.maximum_coverage:.9f}"
+                    ),
+                    "dominant_bed": item.dominant_bed,
+                }
+            )
+
+
+def write_barycenter_plots(
+    directory: Path,
+    barycenters: list[BedBarycenter],
+    plot_gain: float,
+) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Polygon
+
+    directory.mkdir(parents=True, exist_ok=True)
+    write_barycenter_tsv(directory / "positions.tsv", barycenters)
+    gain_label = (
+        f"{plot_gain:.1f}"
+        if plot_gain.is_integer()
+        else f"{plot_gain:.6f}".rstrip("0")
+    )
+    colors = plt.get_cmap("tab10").colors
+    label_offsets = (
+        (-24, 14),
+        (24, 14),
+        (-24, -16),
+        (24, -16),
+        (-24, 14),
+        (24, 14),
+        (-24, -16),
+        (24, -16),
+    )
+    titles = sorted({item.title for item in barycenters})
+    for title in titles:
+        selected = [
+            item for item in barycenters if item.title == title
+        ]
+        figure, axis = plt.subplots(figsize=(9.0, 9.0))
+        axis.add_patch(
+            Polygon(
+                [(-1.0, 1.0), (1.0, 1.0), (1.0, -1.0), (-1.0, -1.0)],
+                closed=True,
+                fill=False,
+                edgecolor="#666666",
+                linewidth=1.5,
+            )
+        )
+        for bed, (x, y) in BED_COORDINATES.items():
+            axis.scatter(
+                x,
+                y,
+                marker="s",
+                s=115,
+                color="#222222",
+                edgecolor="white",
+                linewidth=1.0,
+                zorder=4,
+            )
+            horizontal = "right" if x < 0 else "left" if x > 0 else "center"
+            x_offset = -0.04 if x < 0 else 0.04 if x > 0 else 0.0
+            y_offset = 0.075 if y >= 0 else -0.09
+            axis.text(
+                x + x_offset,
+                y + y_offset,
+                bed,
+                ha=horizontal,
+                va="center",
+                fontsize=10,
+                fontweight="bold",
+                color="#222222",
+            )
+        axis.scatter(
+            0.0,
+            0.0,
+            marker="+",
+            s=90,
+            color="#777777",
+            linewidth=1.5,
+            zorder=2,
+        )
+        for item in selected:
+            index = int(item.extension.removeprefix("X"))
+            color = colors[index % len(colors)]
+            size = 90.0 + 150.0 * item.maximum_coverage
+            axis.scatter(
+                item.x,
+                item.y,
+                s=size,
+                color=color,
+                edgecolor="white",
+                linewidth=1.4,
+                zorder=5,
+            )
+            axis.annotate(
+                item.extension,
+                xy=(item.x, item.y),
+                xytext=label_offsets[index],
+                textcoords="offset points",
+                ha="center",
+                va="center",
+                fontsize=10,
+                fontweight="bold",
+                color=color,
+                bbox={
+                    "boxstyle": "round,pad=0.18",
+                    "facecolor": "white",
+                    "edgecolor": color,
+                    "alpha": 0.9,
+                },
+                arrowprops={
+                    "arrowstyle": "-",
+                    "color": color,
+                    "linewidth": 0.9,
+                    "alpha": 0.8,
+                },
+                zorder=6,
+            )
+        axis.set_xlim(-1.18, 1.18)
+        axis.set_ylim(-1.18, 1.18)
+        axis.set_aspect("equal", adjustable="box")
+        axis.set_xlabel("x (left - / right +)")
+        axis.set_ylabel("y (rear - / front +)")
+        axis.set_title(
+            f"{title}\n"
+            f"Bed-coverage barycentres at g = {gain_label}"
+        )
+        axis.grid(True, color="#dddddd", linewidth=0.7)
+        axis.axhline(0.0, color="#bbbbbb", linewidth=0.8, zorder=1)
+        axis.axvline(0.0, color="#bbbbbb", linewidth=0.8, zorder=1)
+        figure.text(
+            0.5,
+            0.025,
+            "Weights: energy-decrease coverage; LFE excluded "
+            "(no spatial coordinate). Marker size: maximum bed coverage.",
+            ha="center",
+            fontsize=9,
+        )
+        figure.tight_layout(rect=(0.0, 0.045, 1.0, 1.0))
+        safe_title = re.sub(r"[^A-Za-z0-9_.-]+", "_", title)
+        output = (
+            directory
+            / f"{safe_title}.position-{gain_label}.png"
+        )
+        figure.savefig(output, dpi=160, facecolor="white")
+        plt.close(figure)
+        print(f"position_plot\t{output}")
+    print(f"positions\t{directory / 'positions.tsv'}")
+
+
+def calculate_temporal_barycenters(
+    title: str,
+    video: VideoInfo,
+    info: AudioInfo,
+    statistics: BlockStatistics,
+    block_samples: int,
+    activity_db: float,
+    plot_gain: float,
+    target_fps: float,
+    window_seconds: float,
+    minimum_active_blocks: int,
+) -> TemporalBarycenters:
+    extension_energy = statistics.extension_energy
+    cross_energy = statistics.cross_energy
+    blocks, extension_count = extension_energy.shape
+    block_centres = (
+        np.arange(blocks, dtype=np.float64) + 0.5
+    ) * block_samples / info.sample_rate
+    activity_ratio = 10.0 ** (activity_db / 10.0)
+    peaks = np.max(extension_energy, axis=0)
+    active = (
+        (extension_energy > 0.0)
+        & (extension_energy >= peaks[None, :] * activity_ratio)
+    )
+    delta = (
+        plot_gain * plot_gain * extension_energy[:, None, :]
+        - 2.0 * plot_gain * cross_energy
+    )
+    passed = (delta < 0.0) & active[:, None, :]
+    cumulative_active = np.concatenate(
+        (
+            np.zeros((1, extension_count), dtype=np.int64),
+            np.cumsum(active, axis=0, dtype=np.int64),
+        ),
+        axis=0,
+    )
+    cumulative_passed = np.concatenate(
+        (
+            np.zeros(
+                (1, len(BED_NAMES), extension_count),
+                dtype=np.int64,
+            ),
+            np.cumsum(passed, axis=0, dtype=np.int64),
+        ),
+        axis=0,
+    )
+    cumulative_energy = np.concatenate(
+        (
+            np.zeros((1, extension_count), dtype=np.float64),
+            np.cumsum(extension_energy, axis=0, dtype=np.float64),
+        ),
+        axis=0,
+    )
+
+    frame_count = max(1, round(video.duration * target_fps))
+    effective_fps = frame_count / video.duration
+    times = np.arange(frame_count, dtype=np.float64) / effective_fps
+    positions = np.full(
+        (frame_count, extension_count, 2), np.nan, dtype=np.float64
+    )
+    coverages = np.full(
+        (frame_count, len(BED_NAMES), extension_count),
+        np.nan,
+        dtype=np.float64,
+    )
+    active_blocks = np.zeros(
+        (frame_count, extension_count), dtype=np.int64
+    )
+    window_energy = np.zeros(
+        (frame_count, extension_count), dtype=np.float64
+    )
+    valid = np.zeros(
+        (frame_count, extension_count), dtype=np.bool_
+    )
+    spatial_beds = [
+        BED_NAMES.index(name) for name in BED_COORDINATES
+    ]
+    coordinates = np.array(
+        list(BED_COORDINATES.values()), dtype=np.float64
+    )
+    audio_duration = info.frames / info.sample_rate
+    half_window = window_seconds / 2.0
+    for frame, video_time in enumerate(times):
+        audio_time = video_time - video.audio_start
+        if audio_time < 0.0 or audio_time >= audio_duration:
+            continue
+        start = int(
+            np.searchsorted(
+                block_centres, audio_time - half_window, side="left"
+            )
+        )
+        end = int(
+            np.searchsorted(
+                block_centres, audio_time + half_window, side="right"
+            )
+        )
+        if end <= start:
+            continue
+        active_count = (
+            cumulative_active[end] - cumulative_active[start]
+        )
+        active_blocks[frame] = active_count
+        pass_count = (
+            cumulative_passed[end] - cumulative_passed[start]
+        )
+        energy = (
+            cumulative_energy[end] - cumulative_energy[start]
+        )
+        window_energy[frame] = energy
+        for extension in range(extension_count):
+            if active_count[extension] < minimum_active_blocks:
+                continue
+            coverage = (
+                pass_count[:, extension] / active_count[extension]
+            )
+            coverages[frame, :, extension] = coverage
+            weights = coverage[spatial_beds]
+            weight_sum = float(np.sum(weights))
+            if weight_sum <= 0.0:
+                continue
+            positions[frame, extension] = (
+                np.sum(coordinates * weights[:, None], axis=0)
+                / weight_sum
+            )
+            valid[frame, extension] = True
+
+    activity = np.zeros_like(window_energy)
+    for extension in range(extension_count):
+        selected = window_energy[
+            window_energy[:, extension] > 0.0, extension
+        ]
+        if selected.size == 0:
+            continue
+        scale = float(np.percentile(selected, 95.0))
+        if scale > 0.0:
+            activity[:, extension] = np.clip(
+                window_energy[:, extension] / scale, 0.0, 1.0
+            )
+    activity[~valid] = 0.0
+    return TemporalBarycenters(
+        title=title,
+        video=video,
+        fps=effective_fps,
+        encoding_fps=target_fps,
+        times=times,
+        positions=positions,
+        coverages=coverages,
+        active_blocks=active_blocks,
+        activity=activity,
+        valid=valid,
+    )
+
+
+def format_clock(seconds: float) -> str:
+    milliseconds = round(seconds * 1000.0)
+    hours, remainder = divmod(milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    seconds, milliseconds = divmod(remainder, 1000)
+    return (
+        f"{hours:02d}:{minutes:02d}:{seconds:02d}."
+        f"{milliseconds:03d}"
+    )
+
+
+def write_temporal_positions(
+    path: Path, tracks: list[TemporalBarycenters]
+) -> None:
+    fields = [
+        "title",
+        "video_time",
+        "audio_time",
+        "extension",
+        "x",
+        "y",
+        "activity",
+        "valid",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as output:
+        writer = csv.DictWriter(
+            output, fieldnames=fields, dialect="excel-tab"
+        )
+        writer.writeheader()
+        for track in tracks:
+            extension_count = track.positions.shape[1]
+            for frame, video_time in enumerate(track.times):
+                audio_time = video_time - track.video.audio_start
+                for extension in range(extension_count):
+                    is_valid = bool(track.valid[frame, extension])
+                    writer.writerow(
+                        {
+                            "title": track.title,
+                            "video_time": f"{video_time:.9f}",
+                            "audio_time": f"{audio_time:.9f}",
+                            "extension": f"X{extension}",
+                            "x": (
+                                f"{track.positions[frame, extension, 0]:.9f}"
+                                if is_valid
+                                else ""
+                            ),
+                            "y": (
+                                f"{track.positions[frame, extension, 1]:.9f}"
+                                if is_valid
+                                else ""
+                            ),
+                            "activity": (
+                                f"{track.activity[frame, extension]:.9f}"
+                            ),
+                            "valid": int(is_valid),
+                        }
+                    )
+
+
+def write_temporal_coverages(
+    path: Path, tracks: list[TemporalBarycenters]
+) -> None:
+    fields = [
+        "title",
+        "video_time",
+        "audio_time",
+        "extension",
+        "bed",
+        "coverage",
+        "active_blocks",
+        "valid",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as output:
+        writer = csv.DictWriter(
+            output, fieldnames=fields, dialect="excel-tab"
+        )
+        writer.writeheader()
+        for track in tracks:
+            extension_count = track.coverages.shape[2]
+            for frame, video_time in enumerate(track.times):
+                audio_time = video_time - track.video.audio_start
+                for extension in range(extension_count):
+                    active_blocks = int(
+                        track.active_blocks[frame, extension]
+                    )
+                    for bed_index, bed in enumerate(BED_NAMES):
+                        coverage = track.coverages[
+                            frame, bed_index, extension
+                        ]
+                        is_valid = bool(np.isfinite(coverage))
+                        writer.writerow(
+                            {
+                                "title": track.title,
+                                "video_time": f"{video_time:.9f}",
+                                "audio_time": f"{audio_time:.9f}",
+                                "extension": f"X{extension}",
+                                "bed": bed,
+                                "coverage": (
+                                    f"{coverage:.9f}"
+                                    if is_valid
+                                    else ""
+                                ),
+                                "active_blocks": active_blocks,
+                                "valid": int(is_valid),
+                            }
+                        )
+
+
+def write_barycenter_animations(
+    directory: Path,
+    tracks: list[TemporalBarycenters],
+    plot_gain: float,
+    window_seconds: float,
+    trail_seconds: float,
+) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FFMpegWriter
+    from matplotlib.patches import Polygon
+
+    directory.mkdir(parents=True, exist_ok=True)
+    write_temporal_positions(
+        directory / "temporal-positions.tsv", tracks
+    )
+    write_temporal_coverages(
+        directory / "temporal-coverages.tsv", tracks
+    )
+    gain_label = (
+        f"{plot_gain:.1f}"
+        if plot_gain.is_integer()
+        else f"{plot_gain:.6f}".rstrip("0")
+    )
+    colors = plt.get_cmap("tab10").colors
+    for track in tracks:
+        figure, axis = plt.subplots(figsize=(6.0, 6.0))
+        axis.add_patch(
+            Polygon(
+                [(-1.0, 1.0), (1.0, 1.0), (1.0, -1.0), (-1.0, -1.0)],
+                closed=True,
+                fill=False,
+                edgecolor="#666666",
+                linewidth=1.3,
+            )
+        )
+        for bed, (x, y) in BED_COORDINATES.items():
+            axis.scatter(
+                x,
+                y,
+                marker="s",
+                s=65,
+                color="#222222",
+                edgecolor="white",
+                linewidth=0.8,
+                zorder=4,
+            )
+            horizontal = (
+                "right" if x < 0 else "left" if x > 0 else "center"
+            )
+            x_offset = -0.04 if x < 0 else 0.04 if x > 0 else 0.0
+            y_offset = 0.075 if y >= 0 else -0.09
+            axis.text(
+                x + x_offset,
+                y + y_offset,
+                bed,
+                ha=horizontal,
+                va="center",
+                fontsize=8,
+                fontweight="bold",
+                color="#222222",
+            )
+        axis.scatter(
+            0.0,
+            0.0,
+            marker="+",
+            s=55,
+            color="#777777",
+            linewidth=1.2,
+            zorder=2,
+        )
+        axis.set_xlim(-1.18, 1.18)
+        axis.set_ylim(-1.18, 1.18)
+        axis.set_aspect("equal", adjustable="box")
+        axis.set_xlabel("x (left - / right +)")
+        axis.set_ylabel("y (rear - / front +)")
+        axis.set_title(
+            f"{track.title}\n"
+            f"Temporal bed-coverage barycentres at g = {gain_label}"
+        )
+        axis.grid(True, color="#dddddd", linewidth=0.6)
+        axis.axhline(0.0, color="#bbbbbb", linewidth=0.7, zorder=1)
+        axis.axvline(0.0, color="#bbbbbb", linewidth=0.7, zorder=1)
+        time_text = axis.text(
+            0.02,
+            0.98,
+            "",
+            transform=axis.transAxes,
+            ha="left",
+            va="top",
+            fontsize=9,
+            family="monospace",
+            bbox={
+                "boxstyle": "round,pad=0.25",
+                "facecolor": "white",
+                "edgecolor": "#aaaaaa",
+                "alpha": 0.9,
+            },
+            zorder=10,
+        )
+        status_text = axis.text(
+            0.5,
+            0.04,
+            "",
+            transform=axis.transAxes,
+            ha="center",
+            va="bottom",
+            fontsize=8,
+            color="#666666",
+            zorder=10,
+        )
+        figure.text(
+            0.5,
+            0.015,
+            f"{window_seconds:g} s coverage window; LFE excluded; "
+            "marker size/opacity = X activity.",
+            ha="center",
+            fontsize=8,
+        )
+        figure.tight_layout(rect=(0.0, 0.035, 1.0, 1.0))
+
+        extension_count = track.positions.shape[1]
+        points = []
+        labels = []
+        trails = []
+        for extension in range(extension_count):
+            color = colors[extension % len(colors)]
+            trail, = axis.plot(
+                [],
+                [],
+                color=color,
+                linewidth=1.2,
+                alpha=0.35,
+                zorder=3,
+            )
+            point, = axis.plot(
+                [],
+                [],
+                marker="o",
+                linestyle="none",
+                color=color,
+                markeredgecolor="white",
+                markeredgewidth=1.0,
+                zorder=5,
+            )
+            label = axis.text(
+                0.0,
+                0.0,
+                f"X{extension}",
+                fontsize=8,
+                fontweight="bold",
+                color=color,
+                zorder=6,
+            )
+            trails.append(trail)
+            points.append(point)
+            labels.append(label)
+
+        safe_title = re.sub(
+            r"[^A-Za-z0-9_.-]+", "_", track.title
+        )
+        output = (
+            directory
+            / f"{safe_title}.positions-{gain_label}.mp4"
+        )
+        temporary_output = (
+            directory
+            / f".{safe_title}.positions-{gain_label}.unscaled.mp4"
+        )
+        writer = FFMpegWriter(
+            fps=track.encoding_fps,
+            codec="libx264",
+            metadata={
+                "title": track.title,
+                "comment": (
+                    "Coverage-weighted research visualization; "
+                    "not decoded object metadata"
+                ),
+            },
+            extra_args=[
+                "-pix_fmt",
+                "yuv420p",
+                "-crf",
+                "22",
+                "-movflags",
+                "+faststart",
+            ],
+        )
+        trail_frames = max(1, round(trail_seconds * track.fps))
+        print(
+            f"animation_start\t{track.title}\t"
+            f"frames={len(track.times)} fps={track.encoding_fps:.6f} "
+            f"duration={track.video.duration:.6f}"
+        )
+        with writer.saving(figure, str(temporary_output), dpi=120):
+            for frame, video_time in enumerate(track.times):
+                any_valid = False
+                trail_start = max(0, frame - trail_frames + 1)
+                for extension in range(extension_count):
+                    is_valid = bool(track.valid[frame, extension])
+                    if not is_valid:
+                        points[extension].set_data([], [])
+                        labels[extension].set_visible(False)
+                    else:
+                        any_valid = True
+                        x, y = track.positions[frame, extension]
+                        level = math.sqrt(
+                            float(track.activity[frame, extension])
+                        )
+                        points[extension].set_data([x], [y])
+                        points[extension].set_markersize(
+                            4.0 + 9.0 * level
+                        )
+                        points[extension].set_alpha(
+                            0.25 + 0.75 * level
+                        )
+                        side = -1.0 if extension % 2 == 0 else 1.0
+                        vertical = (
+                            0.035
+                            if extension % 4 < 2
+                            else -0.045
+                        )
+                        labels[extension].set_position(
+                            (x + side * 0.035, y + vertical)
+                        )
+                        labels[extension].set_ha(
+                            "right" if side < 0.0 else "left"
+                        )
+                        labels[extension].set_visible(True)
+                    history = track.positions[
+                        trail_start : frame + 1, extension
+                    ].copy()
+                    history_valid = track.valid[
+                        trail_start : frame + 1, extension
+                    ]
+                    history[~history_valid] = np.nan
+                    trails[extension].set_data(
+                        history[:, 0], history[:, 1]
+                    )
+                time_text.set_text(
+                    f"{format_clock(video_time)} / "
+                    f"{format_clock(track.video.duration)}"
+                )
+                if any_valid:
+                    status_text.set_text("")
+                else:
+                    status_text.set_text(
+                        "No active decoded DTS:X window"
+                    )
+                writer.grab_frame()
+        plt.close(figure)
+        encoded_duration = len(track.times) / track.encoding_fps
+        timestamp_scale = track.video.duration / encoded_duration
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-itsscale",
+                f"{timestamp_scale:.12f}",
+                "-i",
+                str(temporary_output),
+                "-map",
+                "0:v:0",
+                "-c",
+                "copy",
+                "-movflags",
+                "+faststart",
+                "-y",
+                str(output),
+            ],
+            check=True,
+        )
+        temporary_output.unlink()
+        print(f"animation\t{output}")
+    print(
+        f"temporal_positions\t"
+        f"{directory / 'temporal-positions.tsv'}"
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    if args.block_samples <= 0:
+        raise SystemExit("--block-samples must be positive")
+    if not 0.0 < args.coverage <= 1.0:
+        raise SystemExit("--coverage must be in (0, 1]")
+    if args.extensions <= 0:
+        raise SystemExit("--extensions must be positive")
+    if args.activity_db > 0.0:
+        raise SystemExit("--activity-db must be at most 0 dB")
+    if args.animation_fps <= 0.0:
+        raise SystemExit("--animation-fps must be positive")
+    if args.temporal_window_seconds <= 0.0:
+        raise SystemExit("--temporal-window-seconds must be positive")
+    if args.trail_seconds < 0.0:
+        raise SystemExit("--trail-seconds must be non-negative")
+    if args.minimum_active_blocks <= 0:
+        raise SystemExit("--minimum-active-blocks must be positive")
+    needs_temporal = bool(
+        args.animation_dir or args.temporal_coverage_output
+    )
+    if needs_temporal and args.video_dir is None:
+        raise SystemExit(
+            "--video-dir is required with temporal coverage or animation"
+        )
+    gain_distances = [
+        abs(fixed_gain - args.plot_gain)
+        for fixed_gain in FIXED_GAINS
+    ]
+    fixed_gain_index = int(np.argmin(gain_distances))
+    if gain_distances[fixed_gain_index] > 5e-6:
+        raise SystemExit(
+            "--plot-gain must be 0.5, 0.707107 or 1.0"
+        )
+    plot_gain = float(FIXED_GAINS[fixed_gain_index])
+    paths = discover(args.inputs)
+    all_results: list[FoldLimit] = []
+    temporal_tracks: list[TemporalBarycenters] = []
+    analyzed_titles = []
+    for path in paths:
+        info = probe(path)
+        extension_count = info.channels - len(BED_NAMES)
+        if extension_count != args.extensions:
+            print(
+                f"skip\t{path.name}\textensions={extension_count}, "
+                f"requested={args.extensions}"
+            )
+            continue
+        if info.sample_rate != 48_000:
+            raise ValueError(
+                f"{path}: expected 48000 Hz, got {info.sample_rate}"
+            )
+        print(
+            f"analyze\t{path.name}\tchannels={info.channels} "
+            f"frames={info.frames}"
+        )
+        statistics = None
+        if needs_temporal:
+            statistics = read_block_statistics(
+                path, info.channels, args.block_samples
+            )
+        results = analyze_file(
+            path,
+            info,
+            args.block_samples,
+            args.coverage,
+            args.activity_db,
+            statistics,
+        )
+        title = path.name.removesuffix(".dtsx.audio")
+        if needs_temporal:
+            assert statistics is not None
+            assert args.video_dir is not None
+            video = probe_video(args.video_dir, title)
+            temporal_tracks.append(
+                calculate_temporal_barycenters(
+                    title=title,
+                    video=video,
+                    info=info,
+                    statistics=statistics,
+                    block_samples=args.block_samples,
+                    activity_db=args.activity_db,
+                    plot_gain=plot_gain,
+                    target_fps=args.animation_fps,
+                    window_seconds=args.temporal_window_seconds,
+                    minimum_active_blocks=(
+                        args.minimum_active_blocks
+                    ),
+                )
+            )
+        print_file_summary(
+            title, results
+        )
+        all_results.extend(results)
+        analyzed_titles.append(title)
+    if not all_results:
+        raise SystemExit("no matching streams analyzed")
+    print_corpus_summary(
+        all_results, len(analyzed_titles), args.coverage
+    )
+    if args.output:
+        write_tsv(args.output, all_results)
+        print(f"output\t{args.output}")
+    if args.plot_dir:
+        write_coverage_plots(
+            args.plot_dir,
+            all_results,
+            args.coverage,
+            args.block_samples,
+            args.activity_db,
+            plot_gain,
+            fixed_gain_index,
+        )
+    if args.position_plot_dir:
+        barycenters = calculate_bed_barycenters(
+            all_results, fixed_gain_index
+        )
+        write_barycenter_plots(
+            args.position_plot_dir,
+            barycenters,
+            plot_gain,
+        )
+    if args.temporal_coverage_output:
+        write_temporal_coverages(
+            args.temporal_coverage_output,
+            temporal_tracks,
+        )
+        print(
+            f"temporal_coverages\t"
+            f"{args.temporal_coverage_output}"
+        )
+    if args.animation_dir:
+        write_barycenter_animations(
+            args.animation_dir,
+            temporal_tracks,
+            plot_gain,
+            args.temporal_window_seconds,
+            args.trail_seconds,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze-dtsx-fixed-layout-fold.py
+++ b/scripts/analyze-dtsx-fixed-layout-fold.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Detailed fixed-layout comparison for paired spatial-audio encodes.
+
+Inputs are the aligned, interleaved f32le files produced from:
+
+* DTS:X: ``xll_pcm_range``, eight bed channels then X0..X7;
+* Atmos: ``truehdd`` DAMF audio, trimmed to the coarse 512-sample alignment.
+
+The script finds pair-specific delays/correlations in the most active programme
+window.  Folding tests are deliberately performed only after this pairing
+stage; correlation of programme envelopes alone is not treated as a channel
+identity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import linear_sum_assignment, nnls
+from scipy.signal import correlate, correlation_lags
+
+
+SAMPLE_RATE = 48_000
+FRAME_SAMPLES = 512
+DTS_NAMES = [
+    "C",
+    "L",
+    "R",
+    "Ls",
+    "Rs",
+    "LFE",
+    "Lb",
+    "Rb",
+    "X0",
+    "X1",
+    "X2",
+    "X3",
+    "X4",
+    "X5",
+    "X6",
+    "X7",
+]
+ATMOS_NAMES = [
+    "LFE",
+    "L",
+    "R",
+    "Lw",
+    "C",
+    "Ls",
+    "Lb",
+    "TFL",
+    "Rw",
+    "Rs",
+    "TML",
+    "Rb",
+    "TBL",
+    "TFR",
+    "TMR",
+    "TBR",
+]
+EXPECTED_BED = {
+    "C": "C",
+    "L": "L",
+    "R": "R",
+    "Ls": "Ls",
+    "Rs": "Rs",
+    "LFE": "LFE",
+    "Lb": "Lb",
+    "Rb": "Rb",
+}
+STEREO_FOLD_TARGETS = [
+    ("L/R", "L", "R"),
+    ("Ls/Rs", "Ls", "Rs"),
+    ("Lb/Rb", "Lb", "Rb"),
+]
+STEREO_X_PAIRS = [
+    ("X0/X1", "X0", "X1"),
+    ("X2/X3", "X2", "X3"),
+    ("X4/X5", "X4", "X5"),
+    ("X6/X7", "X6", "X7"),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dtsx_f32le", type=Path)
+    parser.add_argument("atmos_f32le", type=Path)
+    parser.add_argument("--window-seconds", type=float, default=10.0)
+    parser.add_argument("--max-lag-samples", type=int, default=1024)
+    parser.add_argument("--fine-lag-samples", type=int, default=10)
+    parser.add_argument("--fold-window-seconds", type=float, default=5.0)
+    return parser.parse_args()
+
+
+def open_pcm(path: Path) -> np.memmap:
+    samples = path.stat().st_size // (4 * 16)
+    return np.memmap(path, dtype="<f4", mode="r", shape=(samples, 16))
+
+
+def frame_rms(pcm: np.ndarray) -> np.ndarray:
+    samples = len(pcm) // FRAME_SAMPLES * FRAME_SAMPLES
+    framed = pcm[:samples].reshape(-1, FRAME_SAMPLES, 16)
+    return np.sqrt(np.mean(framed.astype(np.float64) ** 2, axis=1))
+
+
+def active_window(
+    energy: np.ndarray, seconds: float
+) -> tuple[int, int]:
+    frames = max(1, round(seconds * SAMPLE_RATE / FRAME_SAMPLES))
+    count = len(energy)
+    frames = min(frames, count)
+    cumulative = np.concatenate(([0.0], np.cumsum(energy)))
+    window_energy = cumulative[frames:] - cumulative[:-frames]
+    start_frame = int(np.argmax(window_energy)) if len(window_energy) else 0
+    return start_frame * FRAME_SAMPLES, frames * FRAME_SAMPLES
+
+
+def lagged_correlation(
+    dtsx: np.ndarray, atmos: np.ndarray, max_lag: int
+) -> tuple[float, int]:
+    dtsx = dtsx.astype(np.float64)
+    atmos = atmos.astype(np.float64)
+    dtsx -= np.mean(dtsx)
+    atmos -= np.mean(atmos)
+    cross = correlate(atmos, dtsx, mode="full", method="fft")
+    lags = correlation_lags(len(atmos), len(dtsx), mode="full")
+    selected = np.flatnonzero(np.abs(lags) <= max_lag)
+    denominator = np.linalg.norm(atmos) * np.linalg.norm(dtsx)
+    if denominator == 0.0:
+        return 0.0, 0
+    values = cross[selected] / denominator
+    index = int(np.argmax(np.abs(values)))
+    return float(values[index]), int(lags[selected[index]])
+
+
+def windowed_power_groups(
+    dtsx_rms: np.ndarray,
+    atmos_rms: np.ndarray,
+    window_seconds: float = 5.0,
+) -> tuple[np.ndarray, np.ndarray]:
+    frames = max(100, round(window_seconds * SAMPLE_RATE / FRAME_SAMPLES))
+    aggregate = np.zeros((16, 16))
+    fit_scores: list[list[float]] = [[] for _ in range(16)]
+    for start in range(0, min(len(dtsx_rms), len(atmos_rms)), frames):
+        end = min(
+            start + frames, len(dtsx_rms), len(atmos_rms)
+        )
+        if end - start < 100:
+            continue
+        design = atmos_rms[start:end].astype(np.float64) ** 2
+        scale = np.sqrt(np.mean(design * design, axis=0))
+        scale[scale == 0.0] = 1.0
+        design_scaled = design / scale
+        for channel in range(16):
+            target = dtsx_rms[start:end, channel].astype(np.float64) ** 2
+            if np.max(target) <= 1e-12:
+                continue
+            coefficient, _ = nnls(design_scaled, target)
+            weights = coefficient / scale
+            prediction = design @ weights
+            total = np.sum((target - np.mean(target)) ** 2)
+            residual = np.sum((target - prediction) ** 2)
+            score = max(0.0, 1.0 - residual / total) if total > 0 else 0.0
+            fit_scores[channel].append(score)
+            weight_sum = np.sum(weights)
+            if score >= 0.2 and weight_sum > 0.0:
+                aggregate[channel] += weights / weight_sum * score
+    score_medians = np.array(
+        [
+            np.median(scores) if scores else 0.0
+            for scores in fit_scores
+        ]
+    )
+    return aggregate, score_medians
+
+
+def aligned_channels(
+    dtsx: np.ndarray,
+    atmos: np.ndarray,
+    dtsx_channel: int,
+    atmos_channel: int,
+    lag: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return a DTS/Atmos pair aligned using the lag convention above."""
+    if lag >= 0:
+        return (
+            dtsx[: len(dtsx) - lag, dtsx_channel],
+            atmos[lag:, atmos_channel],
+        )
+    return (
+        dtsx[-lag:, dtsx_channel],
+        atmos[: len(atmos) + lag, atmos_channel],
+    )
+
+
+def covariance(
+    left: np.ndarray, right: np.ndarray
+) -> tuple[float, float, float]:
+    left64 = left.astype(np.float64)
+    right64 = right.astype(np.float64)
+    left64 -= np.mean(left64)
+    right64 -= np.mean(right64)
+    return (
+        float(np.dot(left64, right64)),
+        float(np.dot(left64, left64)),
+        float(np.dot(right64, right64)),
+    )
+
+
+def fold_curve(
+    target: np.ndarray,
+    bed: np.ndarray,
+    extension: np.ndarray,
+    folds: np.ndarray,
+) -> np.ndarray:
+    """Absolute correlation of target with ``bed - fold * extension``."""
+    target64 = target.astype(np.float64)
+    bed64 = bed.astype(np.float64)
+    extension64 = extension.astype(np.float64)
+    target64 -= np.mean(target64)
+    bed64 -= np.mean(bed64)
+    extension64 -= np.mean(extension64)
+    yy = np.dot(target64, target64)
+    bb = np.dot(bed64, bed64)
+    xx = np.dot(extension64, extension64)
+    yb = np.dot(target64, bed64)
+    yx = np.dot(target64, extension64)
+    bx = np.dot(bed64, extension64)
+    variance = bb + folds * folds * xx - 2.0 * folds * bx
+    denominator = np.sqrt(np.maximum(yy * variance, 1e-300))
+    return np.abs((yb - folds * yx) / denominator)
+
+
+def stereo_fold_analysis(
+    dtsx: np.ndarray,
+    atmos: np.ndarray,
+    lag: int,
+    window_seconds: float,
+) -> None:
+    """Test bounded, symmetric subtraction folds without free gain fitting."""
+    folds = np.linspace(0.0, 1.0, 201)
+    window = max(1, round(window_seconds * SAMPLE_RATE))
+    print(
+        "symmetric_folds: corrected_bed=bed-f*X, "
+        f"lag={lag:+d}, f in [0,1]"
+    )
+    for target_name, left_name, right_name in STEREO_FOLD_TARGETS:
+        left_dts = DTS_NAMES.index(left_name)
+        right_dts = DTS_NAMES.index(right_name)
+        left_atmos = ATMOS_NAMES.index(left_name)
+        right_atmos = ATMOS_NAMES.index(right_name)
+        left_bed, left_target = aligned_channels(
+            dtsx, atmos, left_dts, left_atmos, lag
+        )
+        right_bed, right_target = aligned_channels(
+            dtsx, atmos, right_dts, right_atmos, lag
+        )
+        for pair_name, left_x_name, right_x_name in STEREO_X_PAIRS:
+            left_x, _ = aligned_channels(
+                dtsx,
+                atmos,
+                DTS_NAMES.index(left_x_name),
+                left_atmos,
+                lag,
+            )
+            right_x, _ = aligned_channels(
+                dtsx,
+                atmos,
+                DTS_NAMES.index(right_x_name),
+                right_atmos,
+                lag,
+            )
+            full_score = (
+                fold_curve(left_target, left_bed, left_x, folds)
+                + fold_curve(right_target, right_bed, right_x, folds)
+            ) / 2.0
+            best_index = int(np.argmax(full_score))
+            best_fold = float(folds[best_index])
+            baseline = float(full_score[0])
+            best = float(full_score[best_index])
+
+            window_deltas: list[float] = []
+            applied_deltas: list[float] = []
+            window_folds: list[float] = []
+            common = min(
+                len(left_target),
+                len(right_target),
+                len(left_x),
+                len(right_x),
+            )
+            for start in range(0, common, window):
+                end = min(start + window, common)
+                if end - start < SAMPLE_RATE:
+                    continue
+                left_energy = float(
+                    np.mean(left_target[start:end].astype(np.float64) ** 2)
+                )
+                right_energy = float(
+                    np.mean(right_target[start:end].astype(np.float64) ** 2)
+                )
+                if max(left_energy, right_energy) < 1e-10:
+                    continue
+                scores = (
+                    fold_curve(
+                        left_target[start:end],
+                        left_bed[start:end],
+                        left_x[start:end],
+                        folds,
+                    )
+                    + fold_curve(
+                        right_target[start:end],
+                        right_bed[start:end],
+                        right_x[start:end],
+                        folds,
+                    )
+                ) / 2.0
+                index = int(np.argmax(scores))
+                window_folds.append(float(folds[index]))
+                window_deltas.append(float(scores[index] - scores[0]))
+                applied_deltas.append(
+                    float(scores[best_index] - scores[0])
+                )
+
+            applied_median_delta = (
+                float(np.median(applied_deltas))
+                if applied_deltas
+                else 0.0
+            )
+            applied_positive = sum(delta > 0.0 for delta in applied_deltas)
+            improving = [
+                fold
+                for fold, delta in zip(window_folds, window_deltas)
+                if delta >= 0.01
+            ]
+            if improving:
+                lower, median, upper = np.percentile(
+                    improving, [25.0, 50.0, 75.0]
+                )
+                stability = (
+                    f"improving={len(improving)}/{len(window_folds)}, "
+                    f"f_IQR={lower:.2f}/{median:.2f}/{upper:.2f}"
+                )
+            else:
+                stability = (
+                    f"improving=0/{len(window_folds)}, f_IQR=-"
+                )
+            gain = (
+                20.0 * math.log10(best_fold)
+                if best_fold > 0.0
+                else float("-inf")
+            )
+            print(
+                f"  {target_name:<5} - {pair_name}: "
+                f"base={baseline:.4f}, best={best:.4f}, "
+                f"delta={best - baseline:+.4f}, "
+                f"f={best_fold:.3f} ({gain:+.2f} dB), "
+                f"applied_window_delta={applied_median_delta:+.4f}, "
+                f"positive={applied_positive}/{len(applied_deltas)}, "
+                f"{stability}"
+            )
+
+
+def center_fold_analysis(
+    dtsx: np.ndarray,
+    atmos: np.ndarray,
+    lag: int,
+    window_seconds: float,
+) -> None:
+    folds = np.linspace(0.0, 1.0, 201)
+    window = max(1, round(window_seconds * SAMPLE_RATE))
+    center_bed, center_target = aligned_channels(
+        dtsx,
+        atmos,
+        DTS_NAMES.index("C"),
+        ATMOS_NAMES.index("C"),
+        lag,
+    )
+    print("center_folds: corrected_C=C-f*X, f in [0,1]")
+    for extension_name in DTS_NAMES[8:]:
+        extension, _ = aligned_channels(
+            dtsx,
+            atmos,
+            DTS_NAMES.index(extension_name),
+            ATMOS_NAMES.index("C"),
+            lag,
+        )
+        scores = fold_curve(
+            center_target, center_bed, extension, folds
+        )
+        best_index = int(np.argmax(scores))
+        best_fold = float(folds[best_index])
+        deltas: list[float] = []
+        common = min(len(center_target), len(extension))
+        for start in range(0, common, window):
+            end = min(start + window, common)
+            if end - start < SAMPLE_RATE:
+                continue
+            if np.mean(
+                center_target[start:end].astype(np.float64) ** 2
+            ) < 1e-10:
+                continue
+            local = fold_curve(
+                center_target[start:end],
+                center_bed[start:end],
+                extension[start:end],
+                folds[[0, best_index]],
+            )
+            deltas.append(float(local[1] - local[0]))
+        gain = (
+            20.0 * math.log10(best_fold)
+            if best_fold > 0.0
+            else float("-inf")
+        )
+        median_delta = float(np.median(deltas)) if deltas else 0.0
+        positive = sum(delta > 0.0 for delta in deltas)
+        print(
+            f"  C - {extension_name}: base={scores[0]:.4f}, "
+            f"best={scores[best_index]:.4f}, "
+            f"delta={scores[best_index] - scores[0]:+.4f}, "
+            f"f={best_fold:.3f} ({gain:+.2f} dB), "
+            f"applied_window_delta={median_delta:+.4f}, "
+            f"positive={positive}/{len(deltas)}"
+        )
+
+
+def expected_bed_correlations(
+    dtsx: np.ndarray,
+    atmos: np.ndarray,
+    lag: int,
+) -> None:
+    print(f"expected_bed_geometry: fixed_lag={lag:+d}")
+    for dtsx_name, atmos_name in EXPECTED_BED.items():
+        bed, target = aligned_channels(
+            dtsx,
+            atmos,
+            DTS_NAMES.index(dtsx_name),
+            ATMOS_NAMES.index(atmos_name),
+            lag,
+        )
+        cross, bed_power, target_power = covariance(bed, target)
+        correlation = (
+            cross / math.sqrt(bed_power * target_power)
+            if bed_power > 0.0 and target_power > 0.0
+            else 0.0
+        )
+        print(
+            f"  {dtsx_name:>3} -> {atmos_name:<3}: "
+            f"r={correlation:+.4f}, abs={abs(correlation):.4f}"
+        )
+
+
+def expected_bed_active_ranks(
+    correlations: np.ndarray,
+    lags: np.ndarray,
+) -> None:
+    print("expected_bed_active_windows:")
+    for dtsx_name, atmos_name in EXPECTED_BED.items():
+        dtsx_channel = DTS_NAMES.index(dtsx_name)
+        atmos_channel = ATMOS_NAMES.index(atmos_name)
+        order = np.argsort(
+            np.abs(correlations[dtsx_channel])
+        )[::-1]
+        rank = int(np.flatnonzero(order == atmos_channel)[0]) + 1
+        best = int(order[0])
+        print(
+            f"  {dtsx_name:>3} -> {atmos_name:<3}: "
+            f"abs_r={abs(correlations[dtsx_channel, atmos_channel]):.4f}, "
+            f"rank={rank}/16, "
+            f"best={ATMOS_NAMES[best]} "
+            f"({correlations[dtsx_channel, best]:+.4f}"
+            f"@{lags[dtsx_channel, best]:+d})"
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    dtsx = open_pcm(args.dtsx_f32le)
+    atmos = open_pcm(args.atmos_f32le)
+    common = min(len(dtsx), len(atmos))
+    dtsx_rms = frame_rms(dtsx[:common])
+
+    correlations = np.zeros((16, 16))
+    lags = np.zeros((16, 16), dtype=np.int32)
+    starts = np.zeros(16, dtype=np.int64)
+    for dtsx_channel in range(16):
+        start, length = active_window(
+            dtsx_rms[:, dtsx_channel] ** 2,
+            args.window_seconds,
+        )
+        starts[dtsx_channel] = start
+        end = min(start + length, common)
+        dtsx_window = dtsx[start:end]
+        atmos_window = atmos[start:end]
+        for atmos_channel in range(16):
+            value, lag = lagged_correlation(
+                dtsx_window[:, dtsx_channel],
+                atmos_window[:, atmos_channel],
+                args.max_lag_samples,
+            )
+            correlations[dtsx_channel, atmos_channel] = value
+            lags[dtsx_channel, atmos_channel] = lag
+
+    dtsx_indices, atmos_indices = linear_sum_assignment(
+        -np.abs(correlations)
+    )
+    print(f"channel_windows={args.window_seconds:.3f}s at per-channel peak")
+    print("forced_one_to_one_assignment_diagnostic:")
+    for dtsx_channel, atmos_channel in zip(
+        dtsx_indices, atmos_indices
+    ):
+        value = correlations[dtsx_channel, atmos_channel]
+        lag = lags[dtsx_channel, atmos_channel]
+        top = np.argsort(np.abs(correlations[dtsx_channel]))[::-1][:4]
+        top_text = ", ".join(
+            f"{ATMOS_NAMES[index]}:"
+            f"{correlations[dtsx_channel, index]:+.3f}"
+            f"@{lags[dtsx_channel, index]:+d}"
+            for index in top
+        )
+        print(
+            f"  {DTS_NAMES[dtsx_channel]:>3} -> "
+            f"{ATMOS_NAMES[atmos_channel]:<3} "
+            f"r={value:+.4f} lag={lag:+d} "
+            f"window={starts[dtsx_channel] / SAMPLE_RATE:.3f}s; "
+            f"top {top_text}"
+        )
+    expected_bed_active_ranks(correlations, lags)
+
+    groups, group_scores = windowed_power_groups(dtsx_rms, frame_rms(atmos[:common]))
+    print("windowed_power_groups:")
+    for channel, name in enumerate(DTS_NAMES):
+        order = np.argsort(groups[channel])[::-1]
+        weight_sum = np.sum(groups[channel])
+        if weight_sum == 0.0:
+            top_text = "-"
+        else:
+            top_text = ", ".join(
+                f"{ATMOS_NAMES[index]}:{groups[channel, index] / weight_sum:.2f}"
+                for index in order[:4]
+                if groups[channel, index] > 0.0
+            )
+        print(
+            f"  {name:>3}: median_R2={group_scores[channel]:.3f}; "
+            f"{top_text}"
+        )
+
+    expected_bed_correlations(
+        dtsx[:common], atmos[:common], args.fine_lag_samples
+    )
+    stereo_fold_analysis(
+        dtsx[:common],
+        atmos[:common],
+        args.fine_lag_samples,
+        args.fold_window_seconds,
+    )
+    center_fold_analysis(
+        dtsx[:common],
+        atmos[:common],
+        args.fine_lag_samples,
+        args.fold_window_seconds,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze-dtsx-fixed-pan.py
+++ b/scripts/analyze-dtsx-fixed-pan.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Find locally coherent pans in a decoded fixed 7.1.4 presentation.
+
+The input is the interleaved f32le produced by the ``xll_pcm_range`` example:
+eight compatible-bed channels in DCA order followed by X0..X3.  This is a
+research tool.  It estimates a dominant gain vector in short windows; it does
+not claim to recover authoring objects or coordinates from the bitstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import numpy as np
+
+
+CHANNELS = ("C", "L", "R", "Ls", "Rs", "LFE", "Lb", "Rb", "X0", "X1", "X2", "X3")
+HEIGHT = np.array((8, 9, 10, 11))
+HEIGHT_BED_PAIRS = ((8, 1), (9, 2), (10, 6), (11, 7))
+
+
+def clock(seconds: float) -> str:
+    minute, second = divmod(seconds, 60.0)
+    hour, minute = divmod(int(minute), 60)
+    return f"{hour:02d}:{minute:02d}:{second:06.3f}"
+
+
+def load(path: str) -> np.ndarray:
+    raw = np.memmap(path, dtype="<f4", mode="r")
+    samples = raw.size // len(CHANNELS)
+    return raw[: samples * len(CHANNELS)].reshape(samples, len(CHANNELS))
+
+
+def analyze(audio: np.ndarray, rate: int, width_ms: float, hop_ms: float, threshold: float) -> None:
+    width = max(1, round(width_ms * rate / 1000.0))
+    hop = max(1, round(hop_ms * rate / 1000.0))
+    starts = np.arange(0, max(0, audio.shape[0] - width + 1), hop)
+    count = starts.size
+    shares = np.zeros(count)
+    height_fractions = np.zeros(count)
+    gains = np.zeros((count, 4))
+    height_rms = np.zeros((count, 4))
+    fold_beta = np.full((count, 4), np.nan)
+    fold_corr = np.zeros((count, 4))
+
+    for row, start in enumerate(starts):
+        samples = np.asarray(audio[start : start + width], dtype=np.float64)
+        samples -= samples.mean(axis=0, keepdims=True)
+        covariance = samples.T @ samples
+        height_covariance = covariance[np.ix_(HEIGHT, HEIGHT)]
+        eigenvalues, eigenvectors = np.linalg.eigh(height_covariance)
+        total = max(float(np.sum(eigenvalues)), 0.0)
+        if total > 0.0:
+            shares[row] = max(float(eigenvalues[-1]), 0.0) / total
+            gain = eigenvectors[:, -1]
+            if np.sum(gain) < 0.0:
+                gain = -gain
+            gains[row] = gain
+        powers = np.diag(covariance)
+        height_fractions[row] = float(np.sum(powers[HEIGHT]) / max(np.sum(powers), 1e-300))
+        height_rms[row] = np.sqrt(np.maximum(powers[HEIGHT], 0.0) / width)
+        for pair, (height_col, bed_col) in enumerate(HEIGHT_BED_PAIRS):
+            xx = covariance[height_col, height_col]
+            yy = covariance[bed_col, bed_col]
+            xy = covariance[height_col, bed_col]
+            if xx > 1e-30 and yy > 1e-30:
+                fold_beta[row, pair] = xy / xx
+                fold_corr[row, pair] = xy / math.sqrt(xx * yy)
+
+    peak_height = np.max(height_rms, axis=1)
+    active_floor = max(float(np.quantile(peak_height, 0.40)), 1e-12)
+    reliable = (shares >= threshold) & (height_fractions >= 0.05) & (peak_height >= active_floor)
+    selected = gains[reliable]
+    selected_times = (starts[reliable] + width / 2) / rate
+
+    print(
+        f"duration={clock(audio.shape[0] / rate)} windows={count} "
+        f"width={width_ms:g}ms hop={hop_ms:g}ms"
+    )
+    print(f"reliable rank-one height windows: {selected.shape[0]}/{count} (share>={threshold:.3f})")
+    if selected.shape[0] == 0:
+        return
+
+    norms = np.linalg.norm(selected, axis=1)
+    normalized = selected / np.maximum(norms[:, None], 1e-300)
+    negative_energy = float(
+        np.sum(np.square(np.minimum(normalized, 0.0))) / np.sum(np.square(normalized))
+    )
+    amplitudes = np.maximum(normalized, 0.0)
+    amplitude_sum = np.sum(amplitudes, axis=1)
+    valid_amplitude = amplitude_sum > 1e-12
+    amplitudes[valid_amplitude] /= amplitude_sum[valid_amplitude, None]
+    x = amplitudes[:, 1] + amplitudes[:, 3] - amplitudes[:, 0] - amplitudes[:, 2]
+    front = amplitudes[:, 0] + amplitudes[:, 1] - amplitudes[:, 2] - amplitudes[:, 3]
+    active = np.sum(amplitudes >= np.max(amplitudes, axis=1, keepdims=True) * 10 ** (-26 / 20), axis=1)
+    corner = normalized[:, 1] * normalized[:, 2] - normalized[:, 0] * normalized[:, 3]
+    corner_rms = float(np.sqrt(np.mean(np.square(corner))))
+
+    print(f"median dominant covariance share: {np.median(shares[reliable]):.4f}")
+    print(f"negative height-gain energy: {negative_energy:.3e}")
+    print(f"median active height outputs at -26 dB: {np.median(active):.0f}/4")
+    print(f"four-corner separability residual: {corner_rms:.4f}")
+    print(
+        "gain-centroid span: "
+        f"left/right={np.min(x):+.3f}..{np.max(x):+.3f} "
+        f"back/front={np.min(front):+.3f}..{np.max(front):+.3f}"
+    )
+
+    envelope = height_rms
+    print("height RMS-envelope correlation:")
+    correlation = np.corrcoef(envelope.T)
+    for row in range(4):
+        print("  " + " ".join(f"X{col}={correlation[row, col]:+.3f}" for col in range(4)))
+
+    print("compatible-bed scalar links (windows with |r|>=.99):")
+    for pair, (height_col, bed_col) in enumerate(HEIGHT_BED_PAIRS):
+        mask = reliable & (np.abs(fold_corr[:, pair]) >= 0.99)
+        values = fold_beta[mask, pair]
+        if values.size:
+            quantiles = np.quantile(values, (0.1, 0.5, 0.9))
+            print(
+                f"  {CHANNELS[height_col]}->{CHANNELS[bed_col]} n={values.size} "
+                f"beta={quantiles[1]:+.6f}[{quantiles[0]:+.6f},{quantiles[2]:+.6f}]"
+            )
+        else:
+            print(f"  {CHANNELS[height_col]}->{CHANNELS[bed_col]} n=0")
+
+    if selected.shape[0] < 2:
+        return
+    delta = np.hypot(np.diff(x), np.diff(front))
+    elapsed = np.diff(selected_times)
+    adjacent = elapsed <= hop_ms / 1000.0 * 1.5
+    motion = np.zeros(selected.shape[0])
+    motion[1:] = np.where(adjacent, delta, 0.0)
+    order = np.argsort(motion)[::-1]
+    chosen: list[float] = []
+    print("strongest coherent gain-vector motion windows:")
+    for index in order:
+        if motion[index] <= 0.0:
+            break
+        time = float(selected_times[index])
+        if any(abs(time - previous) < 0.5 for previous in chosen):
+            continue
+        chosen.append(time)
+        vector = normalized[index]
+        print(
+            f"  {clock(time)} step={motion[index]:.3f} share={shares[reliable][index]:.4f} "
+            f"centroid=({x[index]:+.3f},{front[index]:+.3f}) "
+            + " ".join(f"X{channel}={vector[channel]:+.3f}" for channel in range(4))
+        )
+        if len(chosen) == 12:
+            break
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("raw", help="interleaved 12-channel f32le")
+    parser.add_argument("--rate", type=int, default=48_000)
+    parser.add_argument("--window-ms", type=float, default=100.0)
+    parser.add_argument("--hop-ms", type=float, default=25.0)
+    parser.add_argument("--rank-one", type=float, default=0.90)
+    args = parser.parse_args()
+    analyze(load(args.raw), args.rate, args.window_ms, args.hop_ms, args.rank_one)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze-dtsx-matrix-id.py
+++ b/scripts/analyze-dtsx-matrix-id.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+
+BED_NAMES = ["C", "L", "R", "Ls", "Rs", "LFE", "Lb", "Rb"]
+
+
+def clock(seconds):
+    minute, second = divmod(seconds, 60.0)
+    hour, minute = divmod(int(minute), 60)
+    return f"{hour:02d}:{minute:02d}:{second:06.3f}"
+
+
+def analyze_side(audio, rate, window, source_cols, source_names, bed_cols, bed_names):
+    count = audio.shape[0] // window
+    coefficients = np.full((count, len(bed_cols), len(source_cols)), np.nan)
+    r2 = np.zeros((count, len(bed_cols)))
+    condition = np.full(count, np.inf)
+    source_rms = np.zeros((count, len(source_cols)))
+    global_xx = np.zeros((len(source_cols), len(source_cols)))
+    global_xy = np.zeros((len(source_cols), len(bed_cols)))
+    chunk_windows = 128
+    for begin in range(0, count, chunk_windows):
+        end = min(begin + chunk_windows, count)
+        rows = end - begin
+        sl = slice(begin * window, end * window)
+        x = np.asarray(audio[sl][:, source_cols], dtype=np.float64).reshape(rows, window, len(source_cols))
+        y = np.asarray(audio[sl][:, bed_cols], dtype=np.float64).reshape(rows, window, len(bed_cols))
+        x -= x.mean(axis=1, keepdims=True)
+        y -= y.mean(axis=1, keepdims=True)
+        xx = np.einsum("wsi,wsj->wij", x, x)
+        xy = np.einsum("wsi,wsk->wik", x, y)
+        yy = np.einsum("wsk,wsk->wk", y, y)
+        energy = np.diagonal(xx, axis1=1, axis2=2)
+        source_rms[begin:end] = np.sqrt(np.maximum(energy, 0.0) / window)
+        scale = np.sqrt(np.maximum(energy[:, :, None] * energy[:, None, :], 1e-300))
+        correlation = xx / scale
+        condition[begin:end] = np.linalg.cond(correlation)
+        valid = np.isfinite(condition[begin:end]) & (condition[begin:end] < 1e8) & np.all(energy > 1e-20, axis=1)
+        for local in np.flatnonzero(valid):
+            beta = np.linalg.solve(xx[local], xy[local])
+            coefficients[begin + local] = beta.T
+            predicted = np.sum(beta * xy[local], axis=0)
+            r2[begin + local] = np.clip(predicted / np.maximum(yy[local], 1e-300), 0.0, 1.0)
+        global_xx += xx.sum(axis=0)
+        global_xy += xy.sum(axis=0)
+
+    print(f"\n{'+'.join(source_names)} -> {','.join(bed_names)}")
+    print("  global least squares:")
+    rank = np.linalg.matrix_rank(global_xx)
+    if rank < len(source_cols):
+        print(
+            "    unavailable: extension sources are silent or linearly dependent "
+            f"(rank {rank}/{len(source_cols)})"
+        )
+    else:
+        global_beta = np.linalg.solve(global_xx, global_xy).T
+        for target, values in zip(bed_names, global_beta):
+            print(
+                "    "
+                + target
+                + ": "
+                + " ".join(
+                    f"{name}={value:+.9f}"
+                    for name, value in zip(source_names, values)
+                )
+            )
+
+    active_floor = np.quantile(source_rms, 0.40, axis=0)
+    active = np.all(source_rms >= active_floor, axis=1)
+    for cond_limit in [3, 10, 30, 100]:
+        mask = active & (condition <= cond_limit) & (np.max(r2, axis=1) >= 0.90)
+        print(f"  condition<={cond_limit:3d}, max R2>=.90: n={mask.sum()}")
+        if not np.any(mask):
+            continue
+        for target_index, target in enumerate(bed_names):
+            values = coefficients[mask, target_index]
+            fields = []
+            for source_index, source in enumerate(source_names):
+                q = np.nanquantile(values[:, source_index], [0.1, 0.5, 0.9])
+                fields.append(f"{source}={q[1]:+.4f}[{q[0]:+.4f},{q[2]:+.4f}]")
+            print(f"    {target}: " + " ".join(fields))
+
+    print("  coefficient plateaus (cond<=3, target R2>=.999, rounded 0.001):")
+    for target_index, target in enumerate(bed_names):
+        mask = active & (condition <= 3) & (r2[:, target_index] >= 0.999)
+        print(f"    {target}: n={mask.sum()}")
+        for source_index, source in enumerate(source_names):
+            values = coefficients[mask, target_index, source_index]
+            values = values[np.isfinite(values) & (np.abs(values) <= 4)]
+            if values.size == 0:
+                continue
+            rounded, counts = np.unique(np.round(values, 3), return_counts=True)
+            order_bins = np.argsort(counts)[::-1][:8]
+            bins = " ".join(f"{rounded[index]:+.3f}:{counts[index]}" for index in order_bins)
+            print(f"      {source}: {bins}")
+
+    joint = active & (condition <= 3) & np.all(r2 >= 0.999, axis=1)
+    print(f"  joint near-exact matrix windows: n={joint.sum()}")
+    if np.any(joint):
+        for target_index, target in enumerate(bed_names):
+            fields = []
+            for source_index, source in enumerate(source_names):
+                values = coefficients[joint, target_index, source_index]
+                median = np.nanmedian(values)
+                mad = np.nanmedian(np.abs(values - median))
+                fields.append(f"{source}={median:+.9f} mad={mad:.3e}")
+            print(f"    {target}: " + " ".join(fields))
+
+    score = np.max(r2, axis=1) - 0.03 * np.log10(np.maximum(condition, 1.0))
+    eligible = active & (condition <= 30)
+    order = np.argsort(np.where(eligible, score, -np.inf))[::-1]
+    chosen = []
+    print("  strongest well-conditioned windows:")
+    for index in order:
+        if not np.isfinite(score[index]):
+            continue
+        time = (index + 0.5) * window / rate
+        if all(abs(time - previous) >= 2.0 for previous in chosen):
+            chosen.append(time)
+            print(f"    {clock(time)} cond={condition[index]:.2f} R2=" + ",".join(f"{name}:{r2[index, i]:.6f}" for i, name in enumerate(bed_names)))
+            for target_index, target in enumerate(bed_names):
+                print("      " + target + ": " + " ".join(
+                    f"{source}={coefficients[index, target_index, source_index]:+.6f}"
+                    for source_index, source in enumerate(source_names)
+                ))
+        if len(chosen) == 12:
+            break
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("raw")
+    parser.add_argument("--extensions", type=int, required=True)
+    parser.add_argument("--rate", type=int, default=48000)
+    parser.add_argument("--window", type=int, default=4096)
+    args = parser.parse_args()
+    channels = len(BED_NAMES) + args.extensions
+    raw = np.memmap(args.raw, dtype="<f4", mode="r")
+    samples = raw.size // channels
+    audio = raw[:samples * channels].reshape(samples, channels)
+    extension = len(BED_NAMES)
+    print(f"duration={clock(samples / args.rate)} samples={samples} channels={channels}")
+    if args.extensions == 4:
+        left_sources = [extension + 0, extension + 2]
+        right_sources = [extension + 1, extension + 3]
+        left_names = ["X0", "X2"]
+        right_names = ["X1", "X3"]
+    elif args.extensions == 6:
+        left_sources = [extension + 0, extension + 2, extension + 4]
+        right_sources = [extension + 1, extension + 3, extension + 5]
+        left_names = ["X0", "X2", "X4"]
+        right_names = ["X1", "X3", "X5"]
+    else:
+        raise SystemExit("expected four or six extension sources")
+    analyze_side(audio, args.rate, args.window, left_sources, left_names, [1, 3, 6], ["L", "Ls", "Lb"])
+    analyze_side(audio, args.rate, args.window, right_sources, right_names, [2, 4, 7], ["R", "Rs", "Rb"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze-dtsx-pan-control.py
+++ b/scripts/analyze-dtsx-pan-control.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Classify the four XLL-X waveforms in the DTS:X Object Emulator clip.
+"""Classify four XLL-X waveforms in a controlled spatial-pan clip.
 
 The test uses the public clip as a controlled, mostly single-source pan.  It
 does not assume that the decoded XLL-X channels are speakers: their gain
@@ -390,7 +390,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--bed", type=Path, required=True, help="decoded eight-channel bed WAV")
     parser.add_argument("--height", type=Path, required=True, help="decoded four-channel XLL-X WAV")
-    parser.add_argument("--video", type=Path, help="optional Object Emulator MKV for picture/audio alignment")
+    parser.add_argument("--video", type=Path, help="optional source MKV for picture/audio alignment")
     parser.add_argument(
         "--audio-start",
         type=float,

--- a/scripts/analyze-dtsx-system-id.py
+++ b/scripts/analyze-dtsx-system-id.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+import argparse
+import math
+import numpy as np
+
+BED_NAMES = ["C", "L", "R", "Ls", "Rs", "LFE", "Lb", "Rb"]
+
+
+def clock(seconds):
+    minutes, second = divmod(seconds, 60.0)
+    hours, minute = divmod(int(minutes), 60)
+    return f"{hours:02d}:{minute:02d}:{second:06.3f}"
+
+
+def lag_fit(x, y, max_lag):
+    best = None
+    for lag in range(-max_lag, max_lag + 1):
+        if lag < 0:
+            xx, yy = x[-lag:], y[:lag]
+        elif lag > 0:
+            xx, yy = x[:-lag], y[lag:]
+        else:
+            xx, yy = x, y
+        xx = xx.astype(np.float64)
+        yy = yy.astype(np.float64)
+        xx -= xx.mean()
+        yy -= yy.mean()
+        energy_x = np.dot(xx, xx)
+        energy_y = np.dot(yy, yy)
+        cross = np.dot(xx, yy)
+        corr = cross / math.sqrt(max(energy_x * energy_y, 1e-300))
+        beta = cross / max(energy_x, 1e-300)
+        score = abs(corr)
+        if best is None or score > best[0]:
+            best = (score, lag, corr, beta)
+    return best
+
+
+def analyze_link(audio, rate, window, source_col, bed_col, label, subtract=(), expected=None):
+    samples = audio.shape[0]
+    windows = samples // window
+    print(f"\n{label}")
+    if windows == 0:
+        print("  unavailable: input is shorter than one analysis window")
+        return None
+    beta = np.empty(windows)
+    corr = np.empty(windows)
+    residual = np.empty(windows)
+    x_rms = np.empty(windows)
+    chunk_windows = 256
+    for begin in range(0, windows, chunk_windows):
+        end = min(begin + chunk_windows, windows)
+        sl = slice(begin * window, end * window)
+        count = end - begin
+        x = np.asarray(audio[sl, source_col], dtype=np.float64).reshape(count, window)
+        y = np.asarray(audio[sl, bed_col], dtype=np.float64).reshape(count, window)
+        for subtract_col, gain in subtract:
+            y -= gain * np.asarray(audio[sl, subtract_col], dtype=np.float64).reshape(count, window)
+        x -= x.mean(axis=1, keepdims=True)
+        y -= y.mean(axis=1, keepdims=True)
+        xx = np.sum(x * x, axis=1)
+        yy = np.sum(y * y, axis=1)
+        xy = np.sum(x * y, axis=1)
+        local_beta = np.divide(xy, xx, out=np.zeros_like(xy), where=xx > 1e-30)
+        local_corr = np.divide(xy, np.sqrt(xx * yy), out=np.zeros_like(xy), where=xx * yy > 1e-30)
+        err = yy - np.divide(xy * xy, xx, out=np.zeros_like(xy), where=xx > 1e-30)
+        beta[begin:end] = local_beta
+        corr[begin:end] = local_corr
+        residual[begin:end] = np.sqrt(np.maximum(err, 0.0) / np.maximum(yy, 1e-30))
+        x_rms[begin:end] = np.sqrt(xx / window)
+
+    active = x_rms >= max(np.quantile(x_rms, 0.70), 1e-12)
+    if not np.any(active):
+        print("  unavailable: source is silent in this range")
+        return None
+    order = np.argsort(np.where(active, residual, np.inf))
+    selected = [
+        int(index)
+        for index in order[:64]
+        if active[index] and np.isfinite(residual[index])
+    ]
+    for threshold in [0.95, 0.99, 0.999, 0.9999]:
+        mask = active & (np.abs(corr) >= threshold)
+        if np.any(mask):
+            q = np.quantile(beta[mask], [0.05, 0.5, 0.95])
+            print(f"  |r|>={threshold:.4f}: n={mask.sum():5d} beta={q[1]:+.9f} [{q[0]:+.9f},{q[2]:+.9f}]")
+    print("  best scalar windows:")
+    for index in selected[:8]:
+        time = (index + 0.5) * window / rate
+        print(f"    {clock(time)} r={corr[index]:+.9f} beta={beta[index]:+.9f} resid={residual[index]:.6e} xrms={x_rms[index]:.3e}")
+
+    if expected is not None:
+        fixed_residual = np.empty(windows)
+        for begin in range(0, windows, chunk_windows):
+            end = min(begin + chunk_windows, windows)
+            sl = slice(begin * window, end * window)
+            count = end - begin
+            x = np.asarray(audio[sl, source_col], dtype=np.float64).reshape(count, window)
+            y = np.asarray(audio[sl, bed_col], dtype=np.float64).reshape(count, window)
+            for subtract_col, gain in subtract:
+                y -= gain * np.asarray(audio[sl, subtract_col], dtype=np.float64).reshape(count, window)
+            x -= x.mean(axis=1, keepdims=True)
+            y -= y.mean(axis=1, keepdims=True)
+            error = y - expected * x
+            fixed_residual[begin:end] = np.sqrt(
+                np.sum(error * error, axis=1) / np.maximum(np.sum(y * y, axis=1), 1e-30)
+            )
+        fixed_order = np.argsort(np.where(active, fixed_residual, np.inf))
+        print(f"  best windows for expected gain {expected:.9f}:")
+        for index in fixed_order[:8]:
+            time = (index + 0.5) * window / rate
+            print(f"    {clock(time)} fixed_resid={fixed_residual[index]:.6e} r={corr[index]:+.9f} beta={beta[index]:+.9f}")
+
+    lag_rows = []
+    for index in selected[:32]:
+        start = index * window
+        x = np.asarray(audio[start:start + window, source_col])
+        y = np.asarray(audio[start:start + window, bed_col])
+        for subtract_col, gain in subtract:
+            y = y - gain * np.asarray(audio[start:start + window, subtract_col])
+        lag_rows.append(lag_fit(x, y, 32))
+    lag_counts = {}
+    for _, lag, _, _ in lag_rows:
+        lag_counts[lag] = lag_counts.get(lag, 0) + 1
+    print(f"  best lags (32 isolated windows): {dict(sorted(lag_counts.items()))}")
+
+    # Cross-spectral transfer estimate over the best scalar windows. A scalar
+    # fold should have nearly constant real gain and near-zero phase.
+    fft_size = window
+    taper = np.hanning(fft_size)
+    cross = np.zeros(fft_size // 2 + 1, dtype=np.complex128)
+    power = np.zeros(fft_size // 2 + 1, dtype=np.float64)
+    for index in selected:
+        start = index * window
+        x = np.asarray(audio[start:start + window, source_col], dtype=np.float64)
+        y = np.asarray(audio[start:start + window, bed_col], dtype=np.float64)
+        for subtract_col, gain in subtract:
+            y -= gain * np.asarray(audio[start:start + window, subtract_col], dtype=np.float64)
+        x = (x - x.mean()) * taper
+        y = (y - y.mean()) * taper
+        xf = np.fft.rfft(x)
+        yf = np.fft.rfft(y)
+        cross += np.conj(xf) * yf
+        power += np.abs(xf) ** 2
+    transfer = np.divide(cross, power, out=np.zeros_like(cross), where=power > np.max(power) * 1e-12)
+    frequencies = np.fft.rfftfreq(fft_size, 1.0 / rate)
+    print("  transfer by band (weighted complex H):")
+    for low, high in [(20, 80), (80, 250), (250, 1000), (1000, 4000), (4000, 10000), (10000, 20000)]:
+        mask = (frequencies >= low) & (frequencies < high) & (power > np.max(power) * 1e-10)
+        if not np.any(mask):
+            continue
+        h = np.sum(cross[mask]) / np.sum(power[mask])
+        print(f"    {low:5d}-{high:5d} Hz: real={h.real:+.6f} imag={h.imag:+.6f} mag={abs(h):.6f} phase={np.angle(h, deg=True):+.2f}°")
+    return beta, corr, residual, x_rms
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("raw")
+    parser.add_argument("--extensions", type=int, default=6)
+    parser.add_argument("--rate", type=int, default=48000)
+    parser.add_argument("--window", type=int, default=4096)
+    args = parser.parse_args()
+    channels = len(BED_NAMES) + args.extensions
+    raw = np.memmap(args.raw, dtype="<f4", mode="r")
+    samples = raw.size // channels
+    audio = raw[:samples * channels].reshape(samples, channels)
+    print(f"samples={samples} duration={clock(samples / args.rate)} channels={channels} window={args.window}")
+    extension = len(BED_NAMES)
+    gain = 23170.0 / 32768.0
+    if args.extensions == 4:
+        links = [
+            (extension + 0, 1, "calibration X0 -> L (front top fold)", (), gain),
+            (extension + 1, 2, "calibration X1 -> R (front top fold)", (), gain),
+            (extension + 2, 6, "calibration X2 -> Lb (rear top fold)", (), gain),
+            (extension + 3, 7, "calibration X3 -> Rb (rear top fold)", (), gain),
+        ]
+    else:
+        links = [
+            (extension + 0, 1, "D1 X0 -> L", (), gain),
+            (extension + 1, 2, "D1 X1 -> R", (), gain),
+            (extension + 4, 6, "D1 X4 -> Lb", (), gain),
+            (extension + 5, 7, "D1 X5 -> Rb", (), gain),
+            (extension + 2, 1, "candidate X2 -> L after X0 top removal", ((extension + 0, gain),), None),
+            (extension + 2, 3, "candidate X2 -> Ls", (), None),
+            (extension + 3, 2, "candidate X3 -> R after X1 top removal", ((extension + 1, gain),), None),
+            (extension + 3, 4, "candidate X3 -> Rs", (), None),
+        ]
+    for source, bed, label, subtract, expected in links:
+        analyze_link(audio, args.rate, args.window, source, bed, label, subtract, expected)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare-dtsx-bed.py
+++ b/scripts/compare-dtsx-bed.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Compare an xll_pcm_range bed against an interleaved ffmpeg f32 reference."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+
+import numpy as np
+
+
+BED_NAMES = ("C", "L", "R", "Ls", "Rs", "LFE", "Lb", "Rb")
+FFMPEG_NAMES = ("FL", "FR", "FC", "LFE", "BL", "BR", "SL", "SR")
+
+
+def load(path: str, channels: int) -> np.ndarray:
+    raw = np.memmap(path, dtype="<f4", mode="r")
+    samples = raw.size // channels
+    if samples == 0:
+        raise ValueError(f"{path}: empty or shorter than one frame")
+    return raw[: samples * channels].reshape(samples, channels)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("decoded", help="xll_pcm_range interleaved f32le")
+    parser.add_argument("reference", help="ffmpeg interleaved 7.1 f32le")
+    parser.add_argument(
+        "--decoded-channels",
+        type=int,
+        default=12,
+        help="total decoded channels, including four XLL-X sources",
+    )
+    parser.add_argument("--bed-channels", type=int, default=8)
+    parser.add_argument("--reference-channels", type=int, default=8)
+    parser.add_argument("--rate", type=int, default=48_000)
+    parser.add_argument(
+        "--skip-seconds",
+        type=float,
+        default=0.0,
+        help="ignore matching decoder pre-roll at the start of both inputs",
+    )
+    parser.add_argument("--gate", type=float, default=1e-5)
+    args = parser.parse_args()
+
+    decoded = load(args.decoded, args.decoded_channels)
+    reference = load(args.reference, args.reference_channels)
+    if args.bed_channels > decoded.shape[1]:
+        parser.error("--bed-channels exceeds --decoded-channels")
+    if args.bed_channels != args.reference_channels:
+        parser.error("bed and reference channel counts must match")
+
+    skip = round(args.skip_seconds * args.rate)
+    samples = min(decoded.shape[0], reference.shape[0]) - skip
+    if samples <= 0:
+        parser.error("--skip-seconds removes the complete comparison range")
+    bed = np.asarray(
+        decoded[skip : skip + samples, : args.bed_channels], dtype=np.float64
+    )
+    ref = np.asarray(reference[skip : skip + samples], dtype=np.float64)
+    cost = np.empty((args.reference_channels, args.bed_channels))
+    for ref_channel in range(args.reference_channels):
+        for bed_channel in range(args.bed_channels):
+            delta = ref[:, ref_channel] - bed[:, bed_channel]
+            cost[ref_channel, bed_channel] = np.sqrt(np.mean(delta * delta))
+
+    mapping = min(
+        itertools.permutations(range(args.bed_channels)),
+        key=lambda permutation: sum(
+            cost[reference_channel, bed_channel]
+            for reference_channel, bed_channel in enumerate(permutation)
+        ),
+    )
+    worst = 0.0
+    print(
+        f"samples={samples} seconds={samples / args.rate:.3f} "
+        f"skipped={skip}"
+    )
+    for reference_channel, bed_channel in enumerate(mapping):
+        delta = ref[:, reference_channel] - bed[:, bed_channel]
+        rmse = float(np.sqrt(np.mean(delta * delta)))
+        maximum = float(np.max(np.abs(delta)))
+        worst = max(worst, rmse)
+        ref_name = (
+            FFMPEG_NAMES[reference_channel]
+            if args.reference_channels == len(FFMPEG_NAMES)
+            else f"ref{reference_channel}"
+        )
+        bed_name = (
+            BED_NAMES[bed_channel]
+            if args.bed_channels == len(BED_NAMES)
+            else f"bed{bed_channel}"
+        )
+        print(
+            f"{ref_name:>4} -> {bed_name:<3} "
+            f"rmse={rmse:.9e} maxabs={maximum:.9e}"
+        )
+    print(f"worst_rmse={worst:.9e} gate={args.gate:.9e}")
+    if worst >= args.gate:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/decode-ffmpeg-pcm.sh
+++ b/scripts/decode-ffmpeg-pcm.sh
@@ -9,7 +9,7 @@
 # `-drc_scale 0` disables FFmpeg's default dynamic-range compression
 # (applied via the dynrng word per audblk). harletty and Cavern don't
 # apply DRC, so leaving it on inflates the cross-decoder RMSE by 1.7e-4
-# on LFE → 5.4e-4 on surrounds (verified on Dune Part Two 30 s slice).
+# on LFE → 5.4e-4 on surrounds (verified on a 30 s witness slice).
 #
 # Usage:
 #   decode-ffmpeg-pcm.sh <input.eac3> <output.f32>

--- a/scripts/extract-eac3-corpus.sh
+++ b/scripts/extract-eac3-corpus.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   extract-eac3-corpus.sh <mkv_path> <track_id> [audio_track_index]
 #
-# - <mkv_path>            Source MKV (typically on /mnt/nas/...).
+# - <mkv_path>            Source MKV.
 # - <track_id>            Short id used as directory name under dumps/eac3-regression/.
 # - [audio_track_index]   Optional 0-based audio stream index. Default: first
 #                         E-AC3 stream reported by mkvmerge -J.

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 use truehd::process::{MAX_PRESENTATIONS, decode::Decoder, extract::Extractor, parse::Parser};
 
 use crate::ac3_native::NativeAc3Decoder;
+use crate::dts_pipeline::DtsFoldConfig;
 use crate::eac3_pipeline::{
     diagnose_eac3_frame, is_dependent_eac3_frame, is_legacy_ac3_frame,
     is_temporary_eac3_silence_frame, process_eac3_dependent_frame_with_core, process_eac3_frame,
@@ -140,6 +141,9 @@ pub(crate) struct AtmosBridge {
     pub(crate) dts_height_locked: bool,
     /// True when the most recent `push_packet` used the DTS path.
     pub(crate) dts_active: bool,
+    pub(crate) dts_fold_config: DtsFoldConfig,
+    /// Live stream fact: the latest DTS frame carried presented D3 objects.
+    pub(crate) dts_objects_active: bool,
     // ── Shared ───────────────────────────────────────────────────────
     pub(crate) presentation: u8,
     pub(crate) strict: bool,
@@ -196,7 +200,6 @@ impl AtmosBridge {
         eac3_dependent_pcm.set_debug_log_level(eac3_log_level);
         let mut eac3_obj = ObjectPcmDecoder::new();
         eac3_obj.set_debug_log_level(eac3_log_level);
-
         #[allow(unused_mut)]
         let mut bridge = Self {
             mat_stream: MatStream::default(),
@@ -223,6 +226,8 @@ impl AtmosBridge {
             dts_frame_count: 0,
             dts_height_locked: false,
             dts_active: false,
+            dts_fold_config: DtsFoldConfig::from_env(),
+            dts_objects_active: false,
             presentation,
             strict,
             total_samples: 0,
@@ -279,6 +284,7 @@ impl AtmosBridge {
         self.dts_frame_count = 0;
         self.dts_height_locked = false;
         self.dts_active = false;
+        self.dts_objects_active = false;
         // Re-sniff after reset, but keep any host-declared codec.
         self.raw_codec = None;
 
@@ -663,13 +669,13 @@ impl FormatBridge for AtmosBridge {
 
     fn has_objects(&self) -> bool {
         if self.dts_active {
-            // DTS core is plain channel-based audio (a 5.1/7.1 bed), not true
-            // objects. Whether it is placed at canonical speaker positions
-            // (host) or rendered through the virtual bed is the host's
-            // channel-render-mode choice, exactly as for AC-3 — so report it as
-            // non-spatial and let that mode decide. (DTS:X height objects live
-            // in a proprietary blob the bridge does not decode, so the core
-            // never exposes real objects here.)
+            if self.dts_objects_active {
+                return true;
+            }
+            // DTS core and the standard/D0/D1 extension presentations are
+            // labeled fixed channels. Whether they are placed directly or
+            // virtualized remains the renderer's channel-mode decision. D3 is
+            // the only current DTS presentation that declares object channels.
             return false;
         }
         if self.eac3_active {
@@ -826,6 +832,19 @@ impl FormatBridge for AtmosBridge {
 #[cfg(test)]
 mod raw_transport_tests {
     use super::*;
+    use std::io::Read;
+
+    fn read_prefix(path: &str, bytes: u64) -> Option<Vec<u8>> {
+        let mut input = std::fs::File::open(path).ok()?;
+        let mut prefix = Vec::with_capacity(bytes as usize);
+        input.by_ref().take(bytes).read_to_end(&mut prefix).ok()?;
+        Some(prefix)
+    }
+
+    fn corpus_path(variable: &str) -> Option<String> {
+        let path = std::env::var(variable).ok()?;
+        std::path::Path::new(&path).is_file().then_some(path)
+    }
 
     #[test]
     fn sniff_detects_eac3_syncword() {
@@ -908,12 +927,11 @@ mod raw_transport_tests {
     // (uncommitted) corpus is absent.
     #[test]
     fn dts_raw_transport_emits_bed_frames() {
-        const DTS: &str = "/home/user/dev/spatial-renderer/dumps/dts51_core.dts";
-        if !std::path::Path::new(DTS).exists() {
-            eprintln!("skipping: DTS corpus not present");
+        let Some(dts) = corpus_path("HARLETTY_DTS_CORE_CORPUS") else {
+            eprintln!("skipping: HARLETTY_DTS_CORE_CORPUS is not set to a readable file");
             return;
-        }
-        let bytes = std::fs::read(DTS).unwrap();
+        };
+        let bytes = std::fs::read(dts).unwrap();
         let mut bridge = AtmosBridge::new(false);
         let result = bridge.push_packet(RSlice::from_slice(&bytes), RInputTransport::Raw, 0);
         assert!(result.error_message.is_empty(), "{}", result.error_message);
@@ -937,13 +955,12 @@ mod raw_transport_tests {
     // lossless bed frames. Skips when the (uncommitted) dump is absent.
     #[test]
     fn dtshd_raw_transport_emits_labeled_7_1_4_channels() {
-        const DUMP: &str = "/mnt/local/SSD_A-CT4000/DTS:X-Dumps/Ex.Machina.2014.dtsx.eng.dts";
-        if !std::path::Path::new(DUMP).exists() {
-            eprintln!("skipping: DTS:X dump not present");
+        let Some(dump) = corpus_path("HARLETTY_DTSX_STANDARD_CORPUS") else {
+            eprintln!("skipping: HARLETTY_DTSX_STANDARD_CORPUS is not set to a readable file");
             return;
-        }
+        };
         // Feed ~2 MB — enough for many frames past the silent intro.
-        let bytes = std::fs::read(DUMP).unwrap();
+        let bytes = std::fs::read(dump).unwrap();
         let chunk = &bytes[..bytes.len().min(2_000_000)];
         let mut bridge = AtmosBridge::new(false);
         bridge.configure("input_codec".into(), "dts".into());
@@ -967,5 +984,112 @@ mod raw_transport_tests {
         let labels: Vec<_> = f.channel_labels.iter().copied().collect();
         // Active speakers ascending (C,L,R,Ls,Rs,LFE,Lsr,Rsr) + the height quartet.
         assert_eq!(labels, vec![C, L, R, Ls, Rs, LFE, Lb, Rb, Tfl, Tfr, Tbl, Tbr]);
+    }
+
+    #[test]
+    fn alternate_profiles_emit_automatic_presentations() {
+        let Some(d0_path) = corpus_path("HARLETTY_D0_CORPUS") else {
+            eprintln!("skipping: HARLETTY_D0_CORPUS is not set to a readable file");
+            return;
+        };
+        let Some(bytes) = read_prefix(&d0_path, 2_000_000) else {
+            eprintln!("skipping: D0 corpus could not be read");
+            return;
+        };
+        let mut bridge = AtmosBridge::new(false);
+        assert!(bridge.configure("input_codec".into(), "dts".into()));
+        let result = bridge.push_packet(RSlice::from_slice(&bytes), RInputTransport::Raw, 0);
+        assert!(result.error_message.is_empty(), "{}", result.error_message);
+        assert!(
+            !bridge.has_objects(),
+            "fixed D0 presentation must not set the object stream fact"
+        );
+        use bridge_api::RChannelLabel::*;
+        let frame = result
+            .frames
+            .iter()
+            .find(|frame| {
+                [Tfc, Tfl, Tfr, Tbl, Tbr]
+                    .iter()
+                    .all(|label| frame.channel_labels.contains(label))
+            })
+            .expect("no experimental fixed D0 declaration");
+        assert!(frame.metadata.is_empty());
+        assert!(
+            !frame.channel_labels.contains(&Object),
+            "fixed D0 presentation must not fabricate objects"
+        );
+
+        let Some(d1_path) = corpus_path("HARLETTY_D1_CORPUS") else {
+            eprintln!("skipping: HARLETTY_D1_CORPUS is not set to a readable file");
+            return;
+        };
+        let Some(bytes) = read_prefix(&d1_path, 2_000_000) else {
+            eprintln!("skipping: D1 corpus could not be read");
+            return;
+        };
+        let mut bridge = AtmosBridge::new(false);
+        assert!(bridge.configure("input_codec".into(), "dts".into()));
+        let result = bridge.push_packet(RSlice::from_slice(&bytes), RInputTransport::Raw, 0);
+        assert!(result.error_message.is_empty(), "{}", result.error_message);
+        assert!(!bridge.has_objects(), "D1 must remain fixed-channel");
+
+        let frame = result
+            .frames
+            .iter()
+            .find(|frame| {
+                [Tfl, Tfr, Lw, Rw, Tbl, Tbr]
+                    .iter()
+                    .all(|label| frame.channel_labels.contains(label))
+            })
+            .expect("no experimental fixed D1 declaration");
+        assert!(frame.metadata.is_empty());
+        assert!(!frame.channel_labels.contains(&Object));
+
+        let Some(d3_path) = corpus_path("HARLETTY_D3_CORPUS") else {
+            eprintln!("skipping: HARLETTY_D3_CORPUS is not set to a readable file");
+            return;
+        };
+        let Some(bytes) = read_prefix(&d3_path, 2_000_000) else {
+            eprintln!("skipping D3: alternate-extension corpus not present: {d3_path}");
+            return;
+        };
+        let mut bridge = AtmosBridge::new(false);
+        assert!(bridge.configure("input_codec".into(), "dts".into()));
+        let result = bridge.push_packet(RSlice::from_slice(&bytes), RInputTransport::Raw, 0);
+        assert!(result.error_message.is_empty(), "{}", result.error_message);
+        assert!(
+            bridge.has_objects(),
+            "D3 must expose object channels"
+        );
+
+        let frame = result
+            .frames
+            .iter()
+            .find(|frame| {
+                frame
+                    .channel_labels
+                    .iter()
+                    .filter(|&&label| label == Object)
+                    .count()
+                    == 8
+                    && frame
+                        .metadata
+                        .iter()
+                        .any(|metadata| metadata.name_updates.len() == 8)
+            })
+            .expect("no experimental D3 object declaration");
+        assert_eq!(frame.channel_count, 16);
+        let metadata = frame
+            .metadata
+            .iter()
+            .find(|metadata| metadata.name_updates.len() == 8)
+            .expect("no D3 name declaration");
+        for source in 0..8 {
+            assert_eq!(
+                metadata.name_updates[source].name.as_str(),
+                format!("X{source}")
+            );
+        }
     }
 }

--- a/src/dts_pipeline.rs
+++ b/src/dts_pipeline.rs
@@ -4,18 +4,23 @@
 // routes each frame to either the DTS-HD MA lossless decoder (5.1/7.1, when an
 // EXSS substream follows the core) or the plain DTS core decoder (5.1). Every
 // decoded core channel is emitted as a bed channel, placed at its canonical
-// speaker by the renderer. XLL-X's four additional waveforms are mapped as
-// fixed objects at the four 7.1.4 height positions after undoing their -3 dB
-// contribution to the backward-compatible 7.1 bed.
+// speaker by the renderer. XLL-X's standard four-source profile is mapped to
+// the four 7.1.4 height positions after undoing its -3 dB contribution to the
+// backward-compatible 7.1 bed. Alternate decoded profiles use their current
+// experimental presentations automatically.
 
 use abi_stable::std_types::{RString, RVec};
 use bridge_api::RPushResult;
-use bridge_api::{RChannelLabel, RDecodedFrame};
-use dca::{exss_has_xll, exss_substream_size, parse_header, CorePcmFrame, HdError, HdFrame};
+use bridge_api::{
+    RChannelLabel, RDecodedFrame, REvent, RMetadataFrame, RNameUpdate, RObjectChannel,
+};
+use dca::{CorePcmFrame, HdError, HdFrame, exss_has_xll, exss_substream_size, parse_header};
+use serde::Deserialize;
 
 use crate::bridge::AtmosBridge;
 use crate::frame_builders::float_to_pcm_i32;
 use crate::labels::dca_bed_channel_to_r;
+use crate::metadata::declare_object_channels;
 
 const CORE_SYNC: [u8; 4] = 0x7FFE_8001u32.to_be_bytes();
 const SUBSTREAM_SYNC: [u8; 4] = 0x6458_2025u32.to_be_bytes();
@@ -27,7 +32,117 @@ const XLL_X_HEIGHT_LABELS: [RChannelLabel; 4] = [
 ];
 // Exact Q15 -3 dB coefficient used by the DTS downmix table. The regular 7.1
 // presentation contains this contribution from each corresponding height feed.
+#[cfg(test)]
 const XLL_X_HEIGHT_DOWNMIX_GAIN: f32 = 23_170.0 / 32_768.0;
+
+// Research-only D0 partial-unfold coefficients. The source-to-speaker
+// associations are repeatable across the two measured programmes, but these
+// gains are conservative presentation choices, not decoded metadata or a proven
+// profile-exact matrix. In particular, the partial subtraction deliberately
+// preserves some programme material authored in both the lower and top feeds.
+#[cfg(test)]
+const D0_TFC_CENTER_DOWNMIX_GAIN: f32 = 0.5;
+#[cfg(test)]
+const ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN: f32 = 1.0 / std::f32::consts::SQRT_2;
+
+// Research-only D1 compatibility-fold estimates, measured on strict,
+// well-conditioned full-programme matrices in the D1 corpus. These are
+// intentionally isolated from the lossless decoder. They are not claimed to be
+// a normative/profile-exact matrix yet.
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct FoldRoute {
+    pub target: String,
+    pub gain_db: f32,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct FoldSource {
+    pub source: String,
+    #[serde(default)]
+    pub routes: Vec<FoldRoute>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct DtsFoldConfig {
+    #[serde(default)]
+    pub sources: Vec<FoldSource>,
+}
+
+impl Default for DtsFoldConfig {
+    fn default() -> Self {
+        serde_yaml_ng::from_str(include_str!("../dts-fold.yaml"))
+            .expect("valid bundled dts-fold.yaml")
+    }
+}
+
+impl DtsFoldConfig {
+    pub(crate) fn from_env() -> Self {
+        let path = std::path::Path::new("dts-fold.yaml");
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|text| serde_yaml_ng::from_str(&text).ok())
+            .unwrap_or_else(|| Self::default())
+    }
+
+    pub(crate) fn gain(&self, target: &str, source: &str) -> f32 {
+        self.sources
+            .iter()
+            .find(|entry| entry.source.eq_ignore_ascii_case(source))
+            .and_then(|entry| {
+                entry
+                    .routes
+                    .iter()
+                    .find(|route| route.target.eq_ignore_ascii_case(target))
+            })
+            .map_or(0.0, |route| 10.0_f32.powf(route.gain_db / 20.0))
+    }
+}
+// Working D0 presentation inferred from two complete programmes. X0 has a
+// stable front-centre signature; X1..X4 form the established top quartet.
+// Keep this isolated and experimental until a reference decode confirms it.
+const D0_FIXED_LABELS: [RChannelLabel; 5] = [
+    RChannelLabel::Tfc,
+    RChannelLabel::Tfl,
+    RChannelLabel::Tfr,
+    RChannelLabel::Tbl,
+    RChannelLabel::Tbr,
+];
+// Working D1 presentation inferred from one complete programme. The wide fold
+// is strongly measurable, while all six channel identities and every unfold
+// coefficient remain experimental pending an independent D1 source.
+const D1_FIXED_LABELS: [RChannelLabel; 6] = [
+    RChannelLabel::Tfl,
+    RChannelLabel::Tfr,
+    RChannelLabel::Lw,
+    RChannelLabel::Rw,
+    RChannelLabel::Tbl,
+    RChannelLabel::Tbr,
+];
+const D3_OBJECT_SOURCE_INDICES: [usize; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+
+// Research-only D3 default positions. The corpus supports stable left/right
+// pairing and a recurring rear association for X6/X7. X2/X3 also match the
+// front-elevation group in the paired fixed-layout control, while X4/X5
+// remain the broad side pair. X0/X1 are the least stable pair and are placed
+// at the front-wide positions by elimination. These are presentation defaults,
+// not decoded coordinates or a claimed normative speaker map.
+const D3_INFERRED_OBJECT_POSITIONS: [[f64; 3]; 8] = [
+    [-1.0, 0.5, 0.0],  // X0: Lw
+    [1.0, 0.5, 0.0],   // X1: Rw
+    [-1.0, 1.0, 1.0],  // X2: TFL
+    [1.0, 1.0, 1.0],   // X3: TFR
+    [-1.0, 0.0, 1.0],  // X4: TSL
+    [1.0, 0.0, 1.0],   // X5: TSR
+    [-1.0, -1.0, 1.0], // X6: TBL
+    [1.0, -1.0, 1.0],  // X7: TBR
+];
+
+enum FoldSources<'a> {
+    None,
+    One(&'a [f32], f32),
+    Two(&'a [f32], f32, &'a [f32], f32),
+}
 
 /// Demux and decode all complete DTS frames buffered in `bridge.dts_buf`.
 pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
@@ -72,7 +187,14 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
                 {
                     Ok(hd) => {
                         let n = hd_samples(&hd);
-                        if let Some(frame) = build_hd_frame(&hd, &mut bridge.dts_height_locked) {
+                        if let Some((frame, emitted_objects)) = build_hd_frame_with_extensions(
+                            &hd,
+                            &mut bridge.dts_height_locked,
+                            &bridge.dts_fold_config,
+                            bridge.total_samples,
+                            &mut bridge.declared_object_channels,
+                        ) {
+                            bridge.dts_objects_active = emitted_objects;
                             result.frames.push(frame);
                         }
                         bridge.total_samples += n as u64;
@@ -97,6 +219,7 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
                 // instead of failing the whole track.
                 match bridge.dts_decoder.push_access_unit(&rest[..fs]) {
                     Ok(push) => {
+                        bridge.dts_objects_active = false;
                         result.frames.push(build_core_frame(&push.pcm));
                         bridge.total_samples += push.pcm.samples_per_channel() as u64;
                         bridge.dts_frame_count += 1;
@@ -118,6 +241,7 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
             match bridge.dts_decoder.push_access_unit(&rest[..fs]) {
                 Ok(push) => {
                     let frame = build_core_frame(&push.pcm);
+                    bridge.dts_objects_active = false;
                     bridge.total_samples += push.pcm.samples_per_channel() as u64;
                     bridge.dts_frame_count += 1;
                     result.frames.push(frame);
@@ -169,18 +293,23 @@ fn speaker_to_label(spkr: usize) -> RChannelLabel {
     }
 }
 
-
-/// Build a labeled-channel frame from a decoded DTS-HD frame (per-speaker
-/// f32). Fixed channels only — a DTS:X fixed 7.1.4 presentation is twelve
-/// labeled channels, never fabricated metadata
-/// (`docs/channel-object-contract.md`).
+/// Build a frame from decoded DTS-HD per-speaker PCM. The normal path remains
+/// fixed-channel only. Decoded alternate profiles use the current experimental
+/// presentation: inferred fixed channels for D0/D1 and unchanged named objects
+/// at inferred static positions for D3.
 ///
 /// `height_locked` latches once a valid XLL-X quartet has been emitted: from
 /// then on a frame with a missing/invalid quartet keeps the 12-channel shape
 /// (composite bed + silent heights) instead of collapsing to 8 channels, so
 /// the host never renegotiates mid-stream and no content is lost (the folded
 /// height contribution stays in the bed for that frame).
-fn build_hd_frame(hd: &HdFrame, height_locked: &mut bool) -> Option<RDecodedFrame> {
+fn build_hd_frame_with_extensions(
+    hd: &HdFrame,
+    height_locked: &mut bool,
+    fold_config: &DtsFoldConfig,
+    sample_pos: u64,
+    declared_object_channels: &mut Option<RVec<RObjectChannel>>,
+) -> Option<(RDecodedFrame, bool)> {
     // Active speakers in ascending index order = stable channel order.
     let active: Vec<usize> = (0..hd.samples.len())
         .filter(|&s| hd.samples[s].is_some())
@@ -226,31 +355,113 @@ fn build_hd_frame(hd: &HdFrame, height_locked: &mut bool) -> Option<RDecodedFram
     } else {
         0
     };
-    let channel_count = active.len() + height_count;
+    let alternate_samples = hd
+        .x_imax
+        .then_some(hd.x_samples.as_slice())
+        .filter(|channels| matches!(channels.len(), 5 | 6 | 8))
+        .filter(|channels| channels.iter().all(|channel| channel.len() == sample_count));
+    let d0_fixed_samples = alternate_samples
+        .filter(|channels| channels.len() == 5)
+        .map(|channels| {
+            [
+                &channels[0][..],
+                &channels[1][..],
+                &channels[2][..],
+                &channels[3][..],
+                &channels[4][..],
+            ]
+        });
+    let d1_fixed_samples = alternate_samples
+        .filter(|channels| channels.len() == 6)
+        .map(|channels| {
+            [
+                &channels[0][..],
+                &channels[1][..],
+                &channels[2][..],
+                &channels[3][..],
+                &channels[4][..],
+                &channels[5][..],
+            ]
+        });
+    let object_source_indices: &[usize] = match alternate_samples.map(<[Vec<f32>]>::len) {
+        Some(8) => &D3_OBJECT_SOURCE_INDICES,
+        _ => &[],
+    };
+    let d0_fixed_count = d0_fixed_samples.map_or(0, |_| D0_FIXED_LABELS.len());
+    let d1_fixed_count = d1_fixed_samples.map_or(0, |_| D1_FIXED_LABELS.len());
+    let object_count = object_source_indices.len();
+    let channel_count =
+        active.len() + height_count + d0_fixed_count + d1_fixed_count + object_count;
 
-    // Per-channel embedded-height source for the unfold, hoisted out of the
-    // sample loop (no per-sample match / Option deref): DCA speakers
-    // 1=L, 2=R, 7=Lsr, 8=Rsr carry the -3 dB fold of TFL/TFR/TBL/TBR.
-    let fold_source: Vec<Option<&[f32]>> = active
+    // Per-channel source and coefficient for the unfold, hoisted out of the
+    // sample loop (no per-sample speaker/profile branching). The D0 choices
+    // below are conservative research settings, not a normative matrix.
+    let fold_sources: Vec<FoldSources<'_>> = active
         .iter()
         .map(|&spkr| {
-            let height_idx = match spkr {
-                1 => 0usize,
-                2 => 1,
-                7 => 2,
-                8 => 3,
-                _ => return None,
-            };
-            height_samples.map(|h| h[height_idx].as_slice())
+            if let Some(heights) = height_samples {
+                let height_idx = match spkr {
+                    1 => 0usize,
+                    2 => 1,
+                    7 => 2,
+                    8 => 3,
+                    _ => return FoldSources::None,
+                };
+                return FoldSources::One(
+                    heights[height_idx].as_slice(),
+                    match spkr {
+                        1 => fold_config.gain("L", "TFL"),
+                        2 => fold_config.gain("R", "TFR"),
+                        7 => fold_config.gain("Lb", "TBL"),
+                        8 => fold_config.gain("Rb", "TBR"),
+                        _ => 0.0,
+                    },
+                );
+            }
+            if let Some(fixed) = d0_fixed_samples {
+                return match spkr {
+                    0 => FoldSources::One(fixed[0], fold_config.gain("C", "X0")),
+                    1 => FoldSources::One(fixed[1], fold_config.gain("L", "X1")),
+                    2 => FoldSources::One(fixed[2], fold_config.gain("R", "X2")),
+                    7 => FoldSources::One(fixed[3], fold_config.gain("Lb", "X3")),
+                    8 => FoldSources::One(fixed[4], fold_config.gain("Rb", "X4")),
+                    _ => FoldSources::None,
+                };
+            }
+            if let Some(fixed) = d1_fixed_samples {
+                return match spkr {
+                    1 => FoldSources::Two(
+                        fixed[0],
+                        fold_config.gain("L", "X0"),
+                        fixed[2],
+                        fold_config.gain("L", "X2"),
+                    ),
+                    2 => FoldSources::Two(
+                        fixed[1],
+                        fold_config.gain("R", "X1"),
+                        fixed[3],
+                        fold_config.gain("R", "X3"),
+                    ),
+                    3 => FoldSources::One(fixed[2], fold_config.gain("Ls", "X2")),
+                    4 => FoldSources::One(fixed[3], fold_config.gain("Rs", "X3")),
+                    7 => FoldSources::One(fixed[4], fold_config.gain("Lb", "X4")),
+                    8 => FoldSources::One(fixed[5], fold_config.gain("Rb", "X5")),
+                    _ => FoldSources::None,
+                };
+            }
+            FoldSources::None
         })
         .collect();
 
     let mut pcm: RVec<i32> = RVec::with_capacity(sample_count * channel_count);
     for s in 0..sample_count {
-        for (channel, fold) in bed.iter().zip(fold_source.iter()) {
-            let sample = match fold {
-                Some(height) => channel[s] - height[s] * XLL_X_HEIGHT_DOWNMIX_GAIN,
-                None => channel[s],
+        for (channel, fold) in bed.iter().zip(fold_sources.iter()) {
+            let sample = match *fold {
+                FoldSources::None => channel[s],
+                FoldSources::One(source, gain) => channel[s] - source[s] * gain,
+                FoldSources::Two(first, first_gain, second, second_gain) => {
+                    channel[s] - first[s] * first_gain - second[s] * second_gain
+                }
             };
             pcm.push(float_to_pcm_i32(sample));
         }
@@ -263,6 +474,21 @@ fn build_hd_frame(hd: &HdFrame, height_locked: &mut bool) -> Option<RDecodedFram
                 pcm.push(0);
             }
         }
+        if let Some(fixed) = d0_fixed_samples {
+            for channel in fixed {
+                pcm.push(float_to_pcm_i32(channel[s]));
+            }
+        }
+        if let Some(fixed) = d1_fixed_samples {
+            for channel in fixed {
+                pcm.push(float_to_pcm_i32(channel[s]));
+            }
+        }
+        if let Some(alternate) = alternate_samples {
+            for &source in object_source_indices {
+                pcm.push(float_to_pcm_i32(alternate[source][s]));
+            }
+        }
     }
 
     let mut channel_labels: RVec<RChannelLabel> = RVec::with_capacity(channel_count);
@@ -270,23 +496,129 @@ fn build_hd_frame(hd: &HdFrame, height_locked: &mut bool) -> Option<RDecodedFram
         channel_labels.push(speaker_to_label(spkr));
     }
     channel_labels.extend(XLL_X_HEIGHT_LABELS[..height_count].iter().copied());
+    channel_labels.extend(D0_FIXED_LABELS[..d0_fixed_count].iter().copied());
+    channel_labels.extend(D1_FIXED_LABELS[..d1_fixed_count].iter().copied());
+    channel_labels.extend(std::iter::repeat_n(RChannelLabel::Object, object_count));
 
     if height_samples.is_some() {
         *height_locked = true;
     }
 
-    Some(RDecodedFrame {
-        sampling_frequency: hd.sample_rate,
-        sample_count: sample_count as u32,
-        channel_count: channel_count as u32,
-        pcm,
-        channel_labels,
-        metadata: RVec::new(),
-        drc_gain: 1.0,
-        drc_ramp_duration: 0,
-        dialogue_level: None.into(),
-        is_new_segment: false,
-    })
+    let metadata = build_d3_metadata(
+        object_source_indices,
+        active.len() + height_count + d0_fixed_count + d1_fixed_count,
+        sample_pos,
+        hd.sample_rate,
+        sample_count,
+        declared_object_channels,
+    );
+
+    Some((
+        RDecodedFrame {
+            sampling_frequency: hd.sample_rate,
+            sample_count: sample_count as u32,
+            channel_count: channel_count as u32,
+            pcm,
+            channel_labels,
+            metadata,
+            drc_gain: 1.0,
+            drc_ramp_duration: 0,
+            dialogue_level: None.into(),
+            is_new_segment: false,
+        },
+        object_count > 0,
+    ))
+}
+
+fn build_d3_metadata(
+    object_source_indices: &[usize],
+    first_object_channel: usize,
+    sample_pos: u64,
+    sample_rate: u32,
+    sample_count: usize,
+    declared_object_channels: &mut Option<RVec<RObjectChannel>>,
+) -> RVec<RMetadataFrame> {
+    const HEARTBEAT_HZ: u64 = 2;
+
+    let object_count = object_source_indices.len();
+    if object_count == 0 {
+        return RVec::new();
+    }
+
+    let declaration_unchanged = declared_object_channels.as_deref().is_some_and(|channels| {
+        channels.len() == object_count
+            && channels.iter().zip(object_source_indices).enumerate().all(
+                |(index, (channel, source))| {
+                    channel.id == (10 + source) as u32
+                        && channel.channel == (first_object_channel + index) as u32
+                },
+            )
+    });
+    // Keep static presentations alive in monitoring clients whose stream-idle
+    // timeout is shorter than one second, while staying far below the former
+    // per-audio-frame metadata rate that could overwhelm Studio.
+    let heartbeat_period = (sample_rate as u64) / HEARTBEAT_HZ;
+    let heartbeat_due = heartbeat_period > 0 && sample_pos % heartbeat_period < sample_count as u64;
+    if declaration_unchanged && !heartbeat_due {
+        return RVec::new();
+    }
+    let object_channels = if declaration_unchanged {
+        RVec::new()
+    } else {
+        log::warn!(
+            "dts: EXPERIMENTAL D3 presentation declaring X0..X{} at inferred positions; mapping is not source metadata",
+            object_count - 1,
+        );
+        let current: RVec<RObjectChannel> = object_source_indices
+            .iter()
+            .enumerate()
+            .map(|(index, &source)| RObjectChannel {
+                id: (10 + source) as u32,
+                channel: (first_object_channel + index) as u32,
+            })
+            .collect();
+        declare_object_channels(declared_object_channels, current)
+    };
+
+    let events: RVec<REvent> = object_source_indices
+        .iter()
+        .map(|&source| REvent {
+            id: (10 + source) as u32,
+            sample_pos,
+            has_pos: true,
+            pos: D3_INFERRED_OBJECT_POSITIONS[source],
+            gain_db: 0,
+            size: [0.0; 3],
+            ramp_duration: 0,
+        })
+        .collect();
+    let name_updates = if declaration_unchanged {
+        RVec::new()
+    } else {
+        object_source_indices
+            .iter()
+            .map(|&source| RNameUpdate {
+                id: (10 + source) as u32,
+                name: RString::from(format!("X{source}")),
+            })
+            .collect()
+    };
+    let mut metadata = RVec::with_capacity(1);
+    metadata.push(RMetadataFrame {
+        events,
+        object_channels,
+        channel_gains: RVec::new(),
+        name_updates,
+        sample_pos,
+        ramp_duration: 0,
+    });
+    metadata
+}
+
+#[cfg(test)]
+fn build_hd_frame(hd: &HdFrame, height_locked: &mut bool) -> Option<RDecodedFrame> {
+    build_hd_frame_with_extensions(hd, height_locked, &DtsFoldConfig::default(), 0, &mut None)
+        .map(|(frame, _)| frame)
 }
 
 /// Build a bed frame from a plain DTS core PCM frame (DCA primary order + LFE).
@@ -361,7 +693,9 @@ mod tests {
     fn assert_pcm_close(actual: i32, expected: f32) {
         let expected = float_to_pcm_i32(expected);
         assert!(
-            actual.abs_diff(expected) <= 1,
+            // YAML dB values are converted back to linear amplitude; allow
+            // the bounded float32/PCM quantisation difference.
+            actual.abs_diff(expected) <= 64,
             "actual={actual}, expected={expected}"
         );
     }
@@ -507,6 +841,288 @@ mod tests {
             assert_eq!(row[1], float_to_pcm_i32(composite_left[sample]));
             assert!(row[8..12].iter().all(|&s| s == 0));
         }
+    }
+
+    #[test]
+    fn d3_emits_named_objects_without_unfolding_the_bed() {
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        samples[0] = Some(vec![0.10, -0.10]);
+        samples[1] = Some(vec![0.20, -0.20]);
+        samples[2] = Some(vec![0.30, -0.30]);
+        let extension: Vec<Vec<f32>> = (0..8)
+            .map(|index| vec![0.01 * (index + 1) as f32; SAMPLE_COUNT])
+            .collect();
+        let mut hd = hd_frame(samples, extension);
+        hd.x_present = false;
+        hd.x_imax = true;
+
+        let mut locked = false;
+        let mut declared = None;
+        let (frame, emitted) = build_hd_frame_with_extensions(
+            &hd,
+            &mut locked,
+            &DtsFoldConfig::default(),
+            48_000,
+            &mut declared,
+        )
+        .expect("valid D3 frame");
+
+        assert!(emitted);
+        assert!(!locked);
+        assert_eq!(frame.channel_count, 11);
+        assert_eq!(
+            &frame.channel_labels[..3],
+            &[RChannelLabel::C, RChannelLabel::L, RChannelLabel::R]
+        );
+        assert!(
+            frame.channel_labels[3..]
+                .iter()
+                .all(|&label| label == RChannelLabel::Object)
+        );
+        for sample in 0..SAMPLE_COUNT {
+            let row = &frame.pcm[sample * 11..(sample + 1) * 11];
+            for bed in 0..3 {
+                assert_pcm_close(row[bed], hd.samples[bed].as_ref().unwrap()[sample]);
+            }
+            for source in 0..8 {
+                assert_pcm_close(row[3 + source], hd.x_samples[source][sample]);
+            }
+        }
+
+        assert_eq!(frame.metadata.len(), 1);
+        let metadata = &frame.metadata[0];
+        assert_eq!(metadata.sample_pos, 48_000);
+        assert_eq!(metadata.events.len(), 8);
+        assert_eq!(metadata.object_channels.len(), 8);
+        assert_eq!(metadata.name_updates.len(), 8);
+        for source in 0..8 {
+            assert_eq!(metadata.object_channels[source].id, (10 + source) as u32);
+            assert_eq!(
+                metadata.object_channels[source].channel,
+                (3 + source) as u32
+            );
+            assert_eq!(metadata.name_updates[source].id, (10 + source) as u32);
+            assert_eq!(
+                metadata.name_updates[source].name.as_str(),
+                format!("X{source}")
+            );
+            assert_eq!(metadata.events[source].id, (10 + source) as u32);
+            assert_eq!(
+                metadata.events[source].pos,
+                D3_INFERRED_OBJECT_POSITIONS[source]
+            );
+        }
+    }
+
+    #[test]
+    fn d0_emits_fixed_7_1_5_with_partial_unfold() {
+        let dry = [
+            vec![0.10, -0.10],
+            vec![0.20, -0.20],
+            vec![0.30, -0.30],
+            vec![0.40, -0.40],
+            vec![0.50, -0.50],
+        ];
+        let extension: Vec<Vec<f32>> = (0..5)
+            .map(|index| vec![0.01 * (index + 1) as f32; SAMPLE_COUNT])
+            .collect();
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        samples[0] = Some(
+            dry[0]
+                .iter()
+                .zip(&extension[0])
+                .map(|(&bed, &top)| bed + top * D0_TFC_CENTER_DOWNMIX_GAIN)
+                .collect(),
+        );
+        samples[1] = Some(
+            dry[1]
+                .iter()
+                .zip(&extension[1])
+                .map(|(&bed, &top)| bed + top * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN)
+                .collect(),
+        );
+        samples[2] = Some(
+            dry[2]
+                .iter()
+                .zip(&extension[2])
+                .map(|(&bed, &top)| bed + top * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN)
+                .collect(),
+        );
+        samples[3] = Some(vec![0.60, -0.60]);
+        samples[4] = Some(vec![0.70, -0.70]);
+        samples[5] = Some(vec![0.80, -0.80]);
+        samples[7] = Some(
+            dry[3]
+                .iter()
+                .zip(&extension[3])
+                .map(|(&bed, &top)| bed + top * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN)
+                .collect(),
+        );
+        samples[8] = Some(
+            dry[4]
+                .iter()
+                .zip(&extension[4])
+                .map(|(&bed, &top)| bed + top * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN)
+                .collect(),
+        );
+        let mut hd = hd_frame(samples, extension);
+        hd.x_present = false;
+        hd.x_imax = true;
+
+        let mut locked = false;
+        let mut declared = None;
+        let (frame, emitted) = build_hd_frame_with_extensions(
+            &hd,
+            &mut locked,
+            &DtsFoldConfig::default(),
+            100,
+            &mut declared,
+        )
+        .expect("valid D0 frame");
+
+        assert!(
+            !emitted,
+            "fixed channels must not set the object stream fact"
+        );
+        assert!(
+            !locked,
+            "alternate fixed channels must not latch standard heights"
+        );
+        assert!(declared.is_none());
+        assert!(frame.metadata.is_empty());
+        assert_eq!(frame.channel_count, 13);
+        assert_eq!(
+            frame.channel_labels.as_slice(),
+            &[
+                RChannelLabel::C,
+                RChannelLabel::L,
+                RChannelLabel::R,
+                RChannelLabel::Ls,
+                RChannelLabel::Rs,
+                RChannelLabel::LFE,
+                RChannelLabel::Lb,
+                RChannelLabel::Rb,
+                RChannelLabel::Tfc,
+                RChannelLabel::Tfl,
+                RChannelLabel::Tfr,
+                RChannelLabel::Tbl,
+                RChannelLabel::Tbr,
+            ]
+        );
+        for sample in 0..SAMPLE_COUNT {
+            let row = &frame.pcm[sample * 13..(sample + 1) * 13];
+            for channel in 0..3 {
+                assert_pcm_close(row[channel], dry[channel][sample]);
+            }
+            assert_pcm_close(row[3], hd.samples[3].as_ref().unwrap()[sample]);
+            assert_pcm_close(row[4], hd.samples[4].as_ref().unwrap()[sample]);
+            assert_pcm_close(row[5], hd.samples[5].as_ref().unwrap()[sample]);
+            assert_pcm_close(row[6], dry[3][sample]);
+            assert_pcm_close(row[7], dry[4][sample]);
+            for source in 0..5 {
+                assert_pcm_close(row[8 + source], hd.x_samples[source][sample]);
+            }
+        }
+    }
+
+    #[test]
+    fn d1_emits_fixed_wides_and_partial_unfold() {
+        let left_wide = vec![0.20, -0.10];
+        let right_wide = vec![-0.15, 0.25];
+        let dry_l = vec![0.03, -0.04];
+        let dry_r = vec![-0.05, 0.06];
+        let dry_ls = vec![0.07, -0.08];
+        let dry_rs = vec![-0.09, 0.10];
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        samples[0] = Some(vec![0.0; SAMPLE_COUNT]);
+        samples[1] = Some(
+            dry_l
+                .iter()
+                .zip(&left_wide)
+                .map(|(&dry, &wide)| dry + wide * 0.707107)
+                .collect(),
+        );
+        samples[2] = Some(
+            dry_r
+                .iter()
+                .zip(&right_wide)
+                .map(|(&dry, &wide)| dry + wide * 0.707107)
+                .collect(),
+        );
+        samples[3] = Some(
+            dry_ls
+                .iter()
+                .zip(&left_wide)
+                .map(|(&dry, &wide)| dry + wide * 0.707107)
+                .collect(),
+        );
+        samples[4] = Some(
+            dry_rs
+                .iter()
+                .zip(&right_wide)
+                .map(|(&dry, &wide)| dry + wide * 0.707107)
+                .collect(),
+        );
+        let extension = vec![
+            vec![0.01; SAMPLE_COUNT],
+            vec![0.02; SAMPLE_COUNT],
+            left_wide.clone(),
+            right_wide.clone(),
+            vec![0.05; SAMPLE_COUNT],
+            vec![0.06; SAMPLE_COUNT],
+        ];
+        let mut hd = hd_frame(samples, extension);
+        hd.x_present = false;
+        hd.x_imax = true;
+
+        let mut locked = false;
+        let mut declared = None;
+        let (frame, emitted) = build_hd_frame_with_extensions(
+            &hd,
+            &mut locked,
+            &DtsFoldConfig::default(),
+            100,
+            &mut declared,
+        )
+        .expect("valid D1 frame");
+
+        assert!(!emitted, "D1 sources are fixed channels");
+        assert_eq!(frame.channel_count, 11);
+        assert_eq!(
+            frame.channel_labels.as_slice(),
+            &[
+                RChannelLabel::C,
+                RChannelLabel::L,
+                RChannelLabel::R,
+                RChannelLabel::Ls,
+                RChannelLabel::Rs,
+                RChannelLabel::Tfl,
+                RChannelLabel::Tfr,
+                RChannelLabel::Lw,
+                RChannelLabel::Rw,
+                RChannelLabel::Tbl,
+                RChannelLabel::Tbr,
+            ]
+        );
+        for sample in 0..SAMPLE_COUNT {
+            let row = &frame.pcm[sample * 11..(sample + 1) * 11];
+            assert_pcm_close(
+                row[1],
+                dry_l[sample]
+                    - hd.x_samples[0][sample] * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN,
+            );
+            assert_pcm_close(
+                row[2],
+                dry_r[sample]
+                    - hd.x_samples[1][sample] * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN,
+            );
+            assert_pcm_close(row[3], dry_ls[sample]);
+            assert_pcm_close(row[4], dry_rs[sample]);
+            for (slot, source) in (0usize..6).enumerate() {
+                assert_pcm_close(row[5 + slot], hd.x_samples[source][sample]);
+            }
+        }
+        assert!(frame.metadata.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- decode the standard and currently understood alternate spatial extension profiles
- present D0 as fixed 7.1.5 and D1 as fixed 9.1.4 with ordered, user-configurable fold gains
- expose the eight D3 extension sources through the experimental object-audition path
- add bounded corpus-analysis tools and document the evidence and remaining unknowns
- enable automatic presentation without format-specific runtime switches

## Why

The bridge previously handled only the standard four-source extension. The additional profiles were either hidden or left as an uninterpreted compatible bed, despite repeatable channel geometry in the local corpus. This change makes the known fixed presentations usable and keeps the unresolved D3 interpretation explicitly experimental.

## Contract and review status

D0 and D1 emit labeled fixed channels without fabricated bed IDs or dynamic-object metadata. `has_objects` remains false for both. D3 currently declares eight named object channels at documented inferred default positions for audition; those positions are not decoded from the stream and remain the principal contract/review question. This PR must stay draft until that experimental choice and the requested A/B listening result are signed off.

The 35 local research commits were squash-published as one sanitized commit. Added content contains no local corpus paths, source-media filenames, or proprietary demonstration names.

## Validation

- `RUSTFLAGS='-D warnings' cargo build --all-targets`
- `cargo test --workspace --all-targets` with the mounted standard, D0, D1 and D3 corpus inputs; the relevant corpus tests ran rather than self-skipping
- standard 7.1 lossless bed compared bit-exact against ffmpeg: worst RMSE `0.000e0`
- DTS core 5.1 regression compared against ffmpeg
- malformed/truncated alternate payload rejection tests
- A/B listening: pending user sign-off
