### PR TITLE
Harden E-AC-3 decode paths against corrupt streams

### DIFF
--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -44,9 +44,18 @@ pub(crate) struct Eac3DiagStats {
     /// Standalone AC-3 cores (plain AC-3, no dependent) emitted as 5.1 beds.
     pub(crate) standalone_ac3_core_beds: u64,
     pub(crate) short_packet_silence_frames: u64,
+    /// Dependent frames evicted because the pending queue hit its bound
+    /// (their AC-3 cores kept failing to decode).
+    pub(crate) dependent_frames_dropped: u64,
     pub(crate) last_ac3_core_decode_error: Option<String>,
     pub(crate) last_dependent_pair_error: Option<String>,
 }
+
+/// Upper bound on buffered dependent access units awaiting an AC-3 core
+/// partner. In a healthy stream the queue never holds more than one entry;
+/// it only grows while cores fail to decode, so keep a small window and drop
+/// the oldest beyond it.
+const MAX_PENDING_DEPENDENT_FRAMES: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum DrcMode {
@@ -442,6 +451,18 @@ impl AtmosBridge {
         }
 
         let decode_result = if is_dependent_eac3_frame(frame) {
+            // A dependent is normally paired with its core immediately, so the
+            // queue holds at most one entry. It only grows when cores keep
+            // failing to decode; bound it so a corrupt stream cannot grow it
+            // without limit for the whole playback session.
+            while self.pending_dependent_frames.len() >= MAX_PENDING_DEPENDENT_FRAMES {
+                self.pending_dependent_frames.pop_front();
+                self.eac3_diag_stats.dependent_frames_dropped += 1;
+                bridge_diag_log(
+                    log::Level::Warn,
+                    "eac3_dependent_queue_overflow dropping oldest pending dependent frame",
+                );
+            }
             self.pending_dependent_frames.push_back(frame.to_vec());
             match self.try_decode_pending_eac3_pair() {
                 Some(decoded_frame) => Ok(decoded_frame),

--- a/bridge/src/frame_builders.rs
+++ b/bridge/src/frame_builders.rs
@@ -65,7 +65,7 @@ pub(crate) fn float_to_pcm_i32(sample: f32) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::PcmStats;
+    use super::{PcmStats, float_to_pcm_i32};
     use abi_stable::std_types::RVec;
     use bridge_api::{RChannelLabel, RDecodedFrame};
 
@@ -107,5 +107,19 @@ mod tests {
         let frame = decoded_frame(16, 2, vec![i32::MAX; 32]);
         let err = PcmStats::from_frame(&frame).expect_err("frame should be rejected");
         assert!(err.starts_with("too_many_near_clip_samples"));
+    }
+
+    /// The output boundary must map non-finite decoder output to silence and
+    /// clamp everything else to 24-bit full scale — this is the last guard
+    /// between a decoder bug and the user's speakers.
+    #[test]
+    fn float_to_pcm_i32_guards_non_finite_and_out_of_range_samples() {
+        assert_eq!(float_to_pcm_i32(f32::NAN), 0);
+        assert_eq!(float_to_pcm_i32(f32::INFINITY), 0);
+        assert_eq!(float_to_pcm_i32(f32::NEG_INFINITY), 0);
+        assert_eq!(float_to_pcm_i32(1.0e9), 8_388_607);
+        assert_eq!(float_to_pcm_i32(-1.0e9), -8_388_607);
+        assert_eq!(float_to_pcm_i32(0.0), 0);
+        assert_eq!(float_to_pcm_i32(0.5), 4_194_303);
     }
 }

--- a/eac3/fuzz/.gitignore
+++ b/eac3/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/eac3/fuzz/Cargo.toml
+++ b/eac3/fuzz/Cargo.toml
@@ -1,0 +1,34 @@
+# Fuzz targets for the stateful E-AC-3/AC-3 decoders. Not part of the root
+# workspace (the empty [workspace] table below keeps it standalone) and not
+# built by CI; run locally with a nightly toolchain:
+#
+#   cargo +nightly fuzz run push_access_unit
+#   cargo +nightly fuzz run push_legacy_ac3_access_unit
+[package]
+name = "eac3-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+eac3 = { path = ".." }
+
+[[bin]]
+name = "push_access_unit"
+path = "fuzz_targets/push_access_unit.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "push_legacy_ac3_access_unit"
+path = "fuzz_targets/push_legacy_ac3_access_unit.rs"
+test = false
+doc = false
+bench = false
+
+[workspace]

--- a/eac3/fuzz/fuzz_targets/push_access_unit.rs
+++ b/eac3/fuzz/fuzz_targets/push_access_unit.rs
@@ -1,0 +1,25 @@
+// Fuzz the stateful E-AC-3 decode entry points. The decoder runs in-process
+// inside the player, so any panic here is a player crash in the field.
+//
+// The decoders are kept alive across inputs on purpose: cross-frame state
+// (IMDCT delay, coupling/SPX reuse flags, JOC differential state) is exactly
+// where partially-decoded hostile frames can plant corruption.
+#![no_main]
+
+use eac3::{ObjectPcmDecoder, PcmDecoder};
+use libfuzzer_sys::fuzz_target;
+use std::cell::RefCell;
+
+thread_local! {
+    static PCM: RefCell<PcmDecoder> = RefCell::new(PcmDecoder::new());
+    static OBJECT: RefCell<ObjectPcmDecoder> = RefCell::new(ObjectPcmDecoder::new());
+}
+
+fuzz_target!(|data: &[u8]| {
+    PCM.with(|d| {
+        let _ = d.borrow_mut().push_access_unit(data);
+    });
+    OBJECT.with(|d| {
+        let _ = d.borrow_mut().push_access_unit(data);
+    });
+});

--- a/eac3/fuzz/fuzz_targets/push_legacy_ac3_access_unit.rs
+++ b/eac3/fuzz/fuzz_targets/push_legacy_ac3_access_unit.rs
@@ -1,0 +1,17 @@
+// Fuzz the legacy AC-3 decode entry point (see push_access_unit.rs for why
+// the decoder is kept alive across inputs).
+#![no_main]
+
+use eac3::PcmDecoder;
+use libfuzzer_sys::fuzz_target;
+use std::cell::RefCell;
+
+thread_local! {
+    static PCM: RefCell<PcmDecoder> = RefCell::new(PcmDecoder::new());
+}
+
+fuzz_target!(|data: &[u8]| {
+    PCM.with(|d| {
+        let _ = d.borrow_mut().push_legacy_ac3_access_unit(data);
+    });
+});

--- a/eac3/src/eac3dec/pcm.rs
+++ b/eac3/src/eac3dec/pcm.rs
@@ -174,6 +174,14 @@ impl PcmDecoder {
     /// Reset all cross-frame decode state.
     pub fn reset(&mut self) {
         self.frames_seen = 0;
+        self.reset_decode_state();
+    }
+
+    /// Reset the cross-frame bitstream state (IMDCT overlap-add delay, block
+    /// syntax, metadata sequencing) without touching `frames_seen`. A failed
+    /// decode can leave this state partially mutated, so it must never be
+    /// carried into the next frame.
+    fn reset_decode_state(&mut self) {
         self.aux_state.reset();
         self.core_state.reset();
         self.metadata_state.reset();
@@ -208,7 +216,17 @@ impl PcmDecoder {
     }
 
     /// Decode one complete access unit into core PCM.
+    ///
+    /// On `Err`, the decoder's cross-frame state is reset: a failed decode may
+    /// have left it partially mutated, and reusing it would corrupt every
+    /// following frame (stale IMDCT overlap-add delay, stale coupling state).
     pub fn push_access_unit(&mut self, access_unit: &[u8]) -> Result<PcmPushResult, ParseError> {
+        self.push_access_unit_inner(access_unit).inspect_err(|_| {
+            self.reset_decode_state();
+        })
+    }
+
+    fn push_access_unit_inner(&mut self, access_unit: &[u8]) -> Result<PcmPushResult, ParseError> {
         self.apply_debug_log_level();
         let info = inspect_access_unit_with_metadata_state(
             access_unit,
@@ -239,7 +257,20 @@ impl PcmDecoder {
     }
 
     /// Decode one complete legacy AC-3 syncframe into core PCM.
+    ///
+    /// On `Err`, the decoder's cross-frame state is reset (see
+    /// [`PcmDecoder::push_access_unit`]).
     pub fn push_legacy_ac3_access_unit(
+        &mut self,
+        access_unit: &[u8],
+    ) -> Result<PcmPushResult, ParseError> {
+        self.push_legacy_ac3_access_unit_inner(access_unit)
+            .inspect_err(|_| {
+                self.reset_decode_state();
+            })
+    }
+
+    fn push_legacy_ac3_access_unit_inner(
         &mut self,
         access_unit: &[u8],
     ) -> Result<PcmPushResult, ParseError> {
@@ -305,6 +336,12 @@ impl ObjectPcmDecoder {
     /// Reset all cross-frame decode state.
     pub fn reset(&mut self) {
         self.frames_seen = 0;
+        self.reset_decode_state();
+    }
+
+    /// Reset the cross-frame bitstream state without touching `frames_seen`
+    /// (see [`PcmDecoder`]'s private counterpart).
+    fn reset_decode_state(&mut self) {
         self.aux_state.reset();
         self.core_state.reset();
         self.joc_state.reset();
@@ -337,7 +374,19 @@ impl ObjectPcmDecoder {
     ///
     /// Returns `Ok(None)` when the frame is valid E-AC-3 but does not contain the object payloads
     /// needed for this stage.
+    ///
+    /// On `Err`, the decoder's cross-frame state is reset (see
+    /// [`PcmDecoder::push_access_unit`]).
     pub fn push_access_unit(
+        &mut self,
+        access_unit: &[u8],
+    ) -> Result<Option<ObjectPcmPushResult>, ParseError> {
+        self.push_access_unit_inner(access_unit).inspect_err(|_| {
+            self.reset_decode_state();
+        })
+    }
+
+    fn push_access_unit_inner(
         &mut self,
         access_unit: &[u8],
     ) -> Result<Option<ObjectPcmPushResult>, ParseError> {
@@ -397,7 +446,21 @@ impl ObjectPcmDecoder {
     }
 
     /// Decode dynamic object PCM from a dependent access unit using externally decoded core PCM.
+    ///
+    /// On `Err`, the decoder's cross-frame state is reset (see
+    /// [`PcmDecoder::push_access_unit`]).
     pub fn push_access_unit_with_core(
+        &mut self,
+        access_unit: &[u8],
+        core: CorePcmFrame,
+    ) -> Result<Option<ObjectPcmPushResult>, ParseError> {
+        self.push_access_unit_with_core_inner(access_unit, core)
+            .inspect_err(|_| {
+                self.reset_decode_state();
+            })
+    }
+
+    fn push_access_unit_with_core_inner(
         &mut self,
         access_unit: &[u8],
         core: CorePcmFrame,

--- a/eac3/tests/decoder_hardening.rs
+++ b/eac3/tests/decoder_hardening.rs
@@ -1,0 +1,116 @@
+// Hardening guards for the stateful decoders:
+//
+// 1. A decode error must reset the decoder's cross-frame state (IMDCT
+//    overlap-add delay, coupling/SPX reuse flags, JOC differential state).
+//    A failed decode leaves that state partially mutated; carrying it into
+//    the next frame corrupts every frame that follows — in the field this
+//    turned one bad frame after a corrupt seek into a full-scale burst.
+// 2. The decoders must never panic on hostile input. They run in-process
+//    inside the player, so a panic kills playback entirely. The mutation
+//    sweep below is a deterministic, CI-friendly complement to the fuzz
+//    targets in `fuzz/`.
+
+use eac3::{ObjectPcmDecoder, PcmDecoder};
+
+const FIXTURE: &[u8] = include_bytes!("data/short_packet_independent_joc.bin");
+
+#[test]
+fn pcm_decoder_error_resets_cross_frame_state() {
+    let mut decoder = PcmDecoder::default();
+    decoder
+        .push_access_unit(FIXTURE)
+        .expect("fixture must decode");
+    assert!(
+        !decoder.last_chinspx().is_empty(),
+        "a decoded frame must leave block syntax state behind"
+    );
+    let frames_before = decoder.frames_seen();
+
+    // Truncated frame: rejected with an error after the header parse.
+    decoder
+        .push_access_unit(&FIXTURE[..FIXTURE.len() - 64])
+        .expect_err("truncated frame must be rejected");
+
+    assert!(
+        decoder.last_chinspx().is_empty(),
+        "an error must reset cross-frame decode state"
+    );
+    assert_eq!(
+        decoder.frames_seen(),
+        frames_before,
+        "the accepted-frame count must survive an error"
+    );
+
+    // The decoder must accept clean frames again after the error.
+    decoder
+        .push_access_unit(FIXTURE)
+        .expect("decoder must recover after an error");
+}
+
+#[test]
+fn object_decoder_recovers_after_error() {
+    let mut decoder = ObjectPcmDecoder::default();
+    decoder
+        .push_access_unit(FIXTURE)
+        .expect("fixture must decode")
+        .expect("fixture carries JOC objects");
+
+    decoder
+        .push_access_unit(&FIXTURE[..FIXTURE.len() - 64])
+        .expect_err("truncated frame must be rejected");
+
+    decoder
+        .push_access_unit(FIXTURE)
+        .expect("decoder must recover after an error")
+        .expect("fixture carries JOC objects");
+}
+
+/// Minimal deterministic PRNG (xorshift64*) so the sweep is reproducible.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 >> 12;
+        self.0 ^= self.0 << 25;
+        self.0 ^= self.0 >> 27;
+        self.0.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn below(&mut self, bound: usize) -> usize {
+        (self.next() % bound as u64) as usize
+    }
+}
+
+/// Feed byte-flipped and truncated variants of a real frame into every push
+/// entry point. Any input may be rejected; none may panic, and the decoder
+/// must still accept the clean fixture afterwards.
+#[test]
+fn mutated_frames_never_panic() {
+    let mut rng = Rng(0x9E37_79B9_7F4A_7C15);
+    let mut pcm = PcmDecoder::default();
+    let mut object = ObjectPcmDecoder::default();
+    let mut legacy = PcmDecoder::default();
+
+    for _ in 0..1500 {
+        let mut frame = FIXTURE.to_vec();
+        for _ in 0..=rng.below(8) {
+            let index = rng.below(frame.len());
+            frame[index] ^= rng.next() as u8;
+        }
+        // Half the runs also truncate, mimicking a corrupt seek that hands
+        // the parser a partial access unit.
+        if rng.below(2) == 0 {
+            frame.truncate(2 + rng.below(frame.len() - 1));
+        }
+
+        let _ = pcm.push_access_unit(&frame);
+        let _ = object.push_access_unit(&frame);
+        let _ = legacy.push_legacy_ac3_access_unit(&frame);
+    }
+
+    pcm.push_access_unit(FIXTURE)
+        .expect("PCM decoder must still work after the sweep");
+    object
+        .push_access_unit(FIXTURE)
+        .expect("object decoder must still work after the sweep");
+}

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -444,5 +444,10 @@ impl DtsDecodeHandler {
 
 #[inline]
 fn float_to_i24(sample: f32) -> i32 {
+    // NaN must map to silence, not rely on `as`-cast saturation semantics:
+    // a decoder bug upstream must never turn into full-scale output.
+    if !sample.is_finite() {
+        return 0;
+    }
     (sample.clamp(-1.0, 1.0) * I24_MAX) as i32
 }

--- a/harletty/src/cli/decode/eac3_handler.rs
+++ b/harletty/src/cli/decode/eac3_handler.rs
@@ -301,5 +301,10 @@ impl Eac3DecodeHandler {
 
 #[inline]
 fn float_to_i24(sample: f32) -> i32 {
+    // NaN must map to silence, not rely on `as`-cast saturation semantics:
+    // a decoder bug upstream must never turn into full-scale output.
+    if !sample.is_finite() {
+        return 0;
+    }
     (sample.clamp(-1.0, 1.0) * I24_MAX) as i32
 }

--- a/harletty/src/cli/decode/eac3_thread.rs
+++ b/harletty/src/cli/decode/eac3_thread.rs
@@ -146,14 +146,7 @@ fn handle_frame(
                 return Ok(());
             }
             Err(err) => {
-                return surface_decode_err(
-                    err,
-                    strict_mode,
-                    tx,
-                    pb,
-                    &mut state.frame_count,
-                    &frame.info(),
-                );
+                return surface_decode_err(err, strict_mode, tx, pb, state, &frame.info());
             }
         }
     }
@@ -194,14 +187,7 @@ fn handle_frame(
                     return Ok(());
                 }
                 Err(err) => {
-                    return surface_decode_err(
-                        err,
-                        strict_mode,
-                        tx,
-                        pb,
-                        &mut state.frame_count,
-                        &frame.info(),
-                    );
+                    return surface_decode_err(err, strict_mode, tx, pb, state, &frame.info());
                 }
             }
         }
@@ -220,14 +206,7 @@ fn handle_frame(
             // No JOC — fall through to core PCM decode.
         }
         Err(err) => {
-            return surface_decode_err(
-                err,
-                strict_mode,
-                tx,
-                pb,
-                &mut state.frame_count,
-                &frame.info(),
-            );
+            return surface_decode_err(err, strict_mode, tx, pb, state, &frame.info());
         }
     }
 
@@ -239,14 +218,7 @@ fn handle_frame(
             let _ = tx.send(Ok(Eac3FrameMessage::Core(result)));
         }
         Err(err) => {
-            return surface_decode_err(
-                err,
-                strict_mode,
-                tx,
-                pb,
-                &mut state.frame_count,
-                &frame.info(),
-            );
+            return surface_decode_err(err, strict_mode, tx, pb, state, &frame.info());
         }
     }
     Ok(())
@@ -269,14 +241,7 @@ fn handle_ac3_core_pair(
     let dep_info = match inspect_access_unit(bytes) {
         Ok(info) => info,
         Err(err) => {
-            return surface_decode_err(
-                err,
-                strict_mode,
-                tx,
-                pb,
-                &mut state.frame_count,
-                &frame.info(),
-            );
+            return surface_decode_err(err, strict_mode, tx, pb, state, &frame.info());
         }
     };
 
@@ -295,14 +260,7 @@ fn handle_ac3_core_pair(
                 // No object payload after all — fall through to the channel bed.
             }
             Err(err) => {
-                return surface_decode_err(
-                    err,
-                    strict_mode,
-                    tx,
-                    pb,
-                    &mut state.frame_count,
-                    &frame.info(),
-                );
+                return surface_decode_err(err, strict_mode, tx, pb, state, &frame.info());
             }
         }
     }
@@ -338,15 +296,27 @@ fn surface_decode_err(
     strict_mode: bool,
     tx: &mpsc::Sender<Result<Eac3FrameMessage>>,
     pb: &Option<ProgressBar>,
-    frame_count: &mut u64,
+    state: &mut DecoderState,
     info: &eac3::FrameInfo,
 ) -> Result<()> {
+    // The frame that failed is dropped from every decoder's point of view, so
+    // this is a stream discontinuity: cross-frame state (IMDCT overlap-add
+    // delay, coupling/SPX reuse flags, JOC differential state) must not be
+    // carried into the frames that follow, and buffered partial pairs are
+    // stale.
+    state.object_decoder.reset();
+    state.pcm_decoder.reset();
+    state.ac3_core_decoder.reset();
+    state.dependent_pcm_decoder.reset();
+    state.pending_independent_core = None;
+    state.pending_ac3_core = None;
+
     let msg = format!("{err:?}");
     if strict_mode {
         return Err(anyhow::anyhow!("EAC3 decode error: {msg}"));
     }
     log::warn!("EAC3 decode error (substituting silence): {msg}");
-    *frame_count += 1;
+    state.frame_count += 1;
     tick_progress(pb);
     let _ = tx.send(Ok(Eac3FrameMessage::Silence {
         sample_count: info.samples as usize,


### PR DESCRIPTION
Hardening follow-up to #23/#24. No change to the decode of clean streams (re-validated against the local sample set: hybrid 7.1 pair still decodes 1875 frames peak 0.30, mono AC-3 still corr=1.0 vs `ffmpeg -drc_scale 0`).

## Reset decoder state after errors
A failed decode leaves cross-frame state partially mutated (IMDCT overlap-add delay, coupling/SPX reuse flags, JOC differential state, metadata sequencing). Until now that state was silently carried into the next frame, so one bad frame after a corrupt seek corrupted everything that followed.

- `PcmDecoder` / `ObjectPcmDecoder` now reset that state internally whenever a push entry point returns `Err` (`frames_seen` is preserved). Every caller — the bridge, the CLI decode thread, `merge_core_with_dependent` — gets the guarantee, including the bridge path that swallows object-decoder errors before falling back to core PCM decode.
- The CLI E-AC-3 decode thread treats a decode error as a stream discontinuity: it resets all four decoders and drops the buffered pending AC-3 core / pending independent core before substituting silence.
- The bridge now bounds `pending_dependent_frames` (8 entries; it only grows while AC-3 cores keep failing). Evictions are logged and counted in a new `dependent_frames_dropped` diag stat.

## Output bounds
The bridge output boundary (`float_to_pcm_i32`) already guards NaN and clamps to 24-bit full scale; it is now locked in with unit tests (NaN/±inf → 0, out-of-range → ±full scale). The CLI's `float_to_i24` relied on `as`-cast saturation for the NaN case — it now maps non-finite samples to silence explicitly, matching the bridge.

## Panic sweep + fuzzing
Swept `syncframe.rs` / `allocation.rs` / `imdct.rs` / `joc.rs` / `qmf.rs` hot paths for unchecked indexing reachable from bitstream data. No remaining reachable panic found: every candidate site (coupling coefficient offsets, JOC object indexing, SPX extension copy, coupling coordinate shifts) is bounded by a prior validated range or an explicit `.get()`. The delta-bit-allocation panic was already fixed in #23.

To keep it that way:
- `eac3/tests/decoder_hardening.rs`: reset-on-error regression tests plus a deterministic 1500-iteration mutation/truncation sweep over all three push entry points (runs in normal CI, no nightly needed).
- `eac3/fuzz/`: cargo-fuzz targets for `push_access_unit` and `push_legacy_ac3_access_unit` (standalone workspace, not built by CI; decoders kept alive across inputs so cross-frame state is fuzzed too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)