### PR TITLE
Require truehd 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "truehd"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976c2c00294c22a2b14878f123e989d215c6885a2d4af40de09b4c082eb2be7a"
+checksum = "7e511dc322da8e9b095df1fc8f3b29735d15d53ee2a87c0da81d16c8061f10cb"
 dependencies = [
  "anyhow",
  "bitstream-io",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -20,7 +20,7 @@ bridge-perf = ["truehd/perf"]
 bridge_api = { version = "0.3.0", path = "../../Omniphony/omniphony-renderer/bridge_api" }
 spdif = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/spdif" }
 sys = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/sys" }
-truehd = { version = "0.6.3" }
+truehd = { version = "0.7.0" }
 eac3 = { version = "0.7.3", path = "../eac3" }
 dca = { version = "0.7.3", path = "../dca" }
 abi_stable = "0.11"

--- a/bridge/src/truehd_pipeline.rs
+++ b/bridge/src/truehd_pipeline.rs
@@ -150,27 +150,27 @@ fn drain_frames(ctx: &mut DrainContext<'_>) -> (Vec<RDecodedFrame>, Option<Strin
                     *ctx.current_substream_info = Some(major_sync.substream_info);
                     *ctx.current_extended_substream_info = Some(major_sync.extended_substream_info);
 
-                    // Extract dialogue level.
-                    let cm = &major_sync.channel_meaning;
-                    let dialogue_level: i8 = match ctx.presentation {
-                        0 => -(cm.twoch_dialogue_norm as i8),
-                        1 => -(cm.sixch_dialogue_norm as i8),
-                        2 => -(cm.eightch_dialogue_norm as i8),
-                        3 => {
-                            if let Some(ref extra) = cm.extra_channel_meaning {
-                                -(extra.sixteench_dialogue_norm as i8)
-                            } else {
-                                -(cm.eightch_dialogue_norm as i8)
-                            }
-                        }
-                        _ => -(cm.eightch_dialogue_norm as i8),
-                    };
-                    *ctx.current_dialogue_level = Some(dialogue_level);
-                    log::debug!(
-                        "Dialogue level: {} dBFS (presentation {})",
-                        dialogue_level,
-                        ctx.presentation
-                    );
+                    // Extract dialogue level. The other syntax puts an entirely
+                    // different structure in those bits, so a stream carrying one
+                    // states no dialogue level rather than one read from fields that
+                    // mean nothing of the sort.
+                    if let Some(cm) = major_sync.channel_meaning.fba() {
+                        let dialogue_level: i8 = match ctx.presentation {
+                            0 => -(cm.twoch_dialogue_norm as i8),
+                            1 => -(cm.sixch_dialogue_norm as i8),
+                            3 => match major_sync.channel_meaning.extra_channel_meaning() {
+                                Some(extra) => -(extra.sixteench_dialogue_norm as i8),
+                                None => -(cm.eightch_dialogue_norm as i8),
+                            },
+                            _ => -(cm.eightch_dialogue_norm as i8),
+                        };
+                        *ctx.current_dialogue_level = Some(dialogue_level);
+                        log::debug!(
+                            "Dialogue level: {} dBFS (presentation {})",
+                            dialogue_level,
+                            ctx.presentation
+                        );
+                    }
                 }
 
                 #[cfg(feature = "bridge-perf")]

--- a/damf/Cargo.toml
+++ b/damf/Cargo.toml
@@ -16,6 +16,6 @@ crate-type = ["lib"]
 # Nothing here may depend on the bridge ABI or on any CLI crate.
 [dependencies]
 truehdd-macros = "0.1.1"
-truehd = { version = "0.6.3" }
+truehd = { version = "0.7.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"

--- a/damf/src/damf.rs
+++ b/damf/src/damf.rs
@@ -197,7 +197,7 @@ impl TrimMode {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct TrimOptions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -218,13 +218,23 @@ impl TrimOptions {
             return None;
         };
 
-        Some(Self {
+        let options = Self {
             center_trim: trim.trim_centre,
             surround_trim: trim.trim_surround,
             height_trim: trim.trim_height,
             front_back_balance_overhead_floor: trim.bal3d_y_tb,
             front_back_balance_listener: trim.bal3d_y_lis,
-        })
+        };
+
+        // A trim the renderer derives itself carries no value for any of these. The
+        // payload distinguishes it from an absent trim, but the master set has no way
+        // to say "derived", and an empty trim entry states nothing at all — so it is
+        // written as the absence it was written as before that distinction existed.
+        if options == Self::default() {
+            return None;
+        }
+
+        Some(options)
     }
 }
 

--- a/harletty/Cargo.toml
+++ b/harletty/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # invariant (no damf/clap/indicatif reachable from harletty-bridge).
 [dependencies]
 truehdd-macros = "0.1.1"
-truehd = { version = "0.6.3" }
+truehd = { version = "0.7.0" }
 eac3 = { version = "0.7.3", path = "../eac3" }
 dca = { version = "0.7.3", path = "../dca" }
 damf = { version = "0.7.3", path = "../damf" }

--- a/harletty/src/cli/decode/handler.rs
+++ b/harletty/src/cli/decode/handler.rs
@@ -10,7 +10,27 @@ use log::Level;
 use std::fs::File;
 use std::io::{BufWriter, Seek, Write};
 use std::path::{Path, PathBuf};
-use truehd::log_or_err;
+/// Log a failure, or return it where the caller asked for that severity to be fatal.
+///
+/// This was `truehd::log_or_err!` until that macro became parser-internal in all but
+/// name: it now expands to `DiagnosticSink` calls and needs a `&mut` to the sink, which
+/// is machinery a file writer has no business carrying. The behaviour below is the one
+/// the writer has always relied on.
+macro_rules! log_or_err {
+    ($state:expr, $level:expr, $err:expr $(,)?) => {{
+        if $level <= $state.fail_level {
+            return Err($err);
+        }
+
+        match $level {
+            Level::Error => log::error!("{}", $err),
+            Level::Warn => log::warn!("{}", $err),
+            Level::Info => log::info!("{}", $err),
+            Level::Debug => log::debug!("{}", $err),
+            Level::Trace => log::trace!("{}", $err),
+        }
+    }};
+}
 
 struct AudioFormatHandler;
 

--- a/harletty/src/cli/info.rs
+++ b/harletty/src/cli/info.rs
@@ -462,7 +462,10 @@ impl<'a> PresentationBuilder<'a> {
         major_sync: &'a truehd::structs::sync::MajorSyncInfo,
         access_unit: &'a AccessUnit,
     ) -> Self {
-        let presentation_map = PresentationMap::with_substream_info(
+        // `with_substream_info` is the derivation of one syntax alone, and applying it
+        // to the other invents presentations the stream does not declare.
+        let presentation_map = PresentationMap::for_format_sync(
+            major_sync.format_sync,
             major_sync.substream_info,
             major_sync.extended_substream_info,
         );
@@ -517,10 +520,14 @@ impl<'a> PresentationBuilder<'a> {
 
     fn configure_twoch_presentation(&self, presentation: &mut PresentationInfo) {
         let format_info = &self.major_sync.format_info;
-        let channel_meaning = &self.major_sync.channel_meaning;
 
         presentation.twoch_format =
             Some(ChannelGroup::from_modifier(format_info.twoch_decoder_channel_modifier).unwrap());
+
+        let Some(channel_meaning) = self.major_sync.channel_meaning.fba() else {
+            return;
+        };
+
         presentation.control = Some(channel_meaning.twoch_control_enabled);
         presentation.dialogue_level = -(channel_meaning.twoch_dialogue_norm as i8);
         presentation.mix_level = channel_meaning.twoch_mix_level + 70;
@@ -528,7 +535,6 @@ impl<'a> PresentationBuilder<'a> {
 
     fn configure_sixch_presentation(&self, presentation: &mut PresentationInfo) {
         let format_info = &self.major_sync.format_info;
-        let channel_meaning = &self.major_sync.channel_meaning;
 
         let assignment = format_info.sixch_decoder_channel_assignment;
         if assignment == 1 {
@@ -551,6 +557,11 @@ impl<'a> PresentationBuilder<'a> {
 
         presentation.assignments =
             ChannelLabel::from_sixch_channel(format_info.sixch_decoder_channel_assignment).unwrap();
+
+        let Some(channel_meaning) = self.major_sync.channel_meaning.fba() else {
+            return;
+        };
+
         presentation.control = Some(channel_meaning.sixch_control_enabled);
         presentation.dialogue_level = -(channel_meaning.sixch_dialogue_norm as i8);
         presentation.mix_level = channel_meaning.sixch_mix_level + 70;
@@ -558,22 +569,24 @@ impl<'a> PresentationBuilder<'a> {
 
     fn configure_eightch_presentation(&self, presentation: &mut PresentationInfo) {
         let format_info = &self.major_sync.format_info;
-        let channel_meaning = &self.major_sync.channel_meaning;
 
         presentation.assignments = ChannelLabel::from_eightch_channel(
             format_info.eightch_decoder_channel_assignment,
             self.major_sync.flags,
         )
         .unwrap();
+
+        let Some(channel_meaning) = self.major_sync.channel_meaning.fba() else {
+            return;
+        };
+
         presentation.control = Some(channel_meaning.eightch_control_enabled);
         presentation.dialogue_level = -(channel_meaning.eightch_dialogue_norm as i8);
         presentation.mix_level = channel_meaning.eightch_mix_level + 70;
     }
 
     fn configure_sixteench_presentation(&self, presentation: &mut PresentationInfo) {
-        let channel_meaning = &self.major_sync.channel_meaning;
-
-        let Some(extra) = &channel_meaning.extra_channel_meaning else {
+        let Some(extra) = self.major_sync.channel_meaning.extra_channel_meaning() else {
             return;
         };
 

--- a/harletty/src/dts_to_oamd.rs
+++ b/harletty/src/dts_to_oamd.rs
@@ -257,7 +257,9 @@ pub fn convert_dts(layout: &DtsLayout) -> ObjectAudioMetadataPayload {
         object_element,
         trim_element: None,
         extended_object_element: None,
-        oa_element_md: Vec::new(),
+        // The elements a synthesized payload states nothing about: headphone
+        // rendering intent and per-object dialogue indication.
+        ..Default::default()
     }
 }
 

--- a/harletty/src/eac3_to_oamd.rs
+++ b/harletty/src/eac3_to_oamd.rs
@@ -172,7 +172,9 @@ pub fn convert_oamd(
         object_element,
         trim_element: None,
         extended_object_element: None,
-        oa_element_md: Vec::new(),
+        // The elements a synthesized payload states nothing about: headphone
+        // rendering intent and per-object dialogue indication.
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
The library release behind upstream truehdd 0.6.0. Independent of #34 — either can merge first.

## Why

Three of its fixes reach code we run.

**Heavy DRC was read from the wrong restart header.** `heavy_drc_present` was taken from the *previous* header rather than the one being read, and was left standing where `flags` says the stream carries no heavy DRC at all. In this syntax both readings consume the same twelve bits, so no stream lost its place — but the DRC state the decoder tracks came from reserved bits or from the wrong header, and that state is exactly what `truehd_pipeline.rs` reads to build `drc_gain` and `drc_ramp_duration` for `DrcMode::Heavy`.

**Two panics sat in the realtime decode path.** `ObjectAudioMetadataPayload::read` asserted on an unknown OAMD version, and indexed a six-entry table with a three-bit field. Both are reachable from arbitrary stream bytes — that is, from a damaged stream. Both are errors now. Three more `unimplemented!` sites went with the other major-sync syntax becoming readable, one of which a stream we map to this decoder could reach.

Also: object positions are clamped to their own ranges with the clamped code feeding the next block's differential (a stream whose positions walked past an edge used to diverge on every block after it), and `DecodedAccessUnit::channel_labels` survives a restart header instead of being wiped by it.

## The port

Three mechanical changes, plus two judgement calls.

- `MajorSyncInfo::channel_meaning` is an enum over the two syntaxes. The dialogue level in the bridge and the per-presentation metadata in `info` read it through `.fba()` and state *nothing* rather than nonsense for the other syntax — which is the whole point of the upstream change.
- `ObjectAudioMetadataPayload` gained two OAMD elements, so the payloads synthesized from DTS and E-AC-3 fill them by default.
- `log_or_err!` now expands to `DiagnosticSink` calls on a `&mut` sink. That is parser-internal machinery a file writer has no business carrying, so the CLI keeps its own four-line macro with the behaviour it always relied on.
- `PresentationMap::with_substream_info` is now one syntax's derivation alone; `info` picks with `for_format_sync`.
- A trim the renderer derives itself is no longer dropped by the parser. Left alone, that would have started writing an empty `{}` trim entry into every master set carrying one. A master set has no way to say "derived" and an empty entry states nothing, so it is written as the absence it was written as before the distinction existed. The existing golden test caught this.

## Verification

Real streams, not inspection. Three TrueHD Atmos titles (District 9, Alita, Blade Runner — ~50k access units each) and five E-AC-3 samples, decoded with a 0.6.3 binary and a 0.7.0 binary:

- audio, `.atmos.metadata` and `.atmos` DAMF header **byte-identical** on all eight
- **zero warnings** at either version, so none of the newly-typed conformance checks latches on
- `Parser::branches`, the one list 0.7.0 accumulates without a way to clear it, stays **empty** over all of them

Parse cost on those streams is unchanged within noise — 11.91 → 12.01 and 11.12 → 11.17 µs/AU, best of five. Worth stating plainly: the −20 % that 0.7.0's restart-header rework shows on a synthetic stream does **not** appear here, because that work only pays off at a restart gap far shorter than real content uses. This bump is a correctness bump, not a performance one.

Full suite green. Clippy is unchanged (the 5 pre-existing errors in `dts_pipeline.rs` predate this branch), and the new code is rustfmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)