### PR TITLE
Fix AC-3 coupling band range and mono decode, remove a decode-path panic

### DIFF
--- a/bridge/src/eac3_pipeline.rs
+++ b/bridge/src/eac3_pipeline.rs
@@ -865,16 +865,19 @@ mod tests {
     /// Local-only end-to-end check: decode a real non-JOC E-AC3 7.1 stream
     /// (AC-3 core + dependent) through the full bridge and confirm it now emits a
     /// non-silent multichannel bed (it used to drop the pair → silence). Skips
-    /// gracefully when the local capture is absent. Writes the decoded PCM to
-    /// `/tmp/aladdin/harletty_bridge.f32` for `compare_pcm` against ffmpeg.
+    /// gracefully when the local capture is absent. Writes the decoded PCM next
+    /// to the fixture as `<fixture>.harletty_bridge.f32` for `compare_pcm`
+    /// against ffmpeg. The fixture path can be overridden with
+    /// `HARLETTY_EAC3_PAIR_FIXTURE` — keep such captures on disk, not tmpfs.
     #[test]
     fn aladdin_eac3_pair_emits_nonsilent_bed() {
         use crate::bridge::AtmosBridge;
         use abi_stable::std_types::RSlice;
         use bridge_api::{FormatBridge, RInputTransport};
 
-        let path = "/tmp/aladdin/fr.eac3";
-        let Ok(bytes) = std::fs::read(path) else {
+        let path = std::env::var("HARLETTY_EAC3_PAIR_FIXTURE")
+            .unwrap_or_else(|_| "/tmp/aladdin/fr.eac3".to_string());
+        let Ok(bytes) = std::fs::read(&path) else {
             eprintln!("skip: {path} not present");
             return;
         };
@@ -901,18 +904,20 @@ mod tests {
         }
         eprintln!("labels: {labels}");
 
-        assert!(frames > 0, "no frames decoded from the E-AC3 pair stream");
-        assert!(channels >= 6, "expected >= 5.1, got {channels} channels");
         let peak = pcm_f32.iter().fold(0.0f32, |m, &s| m.max(s.abs()));
-        assert!(peak > 1e-4, "decoded bed is silent (peak={peak})");
         eprintln!("decoded {frames} frames, {channels} ch, peak={peak:.4}");
+        // Dump before asserting so an ad-hoc fixture (other layouts fed via
+        // HARLETTY_EAC3_PAIR_FIXTURE) still leaves PCM to compare against ffmpeg.
         let _ = std::fs::write(
-            "/tmp/aladdin/harletty_bridge.f32",
+            format!("{path}.harletty_bridge.f32"),
             pcm_f32
                 .iter()
                 .flat_map(|s| s.to_le_bytes())
                 .collect::<Vec<u8>>(),
         );
+        assert!(frames > 0, "no frames decoded from the E-AC3 pair stream");
+        assert!(channels >= 6, "expected >= 5.1, got {channels} channels");
+        assert!(peak > 1e-4, "decoded bed is silent (peak={peak})");
     }
 
     /// Local-only end-to-end check: decode a real DTS (DTS-HD MA / DTS:X) stream

--- a/eac3/src/eac3dec/allocation.rs
+++ b/eac3/src/eac3dec/allocation.rs
@@ -371,14 +371,22 @@ impl AllocationState {
             DeltaBitAllocationMode::Reuse | DeltaBitAllocationMode::NewInfoFollows
         ) {
             let mut band = bnd_start;
-            for index in 0..delta.offsets.len() {
-                band += delta.offsets[index];
-                let delta_mask = if delta.bit_allocation[index] >= 4 {
-                    ((delta.bit_allocation[index] as i32) - 3) << 7
+            // Iterate the zipped segments so a partially-read state (e.g. a
+            // ShortPacket mid read_segments that a later Reuse block picks up)
+            // can never index out of bounds — audio paths must not panic.
+            for ((&offset, &length), &bits) in delta
+                .offsets
+                .iter()
+                .zip(&delta.lengths)
+                .zip(&delta.bit_allocation)
+            {
+                band += offset;
+                let delta_mask = if bits >= 4 {
+                    ((bits as i32) - 3) << 7
                 } else {
-                    ((delta.bit_allocation[index] as i32) - 4) << 7
+                    ((bits as i32) - 4) << 7
                 };
-                for _ in 0..delta.lengths[index] {
+                for _ in 0..length {
                     let Some(mask) = self.mask.get_mut(band) else {
                         break;
                     };

--- a/eac3/src/eac3dec/syncframe.rs
+++ b/eac3/src/eac3dec/syncframe.rs
@@ -2054,13 +2054,6 @@ fn read_legacy_ac3_coupling_strategy(
     audio_frame: &mut AudioFrameInfo,
     state: &mut BlockSyntaxState,
 ) -> Result<(), ParseError> {
-    if channel_mode <= 1 {
-        audio_frame.coupling_strategy_updates[block] = false;
-        audio_frame.coupling_in_use[block] = false;
-        state.clear_coupling();
-        return Ok(());
-    }
-
     let update = reader.read_bit().ok_or(ParseError::ShortPacket)?;
     if block == 0 && !update {
         return Err(ParseError::InvalidHeader("cplstrat"));
@@ -2068,6 +2061,13 @@ fn read_legacy_ac3_coupling_strategy(
     audio_frame.coupling_strategy_updates[block] = update;
     if update {
         let in_use = reader.read_bit().ok_or(ParseError::ShortPacket)?;
+        // Legacy AC-3 transmits cplstre/cplinu in every audblk regardless of
+        // acmod — mono and dual-mono included (skipping them desyncs the whole
+        // block). Coupling itself needs two full-bandwidth channels, so
+        // cplinu=1 there is invalid data (FFmpeg errors identically).
+        if in_use && channel_mode <= 1 {
+            return Err(ParseError::InvalidHeader("cpl-mono"));
+        }
         audio_frame.coupling_in_use[block] = in_use;
         state.ecplinu = false;
         if in_use {
@@ -4346,6 +4346,44 @@ mod tests {
         assert_eq!(state.ncplsubnd, 2);
         assert_eq!(state.ncplbnd, 1); // band 1 folded into band 0
         assert_eq!(reader.position(), 16); // every strategy bit consumed
+    }
+
+    /// Legacy AC-3 transmits cplstre/cplinu in every audblk regardless of
+    /// acmod — mono included. Skipping the bits desyncs the whole block
+    /// (real-world mono BD tracks then fail every frame).
+    #[test]
+    fn legacy_coupling_reads_strategy_bits_in_mono() {
+        let mut bits = Vec::new();
+        push_bits(&mut bits, 1, 1); // cplstre
+        push_bits(&mut bits, 0, 1); // cplinu = 0 (mandatory in mono)
+        let bytes = bits_to_bytes(&bits, 1);
+
+        let mut reader = super::BitReader::new(&bytes);
+        let mut audio_frame = super::legacy_ac3_audio_frame_info(0, 1, false);
+        let mut state = BlockSyntaxState::new(1, false, 0);
+        super::read_legacy_ac3_coupling_strategy(&mut reader, 0, 1, 1, &mut audio_frame, &mut state)
+            .expect("mono coupling strategy bits must parse");
+        assert!(!audio_frame.coupling_in_use[0]);
+        assert_eq!(reader.position(), 2); // cplstre + cplinu consumed
+
+        // cplinu=1 with fewer than two full-bandwidth channels is invalid data.
+        let mut bits = Vec::new();
+        push_bits(&mut bits, 1, 1); // cplstre
+        push_bits(&mut bits, 1, 1); // cplinu = 1
+        let bytes = bits_to_bytes(&bits, 1);
+        let mut reader = super::BitReader::new(&bytes);
+        let mut audio_frame = super::legacy_ac3_audio_frame_info(0, 1, false);
+        let mut state = BlockSyntaxState::new(1, false, 0);
+        let err = super::read_legacy_ac3_coupling_strategy(
+            &mut reader,
+            0,
+            1,
+            1,
+            &mut audio_frame,
+            &mut state,
+        )
+        .expect_err("coupling in mono must be rejected");
+        assert!(matches!(err, ParseError::InvalidHeader("cpl-mono")));
     }
 
     /// An empty coupling range is a hard parse error: silently clearing

--- a/eac3/src/eac3dec/syncframe.rs
+++ b/eac3/src/eac3dec/syncframe.rs
@@ -2086,10 +2086,14 @@ fn read_legacy_ac3_coupling_strategy(
             };
             state.cplbegf = reader.read_bits(4).ok_or(ParseError::ShortPacket)? as usize;
             state.cplendf = reader.read_bits(4).ok_or(ParseError::ShortPacket)? as usize;
-            if state.cplendf < state.cplbegf {
-                state.clear_coupling();
-                audio_frame.coupling_in_use[block] = false;
-                return Ok(());
+            // The coupled subband range is [cplbegf, cplendf + 3), so
+            // `cplendf < cplbegf` alone is legal (high-band coupling with up to
+            // 2 subbands). Only an empty range is invalid, and it must be a
+            // hard error: bailing out mid-syntax would desync every field
+            // after cplbndstrc (FFmpeg ac3dec.c rejects
+            // `cpl_start_subband >= cpl_end_subband` the same way).
+            if state.cplbegf >= state.cplendf + 3 {
+                return Err(ParseError::InvalidHeader("cpl-band-range"));
             }
             state.ncplsubnd = 3 + state.cplendf - state.cplbegf;
             state.ncplbnd = state.ncplsubnd;
@@ -2431,15 +2435,15 @@ fn read_coupling_strategy(
                 state.spxbegf * 2 - 7
             };
 
-            if state.cplendf < state.cplbegf {
-                state.clear_coupling();
-                return Ok(());
+            // Same range rule as legacy AC-3: coupled subbands span
+            // [cplbegf, cplendf + 3), so only an empty range is invalid, and
+            // continuing after clearing coupling would desync the remaining
+            // block syntax.
+            if state.cplbegf >= state.cplendf + 3 {
+                return Err(ParseError::InvalidHeader("cpl-band-range"));
             }
 
             state.ncplsubnd = 3 + state.cplendf - state.cplbegf;
-            if state.ncplsubnd == 0 {
-                return Err(ParseError::InvalidHeader("ncplsubnd"));
-            }
             state.ncplbnd = state.ncplsubnd;
 
             if reader.read_bit().ok_or(ParseError::ShortPacket)? {
@@ -4308,5 +4312,68 @@ mod tests {
         for bin in 205..256 {
             assert!(coeffs[bin].abs() < 1e-6);
         }
+    }
+
+    /// The coupled subband range is [cplbegf, cplendf + 3), so `cplendf <
+    /// cplbegf` alone is a legal high-band coupling configuration (BD-style
+    /// DD+ 7.1 cores encode e.g. cplbegf=13/cplendf=12 on nearly every
+    /// frame). Rejecting it desyncs the whole remaining block syntax.
+    #[test]
+    fn legacy_coupling_accepts_high_band_range() {
+        let fullband_channels = 5usize;
+        let mut bits = Vec::new();
+        push_bits(&mut bits, 1, 1); // cplstre
+        push_bits(&mut bits, 1, 1); // cplinu
+        push_bits(&mut bits, 0b11111, 5); // chincpl, all coupled
+        push_bits(&mut bits, 13, 4); // cplbegf
+        push_bits(&mut bits, 12, 4); // cplendf -> ncplsubnd = 2
+        push_bits(&mut bits, 1, 1); // cplbndstrc for band 1
+        let bytes = bits_to_bytes(&bits, 4);
+
+        let mut reader = super::BitReader::new(&bytes);
+        let mut audio_frame = super::legacy_ac3_audio_frame_info(0, fullband_channels, true);
+        let mut state = BlockSyntaxState::new(fullband_channels, true, 0);
+        super::read_legacy_ac3_coupling_strategy(
+            &mut reader,
+            0,
+            7,
+            fullband_channels,
+            &mut audio_frame,
+            &mut state,
+        )
+        .expect("high-band coupling range must parse");
+        assert!(audio_frame.coupling_in_use[0]);
+        assert_eq!(state.ncplsubnd, 2);
+        assert_eq!(state.ncplbnd, 1); // band 1 folded into band 0
+        assert_eq!(reader.position(), 16); // every strategy bit consumed
+    }
+
+    /// An empty coupling range is a hard parse error: silently clearing
+    /// coupling and returning Ok would leave the reader misaligned for every
+    /// field after cplbndstrc.
+    #[test]
+    fn legacy_coupling_rejects_empty_range() {
+        let fullband_channels = 5usize;
+        let mut bits = Vec::new();
+        push_bits(&mut bits, 1, 1); // cplstre
+        push_bits(&mut bits, 1, 1); // cplinu
+        push_bits(&mut bits, 0b11111, 5); // chincpl
+        push_bits(&mut bits, 15, 4); // cplbegf
+        push_bits(&mut bits, 0, 4); // cplendf -> ncplsubnd would be -12
+        let bytes = bits_to_bytes(&bits, 4);
+
+        let mut reader = super::BitReader::new(&bytes);
+        let mut audio_frame = super::legacy_ac3_audio_frame_info(0, fullband_channels, true);
+        let mut state = BlockSyntaxState::new(fullband_channels, true, 0);
+        let err = super::read_legacy_ac3_coupling_strategy(
+            &mut reader,
+            0,
+            7,
+            fullband_channels,
+            &mut audio_frame,
+            &mut state,
+        )
+        .expect_err("empty coupling range must be rejected");
+        assert!(matches!(err, ParseError::InvalidHeader("cpl-band-range")));
     }
 }


### PR DESCRIPTION
## Problem

Playing a BD-style DD+ 7.1 track (legacy AC-3 5.1 core + E-AC-3 dependent substream, no JOC) through the bridge produced a loud full-scale burst (~40 ms) at the start, then permanent silence for the whole track. Reported on Windows with both ASIO and WASAPI hosts; decoding the same track with FFmpeg was fine. Legacy AC-3 mono tracks were also unplayable (every frame failed), and one of them triggered an out-of-bounds panic in the decode path — fatal for the host player since the bridge runs in-process.

## Root causes

**Coupling band range (commit 1).** The coupled subband range is `[cplbegf, cplendf + 3)`, so `cplendf < cplbegf` alone is a legal configuration (up to 2 subbands of high-band coupling). Both `read_legacy_ac3_coupling_strategy` and the E-AC-3 `read_coupling_strategy` treated it as invalid, cleared coupling and returned `Ok` mid-syntax, leaving the bit reader misaligned for every field after `cplbndstrc`. The affected stream encodes `cplbegf=13 / cplendf=12` on nearly every core frame, so every core failed (`invalid-header:chbwcod` or `short-packet`), the core/dependent pairing never happened, and the bridge substituted silence for the whole track. The full-scale burst came from the rare misaligned parses that happened to "succeed" with garbage exponents/mantissas. Fixed by aligning with FFmpeg `ac3dec.c` (reject only `cpl_start_subband >= cpl_end_subband`) and making a genuinely empty range a hard `ParseError` instead of a silent desync.

**Mono decode + panic (commit 2).** Legacy AC-3 transmits `cplstre`/`cplinu` in every audio block regardless of acmod — mono and dual-mono included. The parser early-returned for `channel_mode <= 1` without consuming those bits, desyncing every block. The desynced parses also exposed a panic: a `ShortPacket` in the middle of `DeltaBitAllocationState::read_segments` leaves `offsets`/`lengths`/`bit_allocation` with different lengths, and a later `Reuse` block indexed past the shorter vector. Fixed by reading the bits (with `cplinu=1` below two full-bandwidth channels rejected as invalid data, matching FFmpeg) and iterating the zipped delta segments so a partial state can never panic.

## Validation

- 7.1 hybrid sample (60 s): 1875/1875 core+dependent pairs decode into a proper 8-channel bed `[L, C, R, Ls, Rs, Lb, Rb, LFE]`, peak 0.30 (no clipping, no burst); per-channel correlation vs FFmpeg >= 0.9994 at lag 0, unity gain (residual is decoder-specific mantissa dither). Two more previously-failing 7.1/5.1 captures re-verified.
- Three mono AC-3 BD tracks: all decode with correlation 1.000000 and identical RMS vs `ffmpeg -drc_scale 0` (the bridge defers DRC downstream by design).
- Three new unit tests pin the rules (legal high-band range parses and consumes every strategy bit; empty range is a hard error; mono consumes `cplstre`/`cplinu` and rejects `cplinu=1`).
- Full workspace test suites pass (bridge 55, eac3 33, harletty 24).

Also makes the local pair-decode test fixture path overridable via `HARLETTY_EAC3_PAIR_FIXTURE` (large captures belong on disk, not tmpfs) and dumps the decoded PCM before asserting so ad-hoc fixtures of other layouts still produce a reference for FFmpeg comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)