### PR TITLE
Gate truehd perf timings behind bridge-perf

### DIFF
--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = []
-bridge-perf = []
+bridge-perf = ["truehd/perf"]
 
 # Path deps reach out of the workspace to the sibling Omniphony checkout:
 # `bridge/../../Omniphony` is the workflow symlink locally and the second
@@ -20,7 +20,7 @@ bridge-perf = []
 bridge_api = { version = "0.3.0", path = "../../Omniphony/omniphony-renderer/bridge_api" }
 spdif = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/spdif" }
 sys = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/sys" }
-truehd = { version = "0.6.3", features = ["perf"] }
+truehd = { version = "0.6.3" }
 eac3 = { version = "0.7.3", path = "../eac3" }
 dca = { version = "0.7.3", path = "../dca" }
 abi_stable = "0.11"

--- a/bridge/src/metadata.rs
+++ b/bridge/src/metadata.rs
@@ -313,7 +313,7 @@ pub(crate) fn build_metadata_frame_from_oamd(
     evo_base: u64,
     frame_sample_pos: u64,
     declared_object_channels: &mut Option<RVec<bridge_api::RObjectChannel>>,
-    #[cfg(feature = "bridge-perf")] perf: &mut crate::perf::BridgePerf,
+    #[cfg(feature = "bridge-perf")] perf: &mut crate::perf::PerfStats,
 ) -> RMetadataFrame {
     #[cfg(feature = "bridge-perf")]
     let events_started = Instant::now();

--- a/damf/Cargo.toml
+++ b/damf/Cargo.toml
@@ -16,6 +16,6 @@ crate-type = ["lib"]
 # Nothing here may depend on the bridge ABI or on any CLI crate.
 [dependencies]
 truehdd-macros = "0.1.1"
-truehd = { version = "0.6.3", features = ["perf"] }
+truehd = { version = "0.6.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"

--- a/harletty/Cargo.toml
+++ b/harletty/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # invariant (no damf/clap/indicatif reachable from harletty-bridge).
 [dependencies]
 truehdd-macros = "0.1.1"
-truehd = { version = "0.6.3", features = ["perf"] }
+truehd = { version = "0.6.3" }
 eac3 = { version = "0.7.3", path = "../eac3" }
 dca = { version = "0.7.3", path = "../dca" }
 damf = { version = "0.7.3", path = "../damf" }


### PR DESCRIPTION
Follow-up to #30, which enabled truehd's `perf` feature unconditionally in all three consumers (parity with the always-instrumented vendored copy).

Nothing reads the timing counters outside the bridge's own `bridge-perf` gate, so this forwards `truehd/perf` from that feature (`bridge-perf = ["truehd/perf"]`) and drops the unconditional enables — production builds now compile the per-stage parse timers out of truehd entirely.

While enabling the gate to verify it, it turned out the `bridge-perf` path itself no longer compiled (CI never builds it): `build_metadata_frame_from_oamd` still named the perf collector `crate::perf::BridgePerf` after its rename to `PerfStats`. Fixed here.

Verified in both configurations:
- default: full workspace suite green, `cargo tree -e features -i truehd` resolves only truehd's `default` feature;
- `cargo test -p harletty-bridge --features bridge-perf --all-targets` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)