### PR TITLE
Dispatch legacy AC-3 cores in the CLI E-AC-3 decode thread

### DIFF
--- a/bridge/src/eac3_pipeline.rs
+++ b/bridge/src/eac3_pipeline.rs
@@ -112,73 +112,21 @@ pub(crate) fn process_eac3_frame(
     }
 }
 
-/// Speaker positions a dependent-substream `chanmap` carries, in coded-channel
-/// order (MSB→LSB; pair bits emit left then right). Only the bits that map to a
-/// concrete bed position are emitted — enough for the common 5.1/7.1 channel
-/// extensions (e.g. 0x1A00 = Ls, Rs, Lrs/Rrs).
-fn dependent_chanmap_positions(chanmap: u16) -> Vec<BedChannel> {
-    use BedChannel::*;
-    const TABLE: &[(u16, &[BedChannel])] = &[
-        (1 << 15, &[FrontLeft]),
-        (1 << 14, &[Center]),
-        (1 << 13, &[FrontRight]),
-        (1 << 12, &[SurroundLeft]),
-        (1 << 11, &[SurroundRight]),
-        (1 << 9, &[RearLeft, RearRight]), // Lrs/Rrs (back surrounds)
-        (1 << 8, &[RearCenter]),          // Cs
-        (1 << 5, &[WideLeft, WideRight]), // Lw/Rw
-    ];
-    let mut out = Vec::new();
-    for &(bit, chans) in TABLE {
-        if chanmap & bit != 0 {
-            out.extend_from_slice(chans);
-        }
-    }
-    out
-}
-
 /// Merge a decoded core (5.1) with its dependent E-AC3 substream — the discrete
-/// surround/back channels of a 7.1 extension — into one bed, placing the
-/// dependent's channels by its `chanmap`. Returns `None` (caller falls back to
-/// the core alone) when the dependent can't be decoded or doesn't line up.
+/// surround/back channels of a 7.1 extension — into one bed, via the shared
+/// [`eac3::merge_core_with_dependent`] helper (also used by the harletty CLI).
+/// Returns `None` (caller falls back to the core alone) when the dependent
+/// can't be decoded or doesn't line up.
 fn merge_eac3_core_with_dependent(
     bridge: &mut AtmosBridge,
     core: &CorePcmFrame,
     dependent_frame: &[u8],
 ) -> Option<CorePcmFrame> {
-    let dep = bridge
-        .eac3_dependent_pcm_decoder
-        .push_access_unit(dependent_frame)
-        .ok()?;
-    let positions = dependent_chanmap_positions(dep.info.dependent_channel_map?);
-    let dep_pcm = dep.pcm;
-    if positions.len() != dep_pcm.fullband_channels.len()
-        || dep_pcm.samples_per_channel() != core.samples_per_channel()
-    {
-        return None;
-    }
-
-    // Start from the core's fullband channels, then overlay the dependent's:
-    // replace a position the core also carried (discrete side surrounds) or
-    // append a new one (the back pair).
-    let mut order: Vec<BedChannel> = core.fullband_channel_order.clone();
-    let mut chans: Vec<Vec<f32>> = core.fullband_channels.clone();
-    for (i, &pos) in positions.iter().enumerate() {
-        match order.iter().position(|&b| b == pos) {
-            Some(idx) => chans[idx] = dep_pcm.fullband_channels[i].clone(),
-            None => {
-                order.push(pos);
-                chans.push(dep_pcm.fullband_channels[i].clone());
-            }
-        }
-    }
-
-    Some(CorePcmFrame {
-        sample_rate: core.sample_rate,
-        fullband_channel_order: order,
-        fullband_channels: chans,
-        lfe_channel: core.lfe_channel.clone(),
-    })
+    eac3::merge_core_with_dependent(
+        &mut bridge.eac3_dependent_pcm_decoder,
+        core,
+        dependent_frame,
+    )
 }
 
 pub(crate) fn process_eac3_dependent_frame_with_core(
@@ -967,20 +915,6 @@ mod tests {
                 .iter()
                 .flat_map(|s| s.to_le_bytes())
                 .collect::<Vec<u8>>(),
-        );
-    }
-
-    #[test]
-    fn chanmap_0x1a00_maps_to_side_and_back_surrounds() {
-        // The common 7.1 channel-extension chanmap (Ls, Rs, Lrs/Rrs).
-        assert_eq!(
-            dependent_chanmap_positions(0x1A00),
-            vec![
-                BedChannel::SurroundLeft,
-                BedChannel::SurroundRight,
-                BedChannel::RearLeft,
-                BedChannel::RearRight,
-            ]
         );
     }
 

--- a/eac3/src/eac3dec/mod.rs
+++ b/eac3/src/eac3dec/mod.rs
@@ -17,6 +17,7 @@ pub use metadata::{
 };
 pub use pcm::{
     CorePcmFrame, ObjectPcmDecoder, ObjectPcmFrame, ObjectPcmPushResult, PcmDecoder, PcmPushResult,
+    dependent_chanmap_positions, merge_core_with_dependent,
 };
 pub use syncframe::{
     AccessUnitInfo, AudioFrameInfo, AuxParseStatus, BlockDrcInfo, EmdfBlockInfo, EmdfPayloadInfo,

--- a/eac3/src/eac3dec/pcm.rs
+++ b/eac3/src/eac3dec/pcm.rs
@@ -34,6 +34,72 @@ impl CorePcmFrame {
     }
 }
 
+/// Speaker positions a dependent-substream `chanmap` carries, in coded-channel
+/// order (MSB→LSB; pair bits emit left then right). Only the bits that map to a
+/// concrete bed position are emitted — enough for the common 5.1/7.1 channel
+/// extensions (e.g. 0x1A00 = Ls, Rs, Lrs/Rrs).
+pub fn dependent_chanmap_positions(chanmap: u16) -> Vec<BedChannel> {
+    use BedChannel::*;
+    const TABLE: &[(u16, &[BedChannel])] = &[
+        (1 << 15, &[FrontLeft]),
+        (1 << 14, &[Center]),
+        (1 << 13, &[FrontRight]),
+        (1 << 12, &[SurroundLeft]),
+        (1 << 11, &[SurroundRight]),
+        (1 << 9, &[RearLeft, RearRight]), // Lrs/Rrs (back surrounds)
+        (1 << 8, &[RearCenter]),          // Cs
+        (1 << 5, &[WideLeft, WideRight]), // Lw/Rw
+    ];
+    let mut out = Vec::new();
+    for &(bit, chans) in TABLE {
+        if chanmap & bit != 0 {
+            out.extend_from_slice(chans);
+        }
+    }
+    out
+}
+
+/// Merge a decoded core (5.1) with its dependent E-AC-3 substream — the discrete
+/// surround/back channels of a 7.1 extension — into one bed, placing the
+/// dependent's channels by its `chanmap`. Returns `None` (caller falls back to
+/// the core alone) when the dependent can't be decoded or doesn't line up.
+pub fn merge_core_with_dependent(
+    dependent_decoder: &mut PcmDecoder,
+    core: &CorePcmFrame,
+    dependent_frame: &[u8],
+) -> Option<CorePcmFrame> {
+    let dep = dependent_decoder.push_access_unit(dependent_frame).ok()?;
+    let positions = dependent_chanmap_positions(dep.info.dependent_channel_map?);
+    let dep_pcm = dep.pcm;
+    if positions.len() != dep_pcm.fullband_channels.len()
+        || dep_pcm.samples_per_channel() != core.samples_per_channel()
+    {
+        return None;
+    }
+
+    // Start from the core's fullband channels, then overlay the dependent's:
+    // replace a position the core also carried (discrete side surrounds) or
+    // append a new one (the back pair).
+    let mut order: Vec<BedChannel> = core.fullband_channel_order.clone();
+    let mut chans: Vec<Vec<f32>> = core.fullband_channels.clone();
+    for (i, &pos) in positions.iter().enumerate() {
+        match order.iter().position(|&b| b == pos) {
+            Some(idx) => chans[idx] = dep_pcm.fullband_channels[i].clone(),
+            None => {
+                order.push(pos);
+                chans.push(dep_pcm.fullband_channels[i].clone());
+            }
+        }
+    }
+
+    Some(CorePcmFrame {
+        sample_rate: core.sample_rate,
+        fullband_channel_order: order,
+        fullband_channels: chans,
+        lfe_channel: core.lfe_channel.clone(),
+    })
+}
+
 #[derive(Debug, Clone, PartialEq)]
 /// Object-audio PCM plus the metadata that was active for the same access unit.
 ///
@@ -388,5 +454,24 @@ impl ObjectPcmDecoder {
                 oamd_payloads,
             },
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chanmap_0x1a00_maps_to_side_and_back_surrounds() {
+        // The common 7.1 channel-extension chanmap (Ls, Rs, Lrs/Rrs).
+        assert_eq!(
+            dependent_chanmap_positions(0x1A00),
+            vec![
+                BedChannel::SurroundLeft,
+                BedChannel::SurroundRight,
+                BedChannel::RearLeft,
+                BedChannel::RearRight,
+            ]
+        );
     }
 }

--- a/eac3/src/lib.rs
+++ b/eac3/src/lib.rs
@@ -8,10 +8,11 @@ mod types;
 pub use eac3dec::{
     AccessUnitInfo, AudioFrameInfo, AuxParseStatus, BlockDrcInfo, CorePcmFrame, Decoder,
     EmdfBlockInfo, EmdfPayloadInfo, EmdfSource, FrameType, JocObject, JocObjectData, JocPayload,
-    OamdBlockUpdate, OamdElement, OamdElementKind, OamdObjectBlock, OamdObjectElement,
-    OamdPayload, ObjectPcmDecoder, ObjectPcmFrame, ObjectPcmPushResult,
-    ParseError as AccessUnitParseError, ParsedEmdfPayloadData, ParsedEmdfPayloadKind, PayloadInfo,
-    PcmDecoder, PcmPushResult, PushResult, SkipFieldInfo, inspect_access_unit,
+    OamdBlockUpdate, OamdElement, OamdElementKind, OamdObjectBlock, OamdObjectElement, OamdPayload,
+    ObjectPcmDecoder, ObjectPcmFrame, ObjectPcmPushResult, ParseError as AccessUnitParseError,
+    ParsedEmdfPayloadData, ParsedEmdfPayloadKind, PayloadInfo, PcmDecoder, PcmPushResult,
+    PushResult, SkipFieldInfo, dependent_chanmap_positions, inspect_access_unit,
+    merge_core_with_dependent,
 };
 pub use extract::{ExtractError, Extractor, Frame};
 pub use parser::{

--- a/harletty/src/cli/decode/eac3_thread.rs
+++ b/harletty/src/cli/decode/eac3_thread.rs
@@ -2,8 +2,8 @@ use super::eac3_handler::Eac3FrameMessage;
 use crate::input::InputReader;
 use anyhow::Result;
 use eac3::{
-    AccessUnitInfo, AccessUnitParseError, ExtractError, Extractor, Frame, FrameType,
-    ObjectPcmDecoder, PcmDecoder, PcmPushResult, inspect_access_unit,
+    AccessUnitParseError, ExtractError, Extractor, Frame, FrameType, ObjectPcmDecoder, PcmDecoder,
+    PcmPushResult, inspect_access_unit, merge_core_with_dependent,
 };
 use indicatif::ProgressBar;
 use std::path::PathBuf;
@@ -16,6 +16,27 @@ pub struct Eac3DecoderThreadConfig {
     pub prefix: Vec<u8>,
     pub tx: mpsc::Sender<Result<Eac3FrameMessage>>,
     pub pb_clone: Option<ProgressBar>,
+}
+
+/// Cross-frame decode state for one E-AC-3 stream.
+///
+/// Legacy AC-3 cores and dependent substreams each get a dedicated
+/// [`PcmDecoder`] so their bitstream state never mixes with the independent
+/// E-AC-3 stream's — mirroring the bridge's `ac3_decoder` /
+/// `eac3_dependent_pcm_decoder` split.
+#[derive(Default)]
+struct DecoderState {
+    object_decoder: ObjectPcmDecoder,
+    pcm_decoder: PcmDecoder,
+    ac3_core_decoder: PcmDecoder,
+    dependent_pcm_decoder: PcmDecoder,
+    /// Core of the last decoded (and already emitted) independent E-AC-3
+    /// frame, kept in case the next frame is a JOC dependent.
+    pending_independent_core: Option<eac3::CorePcmFrame>,
+    /// Decoded legacy AC-3 core (bsid <= 10) buffered — not yet emitted —
+    /// until we see whether the next access unit is its dependent partner.
+    pending_ac3_core: Option<PcmPushResult>,
+    frame_count: u64,
 }
 
 pub fn spawn_eac3_decoder_thread(
@@ -31,10 +52,7 @@ pub fn spawn_eac3_decoder_thread(
         } = config;
 
         let mut extractor = Extractor::default();
-        let mut object_decoder = ObjectPcmDecoder::default();
-        let mut pcm_decoder = PcmDecoder::default();
-        let mut frame_count: u64 = 0;
-        let mut pending_independent_core: Option<eac3::CorePcmFrame> = None;
+        let mut state = DecoderState::default();
 
         if !prefix.is_empty() {
             extractor.push_bytes(&prefix);
@@ -45,16 +63,7 @@ pub fn spawn_eac3_decoder_thread(
         // the remaining stream. For piped input, the prefix is the head we already buffered.
         let result = input_reader.process_chunks(64 * 1024, |chunk| {
             extractor.push_bytes(chunk);
-            drain_frames(
-                &mut extractor,
-                &mut object_decoder,
-                &mut pcm_decoder,
-                &mut pending_independent_core,
-                &mut frame_count,
-                &pb_clone,
-                strict_mode,
-                &tx,
-            )
+            drain_frames(&mut extractor, &mut state, &pb_clone, strict_mode, &tx)
         });
 
         if result.is_err() {
@@ -62,29 +71,22 @@ pub fn spawn_eac3_decoder_thread(
         }
 
         // Final drain after EOF.
-        drain_frames(
-            &mut extractor,
-            &mut object_decoder,
-            &mut pcm_decoder,
-            &mut pending_independent_core,
-            &mut frame_count,
-            &pb_clone,
-            strict_mode,
-            &tx,
-        )?;
+        drain_frames(&mut extractor, &mut state, &pb_clone, strict_mode, &tx)?;
 
-        log::info!("EAC3 decode complete: {frame_count} frames");
+        // A trailing AC-3 core whose dependent partner never arrived (stream
+        // truncated mid-pair): emit it as a standalone 5.1 bed.
+        if let Some(core) = state.pending_ac3_core.take() {
+            emit_standalone_ac3_core(core, &mut state.frame_count, &pb_clone, &tx);
+        }
+
+        log::info!("EAC3 decode complete: {} frames", state.frame_count);
         Ok(())
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 fn drain_frames(
     extractor: &mut Extractor,
-    object_decoder: &mut ObjectPcmDecoder,
-    pcm_decoder: &mut PcmDecoder,
-    pending_independent_core: &mut Option<eac3::CorePcmFrame>,
-    frame_count: &mut u64,
+    state: &mut DecoderState,
     pb: &Option<ProgressBar>,
     strict_mode: bool,
     tx: &mpsc::Sender<Result<Eac3FrameMessage>>,
@@ -92,16 +94,7 @@ fn drain_frames(
     loop {
         match extractor.next_frame() {
             Ok(Some(frame)) => {
-                handle_frame(
-                    &frame,
-                    object_decoder,
-                    pcm_decoder,
-                    pending_independent_core,
-                    frame_count,
-                    pb,
-                    strict_mode,
-                    tx,
-                )?;
+                handle_frame(&frame, state, pb, strict_mode, tx)?;
             }
             Ok(None) => return Ok(true),
             Err(ExtractError::InvalidHeader(err)) => {
@@ -114,60 +107,112 @@ fn drain_frames(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn handle_frame(
     frame: &Frame,
-    object_decoder: &mut ObjectPcmDecoder,
-    pcm_decoder: &mut PcmDecoder,
-    pending_independent_core: &mut Option<eac3::CorePcmFrame>,
-    frame_count: &mut u64,
+    state: &mut DecoderState,
     pb: &Option<ProgressBar>,
     strict_mode: bool,
     tx: &mpsc::Sender<Result<Eac3FrameMessage>>,
 ) -> Result<()> {
     let bytes = frame.as_bytes();
 
-    let frame_type = inspect_access_unit(bytes)
-        .ok()
-        .map(|info: AccessUnitInfo| info.frame_type);
+    // `inspect_access_unit` rejects legacy AC-3 syncframes (bsid <= 10) with
+    // `NotEac3` — that rejection IS the legacy detection.
+    let (frame_type, is_legacy_ac3) = match inspect_access_unit(bytes) {
+        Ok(info) => (Some(info.frame_type), false),
+        Err(AccessUnitParseError::NotEac3) => (None, true),
+        Err(_) => (None, false),
+    };
+    let is_dependent = matches!(frame_type, Some(FrameType::Dependent));
 
-    // Dependent substream: decode against the previously decoded independent core.
-    if matches!(frame_type, Some(FrameType::Dependent)) {
-        if let Some(core) = pending_independent_core.take() {
-            match object_decoder.push_access_unit_with_core(bytes, core.clone()) {
+    // A buffered AC-3 core is only ever paired with an *immediately* following
+    // dependent access unit. Any other frame type means the buffered core had
+    // no partner (plain AC-3 never carries dependents) — emit it as a
+    // standalone 5.1 bed before handling this unit, otherwise the core sits
+    // buffered forever and the output is short.
+    if !is_dependent {
+        if let Some(core) = state.pending_ac3_core.take() {
+            emit_standalone_ac3_core(core, &mut state.frame_count, pb, tx);
+        }
+    }
+
+    // Legacy AC-3 core: decode with the dedicated AC-3 decoder and buffer it
+    // until the next access unit tells us whether it has a dependent partner
+    // (BD-style DD+ 7.1 delivers [AC-3 5.1 core, E-AC-3 dependent] pairs).
+    if is_legacy_ac3 {
+        match state.ac3_core_decoder.push_legacy_ac3_access_unit(bytes) {
+            Ok(result) => {
+                state.pending_ac3_core = Some(result);
+                return Ok(());
+            }
+            Err(err) => {
+                return surface_decode_err(
+                    err,
+                    strict_mode,
+                    tx,
+                    pb,
+                    &mut state.frame_count,
+                    &frame.info(),
+                );
+            }
+        }
+    }
+
+    if is_dependent {
+        // Pair a buffered legacy AC-3 core with this dependent substream.
+        if let Some(core_result) = state.pending_ac3_core.take() {
+            return handle_ac3_core_pair(core_result, frame, state, pb, strict_mode, tx);
+        }
+
+        // Dependent following an independent E-AC-3 frame: decode against the
+        // previously decoded (and already emitted) independent core.
+        if let Some(core) = state.pending_independent_core.take() {
+            match state
+                .object_decoder
+                .push_access_unit_with_core(bytes, core.clone())
+            {
                 Ok(Some(obj)) => {
-                    *frame_count += 1;
+                    state.frame_count += 1;
                     tick_progress(pb);
                     let _ = tx.send(Ok(Eac3FrameMessage::Object(obj)));
                     return Ok(());
                 }
                 Ok(None) => {
                     // No JOC on dependent frame — emit the core we already have.
-                    *frame_count += 1;
+                    state.frame_count += 1;
                     tick_progress(pb);
                     let info = match inspect_access_unit(bytes) {
                         Ok(i) => i,
                         Err(_) => return Ok(()),
                     };
                     let push = PcmPushResult {
-                        frames_seen: *frame_count,
+                        frames_seen: state.frame_count,
                         info,
                         pcm: core,
                     };
                     let _ = tx.send(Ok(Eac3FrameMessage::Core(push)));
                     return Ok(());
                 }
-                Err(err) => return surface_decode_err(err, strict_mode, tx, pb, frame_count, &frame.info()),
+                Err(err) => {
+                    return surface_decode_err(
+                        err,
+                        strict_mode,
+                        tx,
+                        pb,
+                        &mut state.frame_count,
+                        &frame.info(),
+                    );
+                }
             }
         }
     }
 
     // Try object decode first (independent frame with JOC).
-    match object_decoder.push_access_unit(bytes) {
+    match state.object_decoder.push_access_unit(bytes) {
         Ok(Some(obj)) => {
-            *frame_count += 1;
+            state.frame_count += 1;
             tick_progress(pb);
-            *pending_independent_core = Some(obj.pcm.core.clone());
+            state.pending_independent_core = Some(obj.pcm.core.clone());
             let _ = tx.send(Ok(Eac3FrameMessage::Object(obj)));
             return Ok(());
         }
@@ -175,20 +220,117 @@ fn handle_frame(
             // No JOC — fall through to core PCM decode.
         }
         Err(err) => {
-            return surface_decode_err(err, strict_mode, tx, pb, frame_count, &frame.info());
+            return surface_decode_err(
+                err,
+                strict_mode,
+                tx,
+                pb,
+                &mut state.frame_count,
+                &frame.info(),
+            );
         }
     }
 
-    match pcm_decoder.push_access_unit(bytes) {
+    match state.pcm_decoder.push_access_unit(bytes) {
         Ok(result) => {
-            *frame_count += 1;
+            state.frame_count += 1;
             tick_progress(pb);
-            *pending_independent_core = Some(result.pcm.clone());
+            state.pending_independent_core = Some(result.pcm.clone());
             let _ = tx.send(Ok(Eac3FrameMessage::Core(result)));
         }
-        Err(err) => return surface_decode_err(err, strict_mode, tx, pb, frame_count, &frame.info()),
+        Err(err) => {
+            return surface_decode_err(
+                err,
+                strict_mode,
+                tx,
+                pb,
+                &mut state.frame_count,
+                &frame.info(),
+            );
+        }
     }
     Ok(())
+}
+
+/// Decode a dependent substream against the buffered legacy AC-3 core it
+/// belongs to. JOC dependents (DD+ Atmos with a backward-compatible AC-3 core)
+/// go through the object decoder; non-JOC pairs are a plain channel-extension
+/// bed, merged into a full 7.1 frame (falling back to the 5.1 core alone if
+/// the merge fails — never silent).
+fn handle_ac3_core_pair(
+    core_result: PcmPushResult,
+    frame: &Frame,
+    state: &mut DecoderState,
+    pb: &Option<ProgressBar>,
+    strict_mode: bool,
+    tx: &mpsc::Sender<Result<Eac3FrameMessage>>,
+) -> Result<()> {
+    let bytes = frame.as_bytes();
+    let dep_info = match inspect_access_unit(bytes) {
+        Ok(info) => info,
+        Err(err) => {
+            return surface_decode_err(
+                err,
+                strict_mode,
+                tx,
+                pb,
+                &mut state.frame_count,
+                &frame.info(),
+            );
+        }
+    };
+
+    if dep_info.joc_payload_count() > 0 {
+        match state
+            .object_decoder
+            .push_access_unit_with_core(bytes, core_result.pcm.clone())
+        {
+            Ok(Some(obj)) => {
+                state.frame_count += 1;
+                tick_progress(pb);
+                let _ = tx.send(Ok(Eac3FrameMessage::Object(obj)));
+                return Ok(());
+            }
+            Ok(None) => {
+                // No object payload after all — fall through to the channel bed.
+            }
+            Err(err) => {
+                return surface_decode_err(
+                    err,
+                    strict_mode,
+                    tx,
+                    pb,
+                    &mut state.frame_count,
+                    &frame.info(),
+                );
+            }
+        }
+    }
+
+    let bed = merge_core_with_dependent(&mut state.dependent_pcm_decoder, &core_result.pcm, bytes)
+        .unwrap_or(core_result.pcm);
+    state.frame_count += 1;
+    tick_progress(pb);
+    let push = PcmPushResult {
+        frames_seen: state.frame_count,
+        info: dep_info,
+        pcm: bed,
+    };
+    let _ = tx.send(Ok(Eac3FrameMessage::Core(push)));
+    Ok(())
+}
+
+/// Emit a buffered legacy AC-3 core that had no dependent partner as a plain
+/// 5.1 bed.
+fn emit_standalone_ac3_core(
+    core: PcmPushResult,
+    frame_count: &mut u64,
+    pb: &Option<ProgressBar>,
+    tx: &mpsc::Sender<Result<Eac3FrameMessage>>,
+) {
+    *frame_count += 1;
+    tick_progress(pb);
+    let _ = tx.send(Ok(Eac3FrameMessage::Core(core)));
 }
 
 fn surface_decode_err(


### PR DESCRIPTION
## Problem

`harletty --codec eac3 decode` fed every access unit straight into the E-AC-3 decoders, which reject legacy AC-3 syncframes (bsid <= 10) with `NotEac3`. On BD-style E-AC-3 7.1 streams (legacy AC-3 5.1 core + E-AC-3 dependent substream) every core frame logged `EAC3 decode error (substituting silence): NotEac3` and the output file was silent. The realtime bridge already dispatched these correctly (`is_legacy_ac3_frame` + dedicated AC-3 decoder + core/dependent pairing); the CLI decode thread never did.

## Changes

- **`harletty` CLI (`eac3_thread.rs`)**: port the bridge's dispatch.
  - Legacy cores are detected via `inspect_access_unit`'s `NotEac3` rejection, decoded with a dedicated `PcmDecoder`, and buffered until the next access unit shows whether it has a dependent partner.
  - A buffered core is paired with an immediately following dependent: JOC dependents go through the object decoder with the injected core; non-JOC pairs merge the dependent's discrete surround/back channels onto the 5.1 core for a full 7.1 bed, falling back to the core alone if the merge fails (never silent).
  - Unpaired cores are flushed as standalone 5.1 beds (plain AC-3 never carries dependents), including a trailing core at EOF, so plain AC-3 files keep their exact length.
  - The loose decoder arguments are grouped into a `DecoderState` struct.
- **`eac3` crate**: the core/dependent merge moves here from the bridge (`merge_core_with_dependent` + `dependent_chanmap_positions`, with the chanmap unit test) so both consumers share one implementation.
- **bridge**: `merge_eac3_core_with_dependent` now delegates to the shared helper; behavior unchanged.

## Verification

Against `ffmpeg -drc_scale 0` on local captures:

- 60 s BD E-AC-3 7.1 capture (previously all-silent): decodes to discrete 8 ch, every CLI channel matches a distinct ffmpeg channel with correlation >= 0.9998 (residual is the 24-bit WAV quantization), exact 60.000 s duration, zero silence substitutions.
- Plain AC-3 capture: correlation ~1.0, exact duration (the EOF flush keeps the trailing frame).
- `cargo test -p eac3 -p harletty-bridge -p harletty`: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)