### PR TITLE
fix: keep the output timeline intact across undecodable access units

### DIFF
--- a/harletty/src/cli/decode/decoder_thread.rs
+++ b/harletty/src/cli/decode/decoder_thread.rs
@@ -1,4 +1,4 @@
-use super::processor::{ProcessFramesContext, process_frames};
+use super::processor::{AccessUnitShape, ProcessFramesContext, process_frames};
 use crate::input::InputReader;
 use anyhow::Result;
 use indicatif::ProgressBar;
@@ -38,6 +38,9 @@ pub fn spawn_decoder_thread(config: DecoderThreadConfig) -> thread::JoinHandle<R
         let mut current_substream_info: Option<u8> = None;
         let mut current_extended_substream_info: Option<u8> = None;
         let mut recovering_until_major_sync = false;
+        let mut last_shape: Option<AccessUnitShape> = None;
+        let mut gap_access_units = 0u64;
+        let mut gap_samples = 0u64;
 
         if !prefix.is_empty() {
             extractor.push_bytes(&prefix);
@@ -62,6 +65,9 @@ pub fn spawn_decoder_thread(config: DecoderThreadConfig) -> thread::JoinHandle<R
                 current_substream_info: &mut current_substream_info,
                 current_extended_substream_info: &mut current_extended_substream_info,
                 recovering_until_major_sync: &mut recovering_until_major_sync,
+                last_shape: &mut last_shape,
+                gap_access_units: &mut gap_access_units,
+                gap_samples: &mut gap_samples,
             };
 
             let should_exit = process_frames(&mut ctx)?;
@@ -70,6 +76,23 @@ pub fn spawn_decoder_thread(config: DecoderThreadConfig) -> thread::JoinHandle<R
         })?;
 
         log::info!("Processing complete: {frame_count} frames, {total_samples} samples");
+
+        if gap_access_units > 0 {
+            // Worth stating plainly: the output is not lossless any more, but
+            // it is still in sync, which is the trade the alternative gets
+            // wrong in the other direction.
+            let sample_rate = last_shape
+                .as_ref()
+                .map_or(48000, AccessUnitShape::sampling_frequency)
+                .max(1) as f64;
+            log::warn!(
+                "{gap_access_units} access units could not be decoded and were replaced with \
+                 silence ({gap_samples} samples, {:.0} ms). Output length is preserved; \
+                 audio stays aligned with the source timeline.",
+                gap_samples as f64 / sample_rate * 1000.0
+            );
+        }
+
         Ok(())
     })
 }

--- a/harletty/src/cli/decode/processor.rs
+++ b/harletty/src/cli/decode/processor.rs
@@ -1,7 +1,55 @@
 use anyhow::Result;
 use indicatif::ProgressBar;
 use std::sync::mpsc;
+use truehd::process::decode::DecodedAccessUnit;
 use truehd::process::{decode::Decoder, extract::Extractor, parse::Parser};
+use truehd::structs::channel::ChannelLabel;
+
+/// Shape of the last access unit that came through cleanly.
+///
+/// Used to size the silence that stands in for one we could not decode: a
+/// skipped access unit is a hole in the timeline, and nothing in a frame we
+/// failed to parse tells us how long it was meant to be. TrueHD access units
+/// run at a fixed 1/1200 s for a given sampling rate, so the previous one is
+/// an exact answer in practice rather than an approximation.
+#[derive(Clone)]
+pub struct AccessUnitShape {
+    sampling_frequency: u32,
+    sample_length: usize,
+    channel_count: usize,
+    channel_labels: Vec<ChannelLabel>,
+}
+
+impl AccessUnitShape {
+    pub fn sampling_frequency(&self) -> u32 {
+        self.sampling_frequency
+    }
+
+    fn of(decoded: &DecodedAccessUnit) -> Self {
+        Self {
+            sampling_frequency: decoded.sampling_frequency,
+            sample_length: decoded.sample_length,
+            channel_count: decoded.channel_count,
+            channel_labels: decoded.channel_labels.clone(),
+        }
+    }
+
+    fn to_silence(&self) -> DecodedAccessUnit {
+        DecodedAccessUnit {
+            sampling_frequency: self.sampling_frequency,
+            sample_length: self.sample_length,
+            channel_count: self.channel_count,
+            pcm_data: [[0; 16]; 160],
+            channel_labels: self.channel_labels.clone(),
+            // No object metadata for a span we never decoded: the last
+            // positions stay in force, which is what a renderer does anyway
+            // between events.
+            oamd: Vec::new(),
+            is_duplicate: false,
+            substream_info_changed: false,
+        }
+    }
+}
 
 pub struct ProcessFramesContext<'a> {
     pub extractor: &'a mut Extractor,
@@ -17,6 +65,33 @@ pub struct ProcessFramesContext<'a> {
     pub current_substream_info: &'a mut Option<u8>,
     pub current_extended_substream_info: &'a mut Option<u8>,
     pub recovering_until_major_sync: &'a mut bool,
+    /// Shape of the last cleanly decoded access unit, or `None` before the
+    /// first one.
+    pub last_shape: &'a mut Option<AccessUnitShape>,
+    /// Access units replaced with silence, and the samples that cost.
+    pub gap_access_units: &'a mut u64,
+    pub gap_samples: &'a mut u64,
+}
+
+/// Send silence in place of an access unit that could not be decoded.
+///
+/// Dropping it instead shortens the output by its duration, which is how a
+/// handful of corrupt frames turns into audio that drifts against the picture
+/// for the rest of the programme — the loss is permanent and accumulates at
+/// every stitch point. Returns `false` if the receiver is gone.
+fn emit_gap(ctx: &mut ProcessFramesContext) -> bool {
+    let Some(shape) = ctx.last_shape.as_ref() else {
+        // Nothing decoded yet, so there is no timeline to hold open and no
+        // channel layout to write. The stream has not started.
+        return true;
+    };
+
+    let silence = shape.to_silence();
+    *ctx.gap_access_units += 1;
+    *ctx.gap_samples += silence.sample_length as u64;
+    *ctx.total_samples += silence.sample_length as u64;
+
+    ctx.tx.send(Ok(silence)).is_ok()
 }
 
 pub fn process_frames(ctx: &mut ProcessFramesContext) -> Result<bool> {
@@ -31,6 +106,9 @@ pub fn process_frames(ctx: &mut ProcessFramesContext) -> Result<bool> {
 
                 if *ctx.recovering_until_major_sync {
                     if !frame.is_major_sync() {
+                        if !emit_gap(ctx) {
+                            return Ok(true);
+                        }
                         continue;
                     }
 
@@ -97,6 +175,7 @@ pub fn process_frames(ctx: &mut ProcessFramesContext) -> Result<bool> {
                                     decoded.substream_info_changed = true;
                                 }
 
+                                *ctx.last_shape = Some(AccessUnitShape::of(&decoded));
                                 *ctx.total_samples += decoded.sample_length as u64;
                                 if ctx.tx.send(Ok(decoded)).is_err() {
                                     return Ok(true);
@@ -106,6 +185,10 @@ pub fn process_frames(ctx: &mut ProcessFramesContext) -> Result<bool> {
                                 log::error!("Decode error at frame {}: {e}", *ctx.frame_count);
                                 if ctx.strict_mode {
                                     let _ = ctx.tx.send(Err(e));
+                                    return Ok(true);
+                                }
+
+                                if !emit_gap(ctx) {
                                     return Ok(true);
                                 }
                             }
@@ -123,6 +206,10 @@ pub fn process_frames(ctx: &mut ProcessFramesContext) -> Result<bool> {
                         *ctx.current_substream_info = None;
                         *ctx.current_extended_substream_info = None;
                         *ctx.recovering_until_major_sync = true;
+
+                        if !emit_gap(ctx) {
+                            return Ok(true);
+                        }
                     }
                 }
             }
@@ -142,4 +229,144 @@ pub fn process_frames(ctx: &mut ProcessFramesContext) -> Result<bool> {
         }
     }
     Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use truehd::process::EXAMPLE_DATA;
+
+    struct Run {
+        access_units: Vec<DecodedAccessUnit>,
+        total_samples: u64,
+        gap_access_units: u64,
+        gap_samples: u64,
+    }
+
+    /// `EXAMPLE_DATA` is one major sync plus one continuation access unit, 40
+    /// samples each. Repeating it gives a stream with the sync cadence a
+    /// recovery needs in order to resume.
+    fn stream(copies: usize) -> Vec<u8> {
+        EXAMPLE_DATA.repeat(copies)
+    }
+
+    fn run(bytes: &[u8]) -> Run {
+        let (tx, rx) = mpsc::channel();
+        let mut extractor = Extractor::default();
+        extractor.push_bytes(bytes);
+
+        let mut parser = Parser::default();
+        let mut decoder = Decoder::default();
+        let (mut frames_processed, mut frame_count, mut total_samples) = (0u64, 0u64, 0u64);
+        let (mut substream_info, mut extended_substream_info) = (None, None);
+        let mut recovering = false;
+        let mut last_shape = None;
+        let (mut gap_access_units, mut gap_samples) = (0u64, 0u64);
+
+        let mut ctx = ProcessFramesContext {
+            extractor: &mut extractor,
+            parser: &mut parser,
+            decoder: &mut decoder,
+            frames_processed: &mut frames_processed,
+            frame_count: &mut frame_count,
+            total_samples: &mut total_samples,
+            presentation: 3,
+            strict_mode: false,
+            tx: &tx,
+            pb_clone: &None,
+            current_substream_info: &mut substream_info,
+            current_extended_substream_info: &mut extended_substream_info,
+            recovering_until_major_sync: &mut recovering,
+            last_shape: &mut last_shape,
+            gap_access_units: &mut gap_access_units,
+            gap_samples: &mut gap_samples,
+        };
+
+        process_frames(&mut ctx).expect("processing must not abort in non-strict mode");
+        drop(tx);
+
+        Run {
+            access_units: rx.into_iter().map(|r| r.expect("no error sent")).collect(),
+            total_samples,
+            gap_access_units,
+            gap_samples,
+        }
+    }
+
+    #[test]
+    fn clean_stream_fills_no_gaps() {
+        let run = run(&stream(4));
+
+        assert_eq!(run.access_units.len(), 8);
+        assert_eq!(run.total_samples, 320);
+        assert_eq!(run.gap_access_units, 0, "nothing to recover from");
+    }
+
+    /// An access unit we cannot decode has to leave silence behind, not
+    /// nothing. Dropping it shortens the output by its duration, so the rest of
+    /// the programme slides earlier against the picture — and the error is
+    /// permanent, accumulating at every corrupt stitch point. This is the drift
+    /// reported upstream as truehdd/truehdd#19 and #25.
+    #[test]
+    fn undecodable_access_unit_becomes_silence_of_the_same_length() {
+        let clean = run(&stream(4));
+
+        // Scramble the payload of the second copy's continuation access unit,
+        // past the length field so framing still holds.
+        let mut damaged = stream(4);
+        let frame_len = EXAMPLE_DATA.len() / 2;
+        for byte in damaged
+            .iter_mut()
+            .skip(EXAMPLE_DATA.len() + frame_len + 12)
+            .take(16)
+        {
+            *byte ^= 0xFF;
+        }
+
+        let run = run(&damaged);
+
+        // Checked before the "did it actually break" guard below, so that
+        // removing the gap fill fails here with the sample count rather than
+        // on a counter the fill itself maintains.
+        assert_eq!(
+            run.total_samples,
+            clean.total_samples,
+            "recovery lost {} samples against the intact stream",
+            clean.total_samples as i64 - run.total_samples as i64
+        );
+        assert_eq!(
+            run.access_units.len(),
+            clean.access_units.len(),
+            "an access unit went missing from the timeline"
+        );
+        assert!(
+            run.gap_access_units > 0,
+            "the corruption no longer trips a parse failure, so this test is \
+             not exercising recovery any more"
+        );
+        assert_eq!(run.gap_samples, 40 * run.gap_access_units);
+
+        // The stand-in has to look like its neighbours, or the writer sees a
+        // format change mid-file.
+        let silent: Vec<_> = run
+            .access_units
+            .iter()
+            .filter(|au| {
+                au.pcm_data
+                    .iter()
+                    .take(au.sample_length)
+                    .all(|s| s == &[0; 16])
+            })
+            .collect();
+        assert_eq!(silent.len() as u64, run.gap_access_units);
+        for au in silent {
+            assert_eq!(au.sample_length, 40);
+            assert_eq!(au.channel_count, clean.access_units[0].channel_count);
+            assert_eq!(
+                au.sampling_frequency,
+                clean.access_units[0].sampling_frequency
+            );
+            assert!(!au.is_duplicate, "silence must not be discarded downstream");
+        }
+    }
 }


### PR DESCRIPTION
Fixes the sync drift reported upstream as [#19](https://github.com/truehdd/truehdd/issues/19) and [#25](https://github.com/truehdd/truehdd/issues/25). Neither will be fixed upstream — `truehdd/truehdd` has had no commits since 2025-08-15.

## The half that was already fixed, and the half that was not

Both issues describe two symptoms on seamless-branching titles (Disney/Fox/Pixar, Lionsgate, and similar):

1. **Decoding stops entirely** partway through — the rest of the ADM comes out silent with no panning automation.
2. **Audio drifts against the picture** — sync the head and the tail is seconds out.

Symptom 1 was already handled: `d7fe72b` made a parse failure reset the parser and skip to the next major sync instead of aborting. Symptom 2 was not, and the recovery is what causes it. Every skipped access unit is 1/1200 s that never reaches the output. The hole is permanent and accumulates at every damaged stitch point.

## The change

Emit silence of the same shape instead of dropping, on all three paths that used to drop an access unit:

- the access unit that failed to parse,
- each one skipped while hunting for the next major sync,
- a decode failure in non-strict mode.

The length comes from the last access unit that decoded cleanly. That is exact rather than approximate: TrueHD access units are a fixed 1/1200 s for a given sampling rate, and nothing in a frame we could not parse states its own length. The E-AC-3 path already did this (`eac3_thread.rs`, "substituting silence"); this brings TrueHD in line.

Silence carries no object metadata, so the last object positions stay in force across the hole — what a renderer does between events anyway.

A run that filled any gaps now says so:

```
WARN 17 access units could not be decoded and were replaced with silence
     (680 samples, 14 ms). Output length is preserved; audio stays aligned
     with the source timeline.
```

The output is no longer bit-exact to the source across the damage. It was not going to be either way; the choice is between a hole that stays put and a hole that moves everything after it.

## Measured on a real broken stream

The stream attached to upstream [#15](https://github.com/truehdd/truehdd/issues/15) reproduces this exactly — it fails to parse at frame 3996 and resyncs at 4013, 17 access units later.

|  | access units | samples written | vs. 5973 x 40 |
|---|---|---|---|
| before | 5973 | 238240 | **680 short — 14 ms of drift** |
| after | 5973 | 238920 | exact |

Stronger than the totals: the fixed `.atmos.audio` payload is **byte-identical to the old one with 680 silent samples inserted at sample 159800** —

```
after == before[:159800] + zeros(680) + before[159800:]   ->  True
```

— and sample 159800 is exactly where frame 3996 begins. The audio content is unchanged; it is only in the right place now.

The metadata partitions just as cleanly: same event count (44), the 33 events before the gap unchanged, the 11 after it shifted by exactly +680, nothing else touched.

## Tests

Two unit tests over a synthetic stream built from `truehd::process::EXAMPLE_DATA`, so CI needs no fixture:

- `clean_stream_fills_no_gaps` — an intact stream fills nothing, guarding against the fill firing spuriously.
- `undecodable_access_unit_becomes_silence_of_the_same_length` — a scrambled payload still yields the same total sample count and access-unit count as the intact stream, and the stand-ins are zero-filled with the neighbours' channel count and sampling rate.

The second was confirmed to fail without the fix (`recovery lost 80 samples against the intact stream`). Its assertions are ordered so that removing the fill fails on the sample count rather than on a counter the fill itself maintains, and it carries a guard that fails loudly if the corruption ever stops tripping a parse error.

167 tests pass, including `golden.rs`.

## Not addressed here

- **Extractor-level errors.** When the extractor itself loses framing and resyncs, we cannot tell how many access units went by, so nothing is filled. Still a possible drift source, narrower than this one.
- **No seamless-branching sample on hand.** The proof above uses a stream that is corrupt in the way #15 describes, not a Disney/Fox branch point. The mechanism is the same — skipped access units — but this has not been run against the specific titles #19 and #25 name.
- **Nobody has listened to the result.** A 14 ms silent patch at a stitch point should be inaudible, but that is an expectation, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
