### PR TITLE
Name the CAF channel layout from the decoder's own labels

### DIFF
--- a/damf/src/caf.rs
+++ b/damf/src/caf.rs
@@ -2,6 +2,7 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 
 use crate::byteorder::{WriteBytesBe, WriteBytesLe};
 use crate::impl_u32_enum;
+use truehd::structs::channel::ChannelLabel as DecodedChannelLabel;
 use truehdd_macros::{ToBytes, caf_chunk_type};
 
 pub fn write_caf_file_header<W: Write>(writer: &mut W) -> io::Result<()> {
@@ -89,6 +90,31 @@ impl ChannelLayout {
             Some(tag) => Self::with_tag(tag),
             None => Self::with_descriptions(labels),
         }
+    }
+
+    /// The layout a decode of `channel_count` channels is in, where the decoder's own
+    /// labels describe every one of them.
+    ///
+    /// They do not always. A spatial presentation reports the labels of its bed alone:
+    /// an LFE-only bed is one label for twelve channels, the other eleven being objects,
+    /// which are not speakers and have no place in a channel layout. A label the
+    /// decoder reports and CoreAudio does not name has the same effect. In either case
+    /// the file is better left saying nothing about its layout than saying something
+    /// untrue, so this returns `None` and the caller decides what to fall back to.
+    pub fn for_decoded_channels(
+        labels: &[DecodedChannelLabel],
+        channel_count: usize,
+    ) -> Option<Self> {
+        if labels.is_empty() || labels.len() != channel_count {
+            return None;
+        }
+
+        let named = labels
+            .iter()
+            .map(|&label| ChannelLabel::for_decoded_label(label))
+            .collect::<Option<Vec<_>>>()?;
+
+        Some(Self::for_channel_labels(&named))
     }
 }
 
@@ -403,6 +429,45 @@ const STANDARD_LAYOUTS: &[(ChannelLayoutTag, &[ChannelLabel])] = {
         ),
     ]
 };
+
+impl ChannelLabel {
+    /// The label naming the same speaker as one the decoder reports.
+    ///
+    /// `Tsl`/`Tsr`, the top side pair, have no CoreAudio label. Reporting the nearest
+    /// one would move a speaker, so they have none here either, and a presentation
+    /// carrying them is left without a stated layout rather than with a wrong one.
+    pub fn for_decoded_label(label: DecodedChannelLabel) -> Option<Self> {
+        use DecodedChannelLabel as D;
+
+        Some(match label {
+            D::L => Self::Left,
+            D::R => Self::Right,
+            D::C => Self::Center,
+            D::LFE => Self::LFEScreen,
+            D::LFE2 => Self::LFE2,
+            // The 5.1 surround pair. CoreAudio names this pair for what a 5.1 layout
+            // puts there, and the back pair separately.
+            D::Ls => Self::LeftSurround,
+            D::Rs => Self::RightSurround,
+            D::Lb => Self::RearSurroundLeft,
+            D::Rb => Self::RearSurroundRight,
+            D::Cb => Self::CenterSurround,
+            D::Lsd => Self::LeftSurroundDirect,
+            D::Rsd => Self::RightSurroundDirect,
+            D::Lsc => Self::LeftCenter,
+            D::Rsc => Self::RightCenter,
+            D::Lw => Self::LeftWide,
+            D::Rw => Self::RightWide,
+            D::Tfl => Self::VerticalHeightLeft,
+            D::Tfc => Self::VerticalHeightCenter,
+            D::Tfr => Self::VerticalHeightRight,
+            D::Tbl => Self::TopBackLeft,
+            D::Tbr => Self::TopBackRight,
+            D::Tc => Self::TopCenterSurround,
+            D::Tsl | D::Tsr => return None,
+        })
+    }
+}
 
 impl ChannelLayoutTag {
     /// The tag whose channel order is exactly `labels`, if one names it.
@@ -940,18 +1005,25 @@ pub struct CAFWriterStats {
 
 /// Helper methods for working with TrueHD streams
 impl<W: Write + Seek> CAFWriter<W> {
-    /// Configure the writer from TrueHD stream parameters
+    /// Configure the writer from decoded stream parameters.
+    ///
+    /// `labels` are the decoder's own, and are what the layout is named from wherever
+    /// they describe every channel of the file. Pass an empty slice for a decoder that
+    /// reports none: the layout then falls back to the order this many channels are
+    /// assumed to decode in, which is a guess and is documented as one.
     pub fn configure_audio_format(
         &mut self,
         sample_rate: u32,
         channels: u32,
         bits_per_channel: u32,
+        labels: &[DecodedChannelLabel],
     ) -> io::Result<()> {
-        // Set audio format
         self.set_audio_format(sample_rate as f64, channels, bits_per_channel)?;
 
-        // Set basic channel layout based on channel count
-        self.set_basic_channel_layout(channels)?;
+        match ChannelLayout::for_decoded_channels(labels, channels as usize) {
+            Some(layout) => self.set_channel_layout(layout),
+            None => self.set_basic_channel_layout(channels)?,
+        }
 
         Ok(())
     }
@@ -1028,7 +1100,7 @@ mod tests {
         let cursor = Cursor::new(buffer);
         let mut writer = CAFWriter::new(cursor);
 
-        writer.configure_audio_format(48000, 2, 24)?;
+        writer.configure_audio_format(48000, 2, 24, &[])?;
         writer.write_header()?;
 
         // Test PCM conversion
@@ -1209,7 +1281,7 @@ mod tests {
         let cursor = Cursor::new(buffer);
         let mut writer = CAFWriter::new(cursor);
 
-        writer.configure_audio_format(48000, 2, 24)?;
+        writer.configure_audio_format(48000, 2, 24, &[])?;
         writer.write_header()?;
 
         // Write some data
@@ -1310,6 +1382,67 @@ mod tests {
         assert_eq!(
             unnamed.channel_descriptions.len(),
             unnamed.number_channel_descriptions as usize
+        );
+    }
+
+    /// The orders this decoder actually reports, measured on real streams: presentation
+    /// 0 is `L R`, 1 is `L R C LFE Ls Rs`, 2 is `L R C LFE Ls Rs Lb Rb`. The last is the
+    /// one a channel count gets wrong — its back pair is a *rear* pair, not the front
+    /// centre pair `MPEG_7_1_A` names.
+    #[test]
+    fn decoded_labels_name_the_layout_the_decoder_reports() {
+        use DecodedChannelLabel as D;
+
+        let tag_for = |labels: &[D], channels: usize| {
+            ChannelLayout::for_decoded_channels(labels, channels).map(|l| l.channel_layout_tag)
+        };
+
+        assert_eq!(tag_for(&[D::L, D::R], 2), Some(ChannelLayoutTag::Stereo));
+        assert_eq!(
+            tag_for(&[D::L, D::R, D::C, D::LFE, D::Ls, D::Rs], 6),
+            Some(ChannelLayoutTag::MPEG_5_1_A)
+        );
+        assert_eq!(
+            tag_for(&[D::L, D::R, D::C, D::LFE, D::Ls, D::Rs, D::Lb, D::Rb], 8),
+            Some(ChannelLayoutTag::MPEG_7_1_C)
+        );
+
+        // Where the labels earn their keep: six channels whose surround pair is a
+        // height pair are not the 5.1 that a channel count would call them. No tag
+        // names that order, so it is spelled out instead.
+        let heights =
+            ChannelLayout::for_decoded_channels(&[D::L, D::R, D::C, D::LFE, D::Tfl, D::Tfr], 6)
+                .unwrap();
+        assert_eq!(
+            heights.channel_layout_tag,
+            ChannelLayoutTag::UseChannelDescriptions
+        );
+        assert_eq!(heights.number_channel_descriptions, 6);
+        assert_eq!(
+            heights.channel_descriptions[4].channel_label,
+            ChannelLabel::VerticalHeightLeft
+        );
+    }
+
+    /// A spatial presentation reports its bed's labels alone. Measured on real streams:
+    /// an LFE-only bed is one label for twelve channels, the other eleven being objects.
+    /// Naming a layout from that would describe eleven objects as speakers.
+    #[test]
+    fn a_layout_is_not_named_from_labels_that_describe_part_of_the_file() {
+        use DecodedChannelLabel as D;
+
+        assert!(
+            ChannelLayout::for_decoded_channels(&[D::LFE], 12).is_none(),
+            "an LFE-only bed with eleven objects states no layout"
+        );
+        assert!(ChannelLayout::for_decoded_channels(&[], 6).is_none());
+        assert!(
+            ChannelLayout::for_decoded_channels(&[D::L, D::R], 6).is_none(),
+            "fewer labels than channels states no layout"
+        );
+        assert!(
+            ChannelLayout::for_decoded_channels(&[D::L, D::R, D::Tsl, D::Tsr], 4).is_none(),
+            "a label CoreAudio cannot name leaves the whole layout unstated"
         );
     }
 }

--- a/harletty/src/cli/decode/decode_impl.rs
+++ b/harletty/src/cli/decode/decode_impl.rs
@@ -143,6 +143,7 @@ pub fn cmd_decode(args: &DecodeArgs, cli: &Cli, multi: Option<&MultiProgress>) -
                         decoded.sampling_frequency,
                         decoded.channel_count,
                         args.bed_conform,
+                        &decoded.channel_labels,
                     )?;
                     handler.is_segmented = true; // Mark that we're now in segmented mode
                 }

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -292,7 +292,7 @@ impl DtsDecodeHandler {
         log::info!("Creating audio file: {}", audio_path.display());
         let writer = match (format, self.has_spatial) {
             (AudioFormat::Caf, _) | (_, true) => {
-                AudioWriter::create_caf(audio_path, sample_rate, channel_count as u32)?
+                AudioWriter::create_caf(audio_path, sample_rate, channel_count as u32, &[])?
             }
             (AudioFormat::W64, false) => {
                 AudioWriter::create_w64(audio_path, sample_rate, channel_count as u32)?

--- a/harletty/src/cli/decode/eac3_handler.rs
+++ b/harletty/src/cli/decode/eac3_handler.rs
@@ -202,7 +202,7 @@ impl Eac3DecodeHandler {
         log::info!("Creating audio file: {}", audio_path.display());
         let writer = match (format, self.has_atmos) {
             (AudioFormat::Caf, _) | (_, true) => {
-                AudioWriter::create_caf(audio_path, sample_rate, channel_count as u32)?
+                AudioWriter::create_caf(audio_path, sample_rate, channel_count as u32, &[])?
             }
             (AudioFormat::W64, false) => {
                 AudioWriter::create_w64(audio_path, sample_rate, channel_count as u32)?

--- a/harletty/src/cli/decode/handler.rs
+++ b/harletty/src/cli/decode/handler.rs
@@ -10,6 +10,8 @@ use log::Level;
 use std::fs::File;
 use std::io::{BufWriter, Seek, Write};
 use std::path::{Path, PathBuf};
+use truehd::structs::channel::ChannelLabel;
+
 /// Log a failure, or return it where the caller asked for that severity to be fatal.
 ///
 /// This was `truehd::log_or_err!` until that macro became parser-internal in all but
@@ -379,12 +381,21 @@ impl DecodeHandler {
             channel_count
         };
 
+        // Bed conformance rewrites the channels into a layout of its own, so the
+        // decoder's labels no longer describe the file being written.
+        let channel_labels: &[ChannelLabel] = if effective_channel_count == channel_count {
+            &decoded.channel_labels
+        } else {
+            &[]
+        };
+
         self.create_audio_writer_if_needed(
             ctx.base_path,
             ctx.format,
             ctx.no_audio,
             sample_rate,
             effective_channel_count,
+            channel_labels,
         )?;
 
         if !ctx.no_audio {
@@ -646,10 +657,13 @@ impl DecodeHandler {
             conformed_channel_count,
         );
 
+        // The samples have just been re-laid-out into the conformed bed, so the
+        // decoder's labels describe an order this file is no longer in.
         let mut caf_writer = AudioWriter::create_caf(
             new_path.to_path_buf(),
             sample_rate as u32,
             conformed_channel_count as u32,
+            &[],
         )?;
         caf_writer.write_pcm_samples(&conformed_samples, conformed_channel_count)?;
         caf_writer.finish()?;
@@ -734,6 +748,7 @@ impl DecodeHandler {
         no_audio: bool,
         sample_rate: u32,
         channel_count: usize,
+        channel_labels: &[ChannelLabel],
     ) -> Result<()> {
         if no_audio {
             return Ok(());
@@ -764,6 +779,7 @@ impl DecodeHandler {
                             audio_path,
                             sample_rate,
                             channel_count as u32,
+                            channel_labels,
                         )?);
                     }
                     AudioFormat::Pcm => {
@@ -865,6 +881,7 @@ impl DecodeHandler {
         sample_rate: u32,
         channel_count: usize,
         bed_conform: bool,
+        channel_labels: &[ChannelLabel],
     ) -> Result<()> {
         if let Some(base_path) = base_path {
             log::info!(
@@ -917,6 +934,14 @@ impl DecodeHandler {
                 channel_count
             };
 
+            // Bed conformance rewrites the channels into a layout of its own, so the
+            // decoder's labels no longer describe the file being written.
+            let channel_labels: &[ChannelLabel] = if effective_channel_count == channel_count {
+                channel_labels
+            } else {
+                &[]
+            };
+
             if !no_audio {
                 // Create new audio writer based on format
                 let audio_writer = match format {
@@ -925,6 +950,7 @@ impl DecodeHandler {
                         new_audio_path.clone(),
                         sample_rate,
                         effective_channel_count as u32,
+                        channel_labels,
                     )?,
                     AudioFormat::W64 => AudioWriter::create_w64(
                         new_audio_path.clone(),

--- a/harletty/src/cli/decode/output.rs
+++ b/harletty/src/cli/decode/output.rs
@@ -1,6 +1,7 @@
 use damf::caf::CAFWriter;
 use damf::wav::WAVWriter;
 use anyhow::Result;
+use truehd::structs::channel::ChannelLabel;
 use std::fs::File;
 use std::io::{BufWriter, Seek, Write};
 use std::path::{Path, PathBuf};
@@ -74,9 +75,17 @@ impl AudioWriter {
         Ok(AudioWriter::Pcm(pcm_writer))
     }
 
-    pub fn create_caf(path: PathBuf, sample_rate: u32, channel_count: u32) -> Result<Self> {
+    /// `labels` are the decoder's own channel labels, from which the file's channel
+    /// layout is named. Pass an empty slice where the decoder reports none, or where
+    /// they do not describe the channels being written.
+    pub fn create_caf(
+        path: PathBuf,
+        sample_rate: u32,
+        channel_count: u32,
+        labels: &[ChannelLabel],
+    ) -> Result<Self> {
         let mut caf_writer = CAFWriter::new(BufWriter::new(File::create(path)?));
-        caf_writer.configure_audio_format(sample_rate, channel_count, 24)?;
+        caf_writer.configure_audio_format(sample_rate, channel_count, 24, labels)?;
         caf_writer.write_header()?;
         Ok(AudioWriter::Caf(caf_writer))
     }


### PR DESCRIPTION
Follow-up to #34 and #35. The layout tag was derived from the channel count, which cannot tell `L R C LFE Ls Rs` from `L R Ls Rs C LFE`; #34 made that assumption explicit and correct for the orders we decode, but it was still an assumption. Now that #35 makes `DecodedAccessUnit::channel_labels` survive a restart header, the decoder can just say what the channels are.

## The rule

A layout is named from the labels **only where they describe every channel of the file**. That single condition covers every case where they do not:

- A spatial presentation reports the labels of its **bed alone**. Measured on three titles, presentation 3 is *twelve channels and one label* (`LFE`) — an LFE-only bed with eleven objects. Objects are not speakers and have no place in a channel layout.
- Bed conformance rewrites the channels into a layout of its own, so the labels describe an order the file is no longer in.
- A label the decoder reports that CoreAudio does not name (`Tsl`/`Tsr`, the top side pair) makes the whole order unstatable. Reporting the nearest label would move a speaker.

In each case nothing is named from the labels and the caller falls back to what it did before — which, for those channel counts, is to write no layout chunk at all. The DTS and E-AC-3 decoders, which report no labels of their own, pass an empty slice and keep their existing behaviour.

## Verification

Against the previous binary, three TrueHD Atmos titles × every presentation:

| presentation | channels | labels reported | tag written |
| --- | --- | --- | --- |
| 0 | 2 | `L R` | `Stereo` |
| 1 | 6 | `L R C LFE Ls Rs` | `MPEG_5_1_A` |
| 2 | 8 | `L R C LFE Ls Rs Lb Rb` | `MPEG_7_1_C` |
| 3 | 12 | `LFE` | *(no layout chunk)* |

**Every output byte-identical**, plus the five E-AC-3 samples. That is the result to want here: this change does not move these files, it derives what they already said instead of assuming it. The assumption and the evidence agree — on the orders we have.

Where they would not agree, a unit test pins the case: six channels whose surround pair is a *height* pair are not the 5.1 a count would call them, so they are spelled out channel by channel rather than given a tag that merely fits the count.

Full suite green, `damf` clippy-clean, new code rustfmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)