### PR TITLE
docs: give the harletty CLI its own reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ It is a **plugin**: you don't run it on its own. You install
 Omniphony or mpv-omniphony, drop this file next to it, and tell the
 config where it is. That's the whole job.
 
-> **Looking for the command-line converter instead?** The same decoders
-> also ship as **`harletty`**, a standalone tool that turns TrueHD,
-> E-AC-3 JOC and DTS bitstreams into Dolby Atmos master files on disk.
-> That one you *do* run yourself — see
-> **[docs/harletty-cli.md](docs/harletty-cli.md)** for the full command
-> reference.
+> **Looking for the command-line converter instead?** This repo also
+> ships **`harletty`** — a fork of
+> [`truehdd`](https://github.com/truehdd/truehdd) by
+> [Rainbaby](https://github.com/truehdd), extended with E-AC-3 JOC and
+> DTS input — which turns those bitstreams into Dolby Atmos master files
+> on disk. That one you *do* run yourself; see
+> **[docs/harletty-cli.md](docs/harletty-cli.md)** for the command
+> reference and the provenance in detail.
 
 [![mpv-omniphony — mpv playing a TrueHD Atmos stream rendered by liborender, supervised by Omniphony Studio](https://github.com/mgth/mpv-omniphony/raw/main/mpv-omniphony-1200.png)](https://github.com/mgth/mpv-omniphony)
 
@@ -220,10 +222,15 @@ unix and `target\release\harletty_bridge.dll` on Windows. Point
 
 ## The offline `harletty` CLI
 
-The same decoders also drive a standalone tool that turns TrueHD,
-E-AC-3 JOC and DTS bitstreams into Dolby Atmos master files (`.atmos`,
-`.atmos.metadata`, plus CAF/WAV audio) — including DTS:X, exported as
-ADM. It reads a file or stdin, so it pipes straight out of ffmpeg:
+**`harletty` is a fork of [`truehdd`](https://github.com/truehdd/truehdd)
+by [Rainbaby](https://github.com/truehdd)** — 85% of the shared-lineage
+code is byte-identical to upstream, including the whole DAMF master-set
+writer and the CAF/Wave64 writers. What was added here is E-AC-3 JOC and
+DTS/DTS:X input, the latter exported as ADM.
+
+It turns those bitstreams into Dolby Atmos master files (`.atmos`,
+`.atmos.metadata`, plus CAF/WAV audio), reading a file or stdin, so it
+pipes straight out of ffmpeg:
 
 ```sh
 ffmpeg -i movie.mkv -map 0:a:0 -c copy -f truehd - \
@@ -237,12 +244,12 @@ Grab `harletty-cli-<version>-<system>.zip` from the
 [releases page](https://github.com/harletty/harletty-bridge/releases),
 or build it with `cargo build --release -p harletty`.
 
-It replaces the standalone `truehdd` fork this workspace used to carry —
-see [docs/truehdd-fork-retirement.md](docs/truehdd-fork-retirement.md)
-for what was ported and what was superseded. It is deliberately *not*
-called `truehdd` any more: it covers three format families now, and
-sharing a binary name with its upstream would mean whichever came first
-on `PATH` won.
+The rename is not a claim of authorship — it exists because the binary
+accepts a superset of upstream's inputs and writes labels upstream does
+not, so two binaries called `truehdd` on one `PATH` would be a miserable
+thing to debug. See
+[docs/truehdd-fork-retirement.md](docs/truehdd-fork-retirement.md) for
+the audit of what was ported, superseded or imported.
 
 It is also a *separate artifact*: the bridge does not link it, does not
 pay for it, and cannot reach it. That isolation is by crate graph rather
@@ -272,17 +279,30 @@ OBJECT_SIZE_NOTES.md # notes on OAMD object_size handling
 ## Credits
 
 The hard part of this project — actually decoding a TrueHD bitstream —
-is **not** our work. The `truehd/` crate is vendored, essentially
-unchanged, from [**truehdd**](https://github.com/truehdd/truehdd) by
+is **not** our work, and neither is most of the offline CLI. Both come
+from [**truehdd**](https://github.com/truehdd/truehdd) by
 [**Rainbaby**](https://github.com/truehdd), a clean-room Rust parser and
-decoder for Dolby TrueHD. Without that decoder this bridge would have
-nothing to hand to the renderer.
+decoder for Dolby TrueHD.
 
-So: huge thanks to Rainbaby and the `truehdd` project. All the credit
-for the TrueHD decode path belongs there; we just wrap it in the
-`bridge_api` ABI and bolt on the OAMD plumbing the renderer needs. If
-this plugin is useful to you, go star [`truehdd`](https://github.com/truehdd/truehdd)
-too.
+Concretely, what is Rainbaby's:
+
+- **`truehd/`** — the TrueHD parser and decoder, vendored essentially
+  unchanged. Without it this bridge would have nothing to hand to the
+  renderer.
+- **The `harletty` CLI**, which is a fork of upstream's own binary rather
+  than something built alongside it. Of the 5470 lines with a shared
+  lineage, **4655 (85%) are byte-identical to upstream**: the command
+  structure, the DAMF master-set writer, the CAF and Wave64 writers, the
+  `info` report and `truehdd-macros/` are all upstream work.
+
+What is ours: the `bridge_api` ABI wrapper and the OAMD plumbing the
+renderer needs; the `eac3` and `dca` crates; the E-AC-3 JOC and DTS/DTS:X
+routing in the CLI; and decoder robustness fixes. Upstream is Apache-2.0,
+as is this repo.
+
+So: huge thanks to Rainbaby and the `truehdd` project. **If any of this
+is useful to you, go star [`truehdd`](https://github.com/truehdd/truehdd).**
+That is where the hard part was done.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ It is a **plugin**: you don't run it on its own. You install
 Omniphony or mpv-omniphony, drop this file next to it, and tell the
 config where it is. That's the whole job.
 
+> **Looking for the command-line converter instead?** The same decoders
+> also ship as **`harletty`**, a standalone tool that turns TrueHD,
+> E-AC-3 JOC and DTS bitstreams into Dolby Atmos master files on disk.
+> That one you *do* run yourself — see
+> **[docs/harletty-cli.md](docs/harletty-cli.md)** for the full command
+> reference.
+
 [![mpv-omniphony — mpv playing a TrueHD Atmos stream rendered by liborender, supervised by Omniphony Studio](https://github.com/mgth/mpv-omniphony/raw/main/mpv-omniphony-1200.png)](https://github.com/mgth/mpv-omniphony)
 
 *mpv-omniphony decoding a TrueHD Atmos track through this bridge, with
@@ -31,7 +38,7 @@ and follow the three steps for your OS below.
 
 > Each release has one bridge file per system. Download the one that
 > matches (the `harletty-cli-*` archives alongside them are the separate
-> offline tool, not needed for playback):
+> [offline tool](docs/harletty-cli.md) — not needed for playback):
 >
 > | Your system | File to download |
 > |---|---|
@@ -213,30 +220,29 @@ unix and `target\release\harletty_bridge.dll` on Windows. Point
 
 ## The offline `harletty` CLI
 
-The same decoders also drive an offline tool that turns TrueHD, E-AC-3
-JOC and DTS bitstreams into Dolby Atmos master files (`.atmos`,
+The same decoders also drive a standalone tool that turns TrueHD,
+E-AC-3 JOC and DTS bitstreams into Dolby Atmos master files (`.atmos`,
 `.atmos.metadata`, plus CAF/WAV audio) — including DTS:X, exported as
-ADM.
+ADM. It reads a file or stdin, so it pipes straight out of ffmpeg:
+
+```sh
+ffmpeg -i movie.mkv -map 0:a:0 -c copy -f truehd - \
+  | harletty --progress decode - --output-path "movie"
+```
+
+📖 **[docs/harletty-cli.md](docs/harletty-cli.md) — commands, every
+option, output files, recipes and limitations.**
 
 Grab `harletty-cli-<version>-<system>.zip` from the
 [releases page](https://github.com/harletty/harletty-bridge/releases),
-or build it:
-
-```sh
-cargo build --release -p harletty
-./target/release/harletty decode --output-path out track.thd
-./target/release/harletty info track.eac3
-```
-
-It reads from a file or from `-` (stdin), so it pipes straight out of
-ffmpeg.
+or build it with `cargo build --release -p harletty`.
 
 It replaces the standalone `truehdd` fork this workspace used to carry —
 see [docs/truehdd-fork-retirement.md](docs/truehdd-fork-retirement.md)
 for what was ported and what was superseded. It is deliberately *not*
 called `truehdd` any more: it covers three format families now, and
-sharing a binary name with its still-active upstream would mean whichever
-came first on `PATH` won.
+sharing a binary name with its upstream would mean whichever came first
+on `PATH` won.
 
 It is also a *separate artifact*: the bridge does not link it, does not
 pay for it, and cannot reach it. That isolation is by crate graph rather

--- a/docs/harletty-cli.md
+++ b/docs/harletty-cli.md
@@ -5,16 +5,53 @@ Dolby Atmos master files — a `.atmos` presentation, its
 `.atmos.metadata` object automation, and the `.atmos.audio` bed/object
 interleave — or plain PCM when you ask for a downmix presentation.
 
-It is a **separate artifact from the bridge**. The bridge is the runtime
-plugin that plays audio; this is the batch tool that converts it. They
-share the decoder crates and nothing else — the bridge does not link the
-CLI, cannot reach it, and does not pay for its dependencies.
-`scripts/check-crate-isolation.sh` asserts that in CI.
+## Where this comes from
 
-> Formerly `truehdd`. It is deliberately not called that any more: it
-> covers three format families now, and sharing a binary name with its
-> still-active-at-the-time upstream meant whichever came first on `PATH`
-> won. See [truehdd-fork-retirement.md](truehdd-fork-retirement.md).
+**`harletty` is a fork of [`truehdd`](https://github.com/truehdd/truehdd)
+by [Rainbaby](https://github.com/truehdd).** Not a tool that borrows its
+decoder — a fork of the whole program. If you have used `truehdd`, you
+are looking at it: same commands, same options, same output files.
+
+Measured against upstream `23c9950`, the files with a shared lineage run
+**5470 lines, of which 4655 — 85% — are byte-identical to upstream**:
+
+| Part | Identical to upstream |
+|---|---|
+| `caf.rs`, `wav.rs`, `byteorder.rs`, `input.rs`, `truehdd-macros/` | 100% |
+| `cli/command.rs` | 94% |
+| `cli/decode/handler.rs` | 92% |
+| `cli/info.rs` | 90% |
+| `damf.rs` (the DAMF writer) | 79% |
+
+So: the command structure, the DAMF master-set writer, the CAF and Wave64
+writers, the `info` report and the proc macros behind it are Rainbaby's
+work, carried here essentially unchanged. Everything this page documents
+about `decode` and `info` describes their design.
+
+What was added on this side is the routing for the two formats upstream
+does not cover — E-AC-3 JOC and DTS/DTS:X, about 2250 lines
+(`eac3_to_oamd.rs`, `dts_to_oamd.rs`, `codec_probe.rs` and their handler
+and thread pairs) — plus decoder robustness work and the damaged-stream
+handling described [below](#damaged-streams).
+
+The rename is not a claim of authorship. It exists because the binary
+now accepts a superset of inputs and writes labels upstream does not, so
+two binaries called `truehdd` on one `PATH` would be a miserable thing to
+debug. Upstream is Apache-2.0 and so is this; see
+[truehdd-fork-retirement.md](truehdd-fork-retirement.md) for the full
+audit of what was ported, superseded or imported.
+
+**If this tool is useful to you, go star
+[`truehdd`](https://github.com/truehdd/truehdd).** That is where the hard
+part was done.
+
+## Relationship to the bridge
+
+It is a **separate artifact**. The bridge is the runtime plugin that
+plays audio; this is the batch tool that converts it. They share the
+decoder crates and nothing else — the bridge does not link the CLI,
+cannot reach it, and does not pay for its dependencies.
+`scripts/check-crate-isolation.sh` asserts that in CI.
 
 ## Install
 

--- a/docs/harletty-cli.md
+++ b/docs/harletty-cli.md
@@ -1,0 +1,215 @@
+# The `harletty` CLI
+
+Offline decoder for TrueHD, E-AC-3 JOC and DTS bitstreams. It writes
+Dolby Atmos master files — a `.atmos` presentation, its
+`.atmos.metadata` object automation, and the `.atmos.audio` bed/object
+interleave — or plain PCM when you ask for a downmix presentation.
+
+It is a **separate artifact from the bridge**. The bridge is the runtime
+plugin that plays audio; this is the batch tool that converts it. They
+share the decoder crates and nothing else — the bridge does not link the
+CLI, cannot reach it, and does not pay for its dependencies.
+`scripts/check-crate-isolation.sh` asserts that in CI.
+
+> Formerly `truehdd`. It is deliberately not called that any more: it
+> covers three format families now, and sharing a binary name with its
+> still-active-at-the-time upstream meant whichever came first on `PATH`
+> won. See [truehdd-fork-retirement.md](truehdd-fork-retirement.md).
+
+## Install
+
+Download `harletty-cli-<version>-<system>.zip` from the
+[releases page](https://github.com/harletty/harletty-bridge/releases)
+and unzip it anywhere. It is a single self-contained binary.
+
+Or build it:
+
+```sh
+cargo build --release -p harletty
+./target/release/harletty --version
+```
+
+## Commands
+
+```
+harletty [GLOBAL OPTIONS] <COMMAND>
+
+  decode   Decode a stream into audio + Atmos master files
+  info     Print stream information and exit
+  help     Print help for a command
+```
+
+### Global options
+
+Accepted before or after the subcommand.
+
+| Option | Values | Default | What it does |
+|---|---|---|---|
+| `--codec` | `auto`, `truehd`, `eac3`, `dts` | `auto` | Input format. `auto` detects by sync word; override it when the probe guesses wrong on a headerless pipe. |
+| `--loglevel` | `off`, `error`, `warn`, `info`, `debug`, `trace` | `info` | `warn` is the useful floor: it still surfaces the timeline warning described under [Damaged streams](#damaged-streams). |
+| `--log-format` | `plain`, `json` | `plain` | `json` emits one structured record per line, for scripted callers. |
+| `--strict` | flag | off | Treat warnings as fatal and stop at the first one. Use it to *audit* a stream, not to convert it — a normal Blu-ray rip trips warnings that do not affect the output. |
+| `--progress` | flag | off | Progress bars on stderr. |
+
+### `decode`
+
+```sh
+harletty decode [OPTIONS] <INPUT>
+```
+
+`<INPUT>` is a file, or `-` to read stdin.
+
+| Option | Values | Default | What it does |
+|---|---|---|---|
+| `--output-path <PATH>` | path prefix | *(none)* | Base name for the outputs — extensions are appended, so `--output-path out` writes `out.atmos`, `out.atmos.audio`, … With no `--output-path`, the stream is decoded and validated but nothing is written. |
+| `--format` | `caf`, `pcm`, `w64` | `caf` | Audio container. **Ignored for Atmos output**, which is always CAF; see [Output files](#output-files). `pcm` is raw 24-bit little-endian, `w64` is Wave64 with a `.wav` extension. |
+| `--no-audio` | flag | off | Skip the audio file; still write `.atmos` and `.atmos.metadata`. Much faster when you only want the object automation. |
+| `--presentation <0-3>` | index | `3` | Which TrueHD presentation to decode. `3` is the 16-channel Atmos presentation; `0`–`2` are the stereo/5.1/7.1 downmixes carried in the same stream. **TrueHD only** — silently ignored for E-AC-3 and DTS, which have no equivalent. |
+| `--bed-conform` | flag | off | Force the Atmos bed to a conformant 7.1.2 layout. |
+| `--warp-mode` | `normal`, `warping`, `prologiciix`, `loro` | *(from stream)* | Downmix warp mode to declare when the metadata does not carry one. |
+| `--no-estimate-progress` | flag | off | Skip the pre-pass that counts frames for the progress bar. Automatic for stdin, which cannot be pre-scanned. |
+
+### `info`
+
+```sh
+harletty info <INPUT>
+```
+
+Prints the stream configuration and exits without decoding audio. The
+report is shaped per codec — TrueHD lists its presentations, E-AC-3
+reports the frame's own configuration.
+
+TrueHD:
+
+```
+TrueHD Stream Information
+=========================
+
+Stream Information
+  Format Sync               F8726FBA
+  Sampling rate             48000 Hz
+  Peak data rate            8412 kbps
+  Number of substreams      4
+  Dolby Atmos               true
+
+Presentation Information
+  Presentation 0
+    Number of channels      2
+    Presentation type       Downmix of presentation 1
+  …
+```
+
+E-AC-3:
+
+```
+Codec        : EAC3 (Dolby Digital Plus)
+Bitstream ID : 16
+Frame type   : independent
+Sample rate  : 48000 Hz
+Channel mode : 5 ch + LFE
+OAMD         : yes
+JOC          : yes
+Frames seen  : 47
+```
+
+## Output files
+
+What lands on disk depends on whether the result is object audio.
+
+**Atmos** (presentation 3 with objects present, or E-AC-3 JOC, or DTS:X)
+— a DAMF master set, which is what Resolve, Pro Tools and the Dolby
+Reference Player consume:
+
+| File | Contents |
+|---|---|
+| `<base>.atmos` | The presentation: channel/object declarations, trims, frame rate, and the names of the other two files. |
+| `<base>.atmos.metadata` | Per-event object automation, timestamped in samples. |
+| `<base>.atmos.audio` | Interleaved bed + object audio, CAF. |
+
+**Non-Atmos** (presentation 0–2, or a stream with no objects) — a single
+audio file named from `--format`: `<base>.caf`, `<base>.pcm` or
+`<base>.wav`.
+
+`--format` is ignored for the Atmos case, with an `info` log line saying
+so. That is not a limitation of this tool: the DAMF spec pins the audio
+member to CAF.
+
+## Recipes
+
+**Straight conversion.**
+
+```sh
+harletty --progress decode --output-path "movie" movie.thd
+```
+
+**Out of a container, without a temporary file.** `harletty` reads
+stdin, so pipe ffmpeg into it:
+
+```sh
+ffmpeg -i movie.mkv -map 0:a:0 -c copy -f truehd - \
+  | harletty --progress decode - --output-path "movie"
+```
+
+**Object automation only**, skipping the (much larger, much slower)
+audio member:
+
+```sh
+harletty --loglevel error decode --no-audio --output-path "movie" movie.thd
+```
+
+**A stereo downmix as a plain wav**, from the same stream:
+
+```sh
+harletty decode --presentation 0 --format w64 --output-path "movie-stereo" movie.thd
+```
+
+**Machine-readable logs** for a batch runner:
+
+```sh
+harletty --log-format json --loglevel warn decode - --output-path "$base" < stream.thd
+```
+
+## Damaged streams
+
+Real rips are not always clean — seamless-branching titles in particular
+stitch segments together in ways that leave malformed access units at the
+joins.
+
+By default `harletty` recovers instead of aborting: on a parse failure it
+resets and resumes at the next major sync, and the access units it could
+not decode are **replaced with silence of the same duration** rather than
+dropped. Dropping them would shorten the output and slide everything
+after the damage earlier against the picture — permanently, and
+cumulatively at every damaged join.
+
+A run that had to do this says so at `warn`:
+
+```
+WARN 17 access units could not be decoded and were replaced with silence
+     (680 samples, 14 ms). Output length is preserved; audio stays aligned
+     with the source timeline.
+```
+
+Read that as: the output is no longer bit-exact to the source across
+those 14 ms, but it is still in sync. If you would rather the run failed
+loudly than substituted anything, use `--strict`.
+
+Errors at the *extractor* level — where framing itself is lost and the
+decoder resynchronises — are not compensated this way, because the number
+of access units that went by is unknowable. They remain a possible source
+of drift.
+
+## Known limitations
+
+- **DTS:X object positions are not decoded.** Spatial presentations are
+  exported with their channel layout and labels, but objects sit at
+  static positions; the per-frame trajectories live in a proprietary
+  extension block that this decoder does not read. A DTS:X master set is
+  therefore fine for layout inspection and useless for anything that
+  measures movement.
+- **ffmpeg cannot open the 6-channel CAF files this writer produces.**
+  12-channel files are fine. This predates the rename and is not a
+  regression — the reference implementation emits byte-identical headers
+  that ffmpeg rejects the same way.
+- **`--presentation` is TrueHD-only** and is accepted-then-ignored for
+  the other codecs rather than rejected.


### PR DESCRIPTION
The `harletty` CLI was a paragraph at the bottom of the bridge README. That is the wrong place for it twice over: someone arriving for the converter has to scroll past a plugin install guide to find it, and there was nowhere to put an option reference.

## What this adds

**`docs/harletty-cli.md`** — the full reference:

- both commands (`decode`, `info`), with every global and per-command option in a table: what it takes, what it defaults to, and what it actually does
- **what lands on disk**, which is the thing the old paragraph left implicit — a DAMF master set (`.atmos` + `.atmos.metadata` + `.atmos.audio`) for object audio, a single `.caf`/`.pcm`/`.wav` for a downmix presentation, and why `--format` is ignored in the first case
- worked recipes: straight conversion, the ffmpeg pipe, metadata-only, a stereo downmix, JSON logs for a batch runner
- a **Damaged streams** section explaining the silence substitution that landed in #20, including how to read the warning and that `--strict` opts out of it
- known limitations stated plainly: DTS:X objects are static, ffmpeg cannot open the 6-channel CAF this writer emits, `--presentation` is accepted-then-ignored for non-TrueHD

**README** — three pointers: a callout in the intro for people who want the converter rather than the plugin, a link from the release-asset table, and the existing section trimmed to a pitch plus a link (it kept the rename rationale and the crate-isolation note, which belong with the bridge).

## Everything here was run, not read

Each documented behaviour was checked against the built binary rather than inferred from the source:

| Claim | Checked |
|---|---|
| ffmpeg pipe recipe | `ffmpeg … -f truehd - \| harletty decode -` → 3 artifacts written |
| `--presentation 0 --format w64` | writes `stereo.wav` |
| `--log-format json` | one record per line, `{"ts":…,"lvl":"WARN","msg":…}` |
| `--strict` on a damaged stream | exits 1 |
| `decode` with no `--output-path` | exit 0, zero files written |
| `info` output shape | **differs by codec** — TrueHD lists presentations, E-AC-3 reports frame config. Both samples are in the page; I had originally documented only the TrueHD shape and corrected it after running the E-AC-3 case. |
| `--presentation` on E-AC-3/DTS | confirmed in `decode_impl.rs` that those paths return before the presentation check, i.e. ignored rather than rejected |

Relative links resolve from both files.

One thing I deliberately left out: `RUST_MIN_STACK`, which Atmos Ranker sets when invoking this binary. It appears nowhere in the source and I could not explain why it would be needed, so documenting it would have been cargo-culting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
