### PR TITLE
Ship the offline truehdd CLI as its own release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build (release)
-        run: cargo build --release -p harletty-bridge
+        run: cargo build --release -p harletty-bridge -p truehdd
         working-directory: harletty-bridge
         env:
           RUSTFLAGS: -D warnings
@@ -35,12 +35,15 @@ jobs:
         run: |
           cd harletty-bridge/target/release
           zip "harletty-bridge-${GITHUB_REF_NAME}-linux-x86_64.zip" libharletty_bridge.so
+          zip "truehdd-${GITHUB_REF_NAME}-linux-x86_64.zip" truehdd
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: harletty-bridge-linux-x86_64
-          path: harletty-bridge/target/release/harletty-bridge-*-linux-x86_64.zip
+          path: |
+            harletty-bridge/target/release/harletty-bridge-*-linux-x86_64.zip
+            harletty-bridge/target/release/truehdd-*-linux-x86_64.zip
 
   build-windows:
     runs-on: windows-latest
@@ -62,7 +65,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build (release)
-        run: cargo build --release -p harletty-bridge
+        run: cargo build --release -p harletty-bridge -p truehdd
         working-directory: harletty-bridge
         env:
           RUSTFLAGS: -D warnings
@@ -71,12 +74,15 @@ jobs:
         run: |
           cd harletty-bridge/target/release
           Compress-Archive -Path harletty_bridge.dll -DestinationPath "harletty-bridge-${env:GITHUB_REF_NAME}-windows-x86_64.zip"
+          Compress-Archive -Path truehdd.exe -DestinationPath "truehdd-${env:GITHUB_REF_NAME}-windows-x86_64.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: harletty-bridge-windows-x86_64
-          path: harletty-bridge/target/release/harletty-bridge-*-windows-x86_64.zip
+          path: |
+            harletty-bridge/target/release/harletty-bridge-*-windows-x86_64.zip
+            harletty-bridge/target/release/truehdd-*-windows-x86_64.zip
 
   build-macos:
     runs-on: macos-14
@@ -98,7 +104,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build (release)
-        run: cargo build --release -p harletty-bridge
+        run: cargo build --release -p harletty-bridge -p truehdd
         working-directory: harletty-bridge
         env:
           RUSTFLAGS: -D warnings
@@ -107,12 +113,15 @@ jobs:
         run: |
           cd harletty-bridge/target/release
           zip "harletty-bridge-${GITHUB_REF_NAME}-macos-arm64.zip" libharletty_bridge.dylib
+          zip "truehdd-${GITHUB_REF_NAME}-macos-arm64.zip" truehdd
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: harletty-bridge-macos-arm64
-          path: harletty-bridge/target/release/harletty-bridge-*-macos-arm64.zip
+          path: |
+            harletty-bridge/target/release/harletty-bridge-*-macos-arm64.zip
+            harletty-bridge/target/release/truehdd-*-macos-arm64.zip
 
   release:
     needs: [build-linux, build-windows, build-macos]
@@ -145,3 +154,6 @@ jobs:
             harletty-bridge-*-linux-x86_64.zip
             harletty-bridge-*-windows-x86_64.zip
             harletty-bridge-*-macos-arm64.zip
+            truehdd-*-linux-x86_64.zip
+            truehdd-*-windows-x86_64.zip
+            truehdd-*-macos-arm64.zip

--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ The same decoders also drive an offline tool that turns TrueHD and
 E-AC-3 JOC bitstreams into Dolby Atmos master files (`.atmos`,
 `.atmos.metadata`, plus CAF/WAV audio):
 
+It ships as its own asset on the
+[releases page](https://github.com/harletty/harletty-bridge/releases) —
+`truehdd-<version>-<system>.zip`, separate from the bridge, since the
+two have nothing to do with each other at install time. Or build it:
+
 ```sh
 cargo build --release -p truehdd
 ./target/release/truehdd decode --output-path out track.thd
@@ -222,7 +227,7 @@ cargo build --release -p truehdd
 ```
 
 It reads from a file or from `-` (stdin), so it pipes straight out of
-ffmpeg. It replaces the standalone `truehdd` fork this workspace used to
+ffmpeg. It also decodes DTS, exporting DTS:X as ADM. It replaces the standalone `truehdd` fork this workspace used to
 carry — see [docs/truehdd-fork-retirement.md](docs/truehdd-fork-retirement.md)
 for what was ported and what was superseded. It is a *separate artifact*: the bridge does not link it, does
 not pay for it, and cannot reach it. That isolation is by crate graph


### PR DESCRIPTION
The workspace has produced two binaries since the CLI was resurrected, but
`release.yml` only packaged the plugin. This adds the CLI to the next tag.

## Separate zip, same release

Packaged as `truehdd-<tag>-<os>.zip` alongside the existing
`harletty-bridge-<tag>-<os>.zip`, rather than added to the bridge archive:

- **The install docs are written around one file** — download the one that
  matches your system, drop it next to `orender`, done. A two-file archive
  invites "which one do I copy?" for no benefit; the audiences barely overlap.
- **The CLI is the bigger of the two**: 5.8 MB against 3.4 uncompressed. Every
  plugin user would pay 2.7× the download for a binary they never run. As it
  stands the bridge zip stays at 1.29 MB compressed instead of becoming
  ~3.5 MB.
- **The versions differ** (bridge 0.7.2, `truehdd` 0.4.0). A binary announcing
  itself as 0.4.0 inside an archive named `harletty-bridge-v0.7.2-*` would just
  be confusing.

Same tag and same job though — both come from one commit, and `truehd`, `eac3`
and `dca` are dependencies of *both* binaries, so they compile once and are
reused. A separate release pipeline would buy nothing.

## Failure coupling

Both packages are built in a single `cargo build` step, so a CLI build failure
blocks the release. That is deliberate: this is the first time the CLI is built
on Windows and macOS, and a silently missing asset would be worse than a loud
failure. Its dependencies are all pure Rust (clap, indicatif, env_logger,
serde), so the risk is low — but the tag is the first real test.

## Verification

Rehearsed locally with the exact build and packaging commands the workflow
runs: two zips, one file each, the bridge archive the same shape as before.
The workflow YAML parses and the release job's asset globs cover both families.

The AUR package still installs only the plugin; shipping the CLI there is a
separate decision.