### PR TITLE
feat(bridge): advertise allow_negative_z — the OAMD decode carries signed z

### DIFF
--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -821,12 +821,20 @@ impl FormatBridge for AtmosBridge {
     }
 
     fn vbap_cartesian_defaults(&self) -> RVbapCartesianDefaults {
-        // Balanced default grid size for runtime cartesian VBAP table generation.
+        // Balanced default grid size for runtime cartesian VBAP table
+        // generation. The axis sizes mirror the OAMD position quantisation
+        // (x, y on 6 bits / 62, z magnitude on 4 bits / 15).
         RVbapCartesianDefaults {
             x_size: 62,
             y_size: 62,
             z_size: 15,
-            allow_negative_z: false,
+            // The OAMD position decode carries z in [-1, 1] — the bitstream
+            // has an explicit sign bit for below-floor objects — so the
+            // renderer must not clamp z at the panner. Grids without
+            // negative-z cells (the default) clamp such requests onto the
+            // z = 0 plane, which is the pre-existing behaviour; realtime and
+            // polar evaluation render them at their true position.
+            allow_negative_z: true,
         }
     }
 


### PR DESCRIPTION
The OAMD position decode outputs `z ∈ [−1, 1]`: the bitstream codes the z magnitude on 4 bits with an **explicit sign bit** (plus signed differential updates), so below-floor object positions are part of the format — even though no master in the scanned corpus uses them.

The bridge advertised `allow_negative_z: false`, so the renderer clamped `z` to 0 at the panner and silently flattened any such position onto the horizontal plane, discarding the decoded sign.

## Change

`RVbapCartesianDefaults.allow_negative_z` → `true` (value only — no ABI change). Effects renderer-side:

- **Realtime and polar evaluation** now render below-horizon positions at their true direction, through the renderer's out-of-hull handling (selectable since mgth/Omniphony#211: BS.2127 virtual poles by default, face blend, or the legacy fade).
- **Cartesian grids without negative-z cells** — the default; `z_neg_size` stays 0, so no table growth — keep the pre-existing behaviour: below-horizon requests clamp onto the `z = 0` plane. This degradation is pinned renderer-side by the new `cartesian_without_neg_cells_clamps_below_horizon_requests` test (finite gains, bit-equal to the same position at `z = 0`).

## Validation

- `cargo build -p harletty-bridge` + full test suite (56 passed, 0 failed) against the current Omniphony renderer.
- `RUSTFLAGS="-D warnings" cargo check -p harletty-bridge --features bridge-perf` clean (the CI gate).

## Note for explicit polar-mode configs

The polar elevation axis now spans `[−90°, 90°]` instead of `[0°, 90°]` at the same cell count (default 180 cells: 1.0°/cell instead of 0.5°). Double `render.vbap_elevation_resolution` to keep the previous upper-hemisphere density. Default users are unaffected — this bridge prefers cartesian mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)