### PR TITLE
chore(release): prepare harletty-bridge 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "harletty-bridge"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "abi_stable",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "harletty-bridge"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
Summary:
- bump the bridge crate and lockfile to 0.7.2

Validation:
- cargo build --all-targets
- cargo test (53 passed)

After review and green CI, promote main to release, tag v0.7.2, and let the release workflow build the draft artifacts.