### PR TITLE
Release 0.7.3: align every workspace crate on one version line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "damf"
-version = "0.1.0"
+version = "0.7.3"
 dependencies = [
  "serde",
  "serde_yaml_ng",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "dca"
-version = "0.1.0"
+version = "0.7.3"
 dependencies = [
  "log",
  "rustfft",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "eac3"
-version = "0.5.1"
+version = "0.7.3"
 dependencies = [
  "log",
  "rustfft",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "harletty"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "harletty-bridge"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "truehd"
-version = "0.5.0"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "bitstream-io",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "truehdd-macros"
-version = "0.1.0"
+version = "0.7.3"
 dependencies = [
  "darling",
  "quote",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harletty-bridge"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -20,9 +20,9 @@ bridge-perf = []
 bridge_api = { version = "0.3.0", path = "../../Omniphony/omniphony-renderer/bridge_api" }
 spdif = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/spdif" }
 sys = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/sys" }
-truehd = { version = "0.5.0", path = "../truehd" }
-eac3 = { version = "0.5.0", path = "../eac3" }
-dca = { version = "0.1.0", path = "../dca" }
+truehd = { version = "0.7.3", path = "../truehd" }
+eac3 = { version = "0.7.3", path = "../eac3" }
+dca = { version = "0.7.3", path = "../dca" }
 abi_stable = "0.11"
 log = "0.4"
 anyhow = "1.0"

--- a/damf/Cargo.toml
+++ b/damf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "damf"
-version = "0.1.0"
+version = "0.7.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Dolby Atmos Master File (DAMF) metadata writer plus CAF/WAV container writers"
@@ -15,7 +15,7 @@ crate-type = ["lib"]
 # `truehd` only for the OAMD payload types the DAMF metadata is projected from.
 # Nothing here may depend on the bridge ABI or on any CLI crate.
 [dependencies]
-truehdd-macros = { version = "0.1.0", path = "../truehdd-macros" }
-truehd = { version = "0.5.0", path = "../truehd" }
+truehdd-macros = { version = "0.7.3", path = "../truehdd-macros" }
+truehd = { version = "0.7.3", path = "../truehd" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"

--- a/dca/Cargo.toml
+++ b/dca/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dca"
-version = "0.1.0"
+version = "0.7.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Independent DTS Coherent Acoustics (DCA) bitstream parser and decoder"

--- a/eac3/Cargo.toml
+++ b/eac3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eac3"
-version = "0.5.1"
+version = "0.7.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Independent E-AC-3 bitstream parser and frame extractor"

--- a/harletty/Cargo.toml
+++ b/harletty/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "harletty"
-# Shares the bridge's version line: the two artifacts come from one commit and
-# are tagged together, so a release number means the same thing for both.
-version = "0.7.2"
+# Every crate in the workspace shares one version line: they all come from a
+# single commit and are tagged together, so a release number means the same
+# thing everywhere. Bump them together or not at all.
+version = "0.7.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Offline decoder for TrueHD, E-AC-3 JOC and DTS bitstreams, writing Dolby Atmos master files"
@@ -19,11 +20,11 @@ path = "src/main.rs"
 # Omniphony bridge ABI: this stays a pure offline tool. CI asserts the mirror
 # invariant (no damf/clap/indicatif reachable from harletty-bridge).
 [dependencies]
-truehdd-macros = { version = "0.1.0", path = "../truehdd-macros" }
-truehd = { version = "0.5.0", path = "../truehd" }
-eac3 = { version = "0.5.0", path = "../eac3" }
-dca = { version = "0.1.0", path = "../dca" }
-damf = { version = "0.1.0", path = "../damf" }
+truehdd-macros = { version = "0.7.3", path = "../truehdd-macros" }
+truehd = { version = "0.7.3", path = "../truehd" }
+eac3 = { version = "0.7.3", path = "../eac3" }
+dca = { version = "0.7.3", path = "../dca" }
+damf = { version = "0.7.3", path = "../damf" }
 
 anyhow = "1.0.99"
 clap = { version = "4.5.45", features = ["derive"] }

--- a/truehd/Cargo.toml
+++ b/truehd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truehd"
-version = "0.5.0"
+version = "0.7.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Research implementation of Dolby TrueHD parser/decoder"

--- a/truehdd-macros/Cargo.toml
+++ b/truehdd-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truehdd-macros"
-version = "0.1.0"
+version = "0.7.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Procedural macros for the truehdd project"


### PR DESCRIPTION
Preparation for the 0.7.3 release.

The workspace versioned its crates independently, which made a release number
ambiguous: `harletty` and `harletty-bridge` were on 0.7.2 while the decoder
crates they are built from sat on 0.1.0 / 0.5.x. All seven ship from a single
commit and are tagged together, so they now share one version line.

Bumps every member to `0.7.3` and the inter-crate path dependencies with them.
External dependencies and the Omniphony path deps (`bridge_api`, `spdif`, `sys`)
are deliberately untouched.

| crate | before | after |
| --- | --- | --- |
| `harletty-bridge` | 0.7.2 | 0.7.3 |
| `harletty` | 0.7.2 | 0.7.3 |
| `eac3` | 0.5.1 | 0.7.3 |
| `truehd` | 0.5.0 | 0.7.3 |
| `dca` | 0.1.0 | 0.7.3 |
| `damf` | 0.1.0 | 0.7.3 |
| `truehdd-macros` | 0.1.0 | 0.7.3 |

Full workspace suite passes. Once this is on `main`, `main` merges into
`release` and `v0.7.3` is tagged there.
