### PR TITLE
fix: correct two DAMF output bugs reported upstream (#26, #17)

### DIFF
--- a/damf/src/damf.rs
+++ b/damf/src/damf.rs
@@ -722,10 +722,103 @@ where
     }
 }
 
-/// Helper function for common YAML string formatting
-fn format_yaml_string(mut yaml_str: String) -> String {
-    yaml_str.retain(|c| c != '\'');
-    yaml_str.replace("  ", "    ").replace("- ", "  - ")
+/// Reformat `serde_yaml_ng` output into the layout Dolby's tools emit for DAMF:
+/// four-space indent steps, sequence dashes one step under their key, and
+/// scalars written plain (DAMF quotes nothing, so `'24'` is written `24`).
+///
+/// Only structural text is rewritten. Scalar *content* is left alone apart from
+/// undoing YAML quoting, so a path containing `'`, `  ` or `- ` survives
+/// intact. This used to be a whole-document search and replace, which rewrote
+/// those sequences inside values too and produced `.atmos` files whose
+/// `metadata:`/`audio:` entries did not name the files actually written.
+fn format_yaml_string(yaml_str: String) -> String {
+    let mut out = String::with_capacity(yaml_str.len() * 2);
+
+    for raw_line in yaml_str.split_inclusive('\n') {
+        let (line, newline) = match raw_line.strip_suffix('\n') {
+            Some(line) => (line, "\n"),
+            None => (raw_line, ""),
+        };
+
+        // serde indents two spaces per level, DAMF four.
+        let content = line.trim_start_matches(' ');
+        for _ in 0..(line.len() - content.len()) * 2 {
+            out.push(' ');
+        }
+
+        // A sequence entry sits one further step in than its key in DAMF.
+        let mut content = content;
+        while let Some(rest) = content.strip_prefix("- ") {
+            out.push_str("  - ");
+            content = rest;
+        }
+
+        match split_key_value(content) {
+            Some((key, value)) => {
+                out.push_str(&unquote(key));
+                out.push(':');
+                if !value.is_empty() {
+                    out.push(' ');
+                    out.push_str(&unquote(value));
+                }
+            }
+            None => out.push_str(&unquote(content)),
+        }
+
+        out.push_str(newline);
+    }
+
+    out
+}
+
+/// Split `key: value` (or a bare `key:`) into its two halves, honouring a
+/// single-quoted key. Returns `None` when the line is a lone scalar.
+fn split_key_value(content: &str) -> Option<(&str, &str)> {
+    let key_end = if content.starts_with('\'') {
+        closing_quote(content)? + 1
+    } else {
+        content.find(':')?
+    };
+
+    let value = content.get(key_end..)?.strip_prefix(':')?;
+
+    match value.strip_prefix(' ') {
+        Some(value) => Some((&content[..key_end], value)),
+        None if value.is_empty() => Some((&content[..key_end], "")),
+        // A colon that is not followed by a space is part of the scalar.
+        None => None,
+    }
+}
+
+/// Byte offset of the `'` closing the single-quoted scalar starting at byte 0,
+/// skipping the `''` escape.
+fn closing_quote(content: &str) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut i = 1;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\'' {
+            if bytes.get(i + 1) == Some(&b'\'') {
+                i += 2;
+                continue;
+            }
+            return Some(i);
+        }
+        i += 1;
+    }
+
+    None
+}
+
+/// Drop the single quotes `serde_yaml_ng` wraps a scalar in and undo the `''`
+/// escape. An apostrophe *inside* a scalar is content and is kept.
+fn unquote(scalar: &str) -> String {
+    match closing_quote(scalar) {
+        Some(end) if scalar.starts_with('\'') && end == scalar.len() - 1 => {
+            scalar[1..end].replace("''", "'")
+        }
+        _ => scalar.to_string(),
+    }
 }
 
 /// Stands in for the CLI binary's own identity. The CLI passes
@@ -883,4 +976,35 @@ presentations:
     let yaml_str = serde_yaml_ng::to_string(&data).unwrap();
 
     assert_eq!(test_str, format_yaml_string(yaml_str));
+}
+
+/// The `metadata:`/`audio:` entries must name the files actually written, even
+/// when the output path holds characters the YAML layout pass used to rewrite:
+/// a single quote, two spaces in a row, or a hyphen followed by a space.
+/// Anything else and the DAMF will not open in a DAW.
+#[test]
+fn base_name_survives_yaml_formatting() {
+    use truehd::structs::oamd::TEST_DATA_TRIM;
+
+    let oamd = ObjectAudioMetadataPayload::read(TEST_DATA_TRIM).unwrap();
+
+    for base_name in [
+        "audio  -  output",
+        "Ocean's Eleven",
+        "Movie - 2017",
+        "A Long Name That Comfortably Exceeds The Emitter's Default Line Width Of Eighty Columns",
+    ] {
+        let data =
+            Data::with_oamd_payload(&oamd, Path::new(base_name), SourceCodec::TrueHD, TEST_TOOL);
+        let yaml = data.serialize_damf();
+
+        assert!(
+            yaml.contains(&format!("metadata: {base_name}.atmos.metadata\n")),
+            "metadata entry mangled for {base_name:?}:\n{yaml}"
+        );
+        assert!(
+            yaml.contains(&format!("audio: {base_name}.atmos.audio\n")),
+            "audio entry mangled for {base_name:?}:\n{yaml}"
+        );
+    }
 }

--- a/truehd/src/structs/oamd.rs
+++ b/truehd/src/structs/oamd.rs
@@ -863,9 +863,15 @@ pub const DISTANCE_FACTORS: [f64; 16] = [
     1.1, 1.3, 1.6, 2.0, 2.5, 3.2, 4.0, 5.0, 6.3, 7.9, 10.0, 12.6, 15.8, 20.0, 25.1, 50.1,
 ];
 
+/// Lookup table mapping a 4-bit trim index to a gain in dB.
+///
+/// Index 14 is -15.0, not the -16.0 this table used to carry: the reference
+/// decoder maps that index to the Q12 value 0x02d8 (728), i.e.
+/// `20 * log10(728 / 4096) = -15.005 dB`, and -15.0 is also where the -1.5 dB
+/// step running through entries 5..=13 lands next. (-16.0 dB would be Q12 649.)
 #[rustfmt::skip]
 pub const TRIM_LUT: [f64; 16] = [
-    6.0, 3.0, 1.5, 0.75, -0.75, -1.5, -3.0, -4.5, -6.0, -7.5, -9.0, -10.5, -12.0, -13.5, -16.0, -36.0,
+    6.0, 3.0, 1.5, 0.75, -0.75, -1.5, -3.0, -4.5, -6.0, -7.5, -9.0, -10.5, -12.0, -13.5, -15.0, -36.0,
 ];
 
 // TODO: TrimElement & ExtendObjectElement
@@ -1306,5 +1312,34 @@ mod tests {
         let _ = ObjectAudioMetadataPayload::read(TEST_DATA_BROKEN)?;
 
         Ok(())
+    }
+
+    /// Entries 3..=14 of the trim table step by a constant -0.75 dB and then
+    /// -1.5 dB; index 14 sitting at -16.0 rather than -15.0 broke that run and
+    /// disagreed with the reference decoder's Q12 code for it (0x02d8 = 728).
+    /// The DAMF `trimMode` block is written straight from this table, so an
+    /// off-by-one entry ships in every master set that carries trim metadata.
+    #[test]
+    fn trim_lut_follows_the_reference_quantiser() {
+        use crate::structs::oamd::TRIM_LUT;
+
+        for (idx, q12) in [(14usize, 728.0f64), (13, 865.0), (8, 2053.0)] {
+            let expected = 20.0 * (q12 / 4096.0).log10();
+            assert!(
+                (TRIM_LUT[idx] - expected).abs() < 0.01,
+                "TRIM_LUT[{idx}] = {} but Q12 {q12} gives {expected:.3} dB",
+                TRIM_LUT[idx]
+            );
+        }
+
+        // -1.5 dB per step from index 5 through 14, no discontinuity at the end.
+        for window in TRIM_LUT[5..=14].windows(2) {
+            assert!(
+                (window[0] - window[1] - 1.5).abs() < f64::EPSILON,
+                "step {} -> {} is not -1.5 dB",
+                window[0],
+                window[1]
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes two defects in the `.atmos` master set writer. Both were reported on the upstream `truehdd/truehdd` tracker and neither will be fixed there: that repository has had no commits since 2025-08-15, while issues keep arriving. This fork is where they get fixed.

## `TRIM_LUT[14]` was -16.0 dB, should be -15.0 dB

Upstream [#26](https://github.com/truehdd/truehdd/issues/26).

The reference decoder maps trim index 14 to the Q12 value `0x02d8` (728), i.e. `20 * log10(728 / 4096) = -15.005 dB`. -16.0 dB would be Q12 649 — a different code. It was also the only break in the -1.5 dB step running through entries 5..=13.

`TrimElement` feeds the DAMF `trimMode` block verbatim, so every master set whose trim metadata selects index 14 shipped a 1 dB error in `centerTrim` / `surroundTrim` / `heightTrim`.

The golden fixture never reaches index 14, so the change would otherwise have been uncovered. `trim_lut_follows_the_reference_quantiser` pins the table against both the Q12 derivation and the step continuity.

## The YAML layout pass rewrote scalar content

Upstream [#17](https://github.com/truehdd/truehdd/issues/17).

`format_yaml_string` turned `serde_yaml_ng` output into Dolby's DAMF layout with three whole-document substitutions: drop every `'`, double every run of two spaces, indent every `"- "`. Those run over values as readily as over structure.

Decoding to `--output-path "Ocean's  Eleven - 2001"`, before this change:

```
on disk      Ocean's  Eleven - 2001.atmos.metadata
in .atmos    Oceans    Eleven   - 2001.atmos.metadata
```

The presentation names files that do not exist, and the master set will not open in Resolve or Pro Tools. **Atmos Ranker hits this routinely** — it passes the movie's filename stem as `--output-path` (`check_grid.rs:172`), and `Title - Year` is a common naming scheme.

The pass now works line by line: re-indent the leading whitespace, shift the sequence dashes, leave the rest of the line alone apart from undoing YAML quoting. Quote removal strips only the quotes that *delimit* a scalar and unescapes `''` -> `'`.

Two things that constrain the fix:

- Quote removal is load-bearing, not cosmetic. `Fps::R24` serialises as `'24'` and `VecDisplay` as `'[3]'`, and DAMF wants those written `24` and `[3]`. A more conservative rule — only unquote when the result stays an unambiguous YAML scalar — would have broken `scBedConfiguration: [3]`. The format quotes nothing.
- libyaml folds lines at 80 columns, which would corrupt long paths. Covered by the test; it does not trigger here.

## Verification

- 167 tests pass. `roundtrip`, `damf` and `harletty/tests/golden.rs` pin the existing output byte for byte, so paths without those characters are unaffected.
- `base_name_survives_yaml_formatting` was confirmed to fail on the previous formatter before being kept.
- End-to-end against `harletty/tests/fixtures/joc_atmos_1s.eac3` with the pathological path above: the `.atmos` entries now match the files on disk exactly.

`cargo fmt --all` was deliberately not run — it reformats 47 unrelated files, and `ci.yml` documents why fmt is not gated. Both touched files are rustfmt-clean apart from one pre-existing deviation left untouched.

## Not verified

- No sample on hand carries a trim at index 14, so #26 rests on the Q12 derivation and the table's own step, not on a real stream.
- No corrected `.atmos` was opened in Resolve or Pro Tools; the evidence stops at the YAML naming the files that were written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)