### PR TITLE
Bump truehd to 0.7.1, configure the parser in one place, and bound the branch list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ resolver = "2"
 inherits = "release"
 lto = "thin"
 strip = "symbols"
+

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -20,7 +20,7 @@ bridge-perf = ["truehd/perf"]
 bridge_api = { version = "0.3.0", path = "../../Omniphony/omniphony-renderer/bridge_api" }
 spdif = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/spdif" }
 sys = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/sys" }
-truehd = { version = "0.7.0" }
+truehd = { version = "0.7.1" }
 eac3 = { version = "0.7.3", path = "../eac3" }
 dca = { version = "0.7.3", path = "../dca" }
 abi_stable = "0.11"

--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -22,7 +22,7 @@ use crate::frame_builders::PcmStats;
 use crate::logging::bridge_diag_log;
 use crate::mat::MatStream;
 use crate::perf::PerfStats;
-use crate::truehd_pipeline::process_extractor_input;
+use crate::truehd_pipeline::{configure_parser, process_extractor_input};
 
 #[derive(Debug, Default)]
 pub(crate) struct Eac3DiagStats {
@@ -204,15 +204,8 @@ impl AtmosBridge {
         } else {
             log::Level::Error
         };
-        parser.set_fail_level(fail_level);
         decoder.set_fail_level(fail_level);
-
-        // Require all presentations up to and including the requested one.
-        let mut required_presentations = [false; MAX_PRESENTATIONS];
-        required_presentations[..=presentation as usize]
-            .iter_mut()
-            .for_each(|p| *p = true);
-        parser.set_required_presentations(&required_presentations);
+        configure_parser(&mut parser, fail_level, presentation);
 
         let eac3_log_level = if strict {
             log::Level::Warn
@@ -321,16 +314,10 @@ impl AtmosBridge {
         } else {
             log::Level::Error
         };
-        self.parser.set_fail_level(fail_level);
         self.decoder.set_fail_level(fail_level);
         self.eac3_pcm_decoder.set_debug_log_level(fail_level);
         self.eac3_object_decoder.set_debug_log_level(fail_level);
-        let mut required_presentations = [false; MAX_PRESENTATIONS];
-        required_presentations[..=self.presentation as usize]
-            .iter_mut()
-            .for_each(|p| *p = true);
-        self.parser
-            .set_required_presentations(&required_presentations);
+        configure_parser(&mut self.parser, fail_level, self.presentation);
         self.declared_object_channels = None;
         self.truehd_spatial_labels = None;
         self.recovering_until_major_sync = false;

--- a/bridge/src/truehd_pipeline.rs
+++ b/bridge/src/truehd_pipeline.rs
@@ -15,6 +15,37 @@ use crate::logging::{bridge_diag_log, drc_diag_log_enabled, panic_message};
 use crate::metadata::build_metadata_frame_from_oamd;
 use crate::perf::PerfStats;
 
+/// Applies everything a fresh [`Parser`] needs to match this bridge's contract.
+///
+/// The bridge replaces its parser wholesale in three places — construction, pipeline
+/// reset, and parse recovery — and each one used to re-apply the settings itself. A
+/// setting applied in two of the three is a setting that silently reverts at the third,
+/// so they all come from here.
+pub(crate) fn configure_parser(parser: &mut Parser, fail_level: log::Level, presentation: u8) {
+    parser.set_fail_level(fail_level);
+
+    // The byte-domain FIFO depth model answers whether a stream is legal to author on a
+    // disc. A playback decode never asks that: the samples are the same either way, and
+    // the model otherwise accounts every access unit for an answer nothing reads.
+    parser.set_check_fifo(false);
+
+    // Require all presentations up to and including the requested one.
+    let mut required_presentations = [false; MAX_PRESENTATIONS];
+    required_presentations[..=presentation as usize]
+        .iter_mut()
+        .for_each(|p| *p = true);
+    parser.set_required_presentations(&required_presentations);
+}
+
+/// How many branch points the parser may hold before the list is dropped.
+///
+/// The parser records every point the stream's timing restarts at and never forgets
+/// one. A pass over a file reads the list at the end, where its size is bounded by the
+/// file; playback has no end to read it at, and a stream that restarts its timing on
+/// every access unit — a damaged one does — would grow it for as long as it plays.
+/// Nothing here reads the list, so it is emptied once it is past any plausible use.
+const MAX_RETAINED_BRANCHES: usize = 64;
+
 struct DrainContext<'a> {
     extractor: &'a mut Extractor,
     parser: &'a mut Parser,
@@ -43,15 +74,8 @@ impl DrainContext<'_> {
 
         *self.parser = Parser::default();
         *self.decoder = Decoder::default();
-        self.parser.set_fail_level(fail_level);
         self.decoder.set_fail_level(fail_level);
-
-        let mut required_presentations = [false; MAX_PRESENTATIONS];
-        required_presentations[..=self.presentation as usize]
-            .iter_mut()
-            .for_each(|p| *p = true);
-        self.parser
-            .set_required_presentations(&required_presentations);
+        configure_parser(self.parser, fail_level, self.presentation);
 
         *self.current_substream_info = None;
         *self.current_extended_substream_info = None;
@@ -113,6 +137,17 @@ fn drain_frames(ctx: &mut DrainContext<'_>) -> (Vec<RDecodedFrame>, Option<Strin
                     ctx.perf.record_parse(parse_started.elapsed());
                     ctx.perf
                         .record_parse_substats(ctx.parser.last_parse_stats());
+                }
+
+                // Reading the length is a slice length; the list is only ever taken
+                // once it has actually grown, which a stream with no splice in it
+                // never does.
+                if ctx.parser.branches().len() > MAX_RETAINED_BRANCHES {
+                    let dropped = ctx.parser.take_branches().len();
+                    log::debug!(
+                        "dropped {dropped} recorded branch points at frame {}",
+                        ctx.frame_count
+                    );
                 }
 
                 // Track substream info changes and extract dialogue level.

--- a/damf/Cargo.toml
+++ b/damf/Cargo.toml
@@ -16,6 +16,6 @@ crate-type = ["lib"]
 # Nothing here may depend on the bridge ABI or on any CLI crate.
 [dependencies]
 truehdd-macros = "0.1.1"
-truehd = { version = "0.7.0" }
+truehd = { version = "0.7.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"

--- a/harletty/Cargo.toml
+++ b/harletty/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 # invariant (no damf/clap/indicatif reachable from harletty-bridge).
 [dependencies]
 truehdd-macros = "0.1.1"
-truehd = { version = "0.7.0" }
+truehd = { version = "0.7.1" }
 eac3 = { version = "0.7.3", path = "../eac3" }
 dca = { version = "0.7.3", path = "../dca" }
 damf = { version = "0.7.3", path = "../damf" }


### PR DESCRIPTION
Bumps `truehd` to 0.7.1 (published 2026-08-14) and wires up the two parser accessors that landed upstream in truehdd/truehdd#30 and #31.

## What this does

- **`set_check_fifo(false)`** — the byte-domain FIFO depth model answers whether a stream is legal to author on a disc; a playback decode never asks that. Decode time is unchanged either way (0.021 ms per 40-sample block), so this is about not doing the work at all, not a speedup.
- **`take_branches()`** — the parser records every timing-restart point and never forgets one. A file pass reads the list at the end, where the file bounds it; playback has no end to read it at, so a stream that restarts its timing often enough grows it for as long as it plays. The list is drained once it exceeds any plausible use (64 entries); checking the length is a slice length, and a stream with no splice never reaches the cap.

Both settings go through a new `configure_parser`, called from all three places that build or replace the parser: construction, pipeline reset, and parse recovery. Each of those re-applied its settings itself, so a setting applied in two of the three would silently revert at the third.

## Verification

- Full workspace test suite green against the published `truehd` 0.7.1 (132 tests, 0 failed), lockfile resolves 0.7.1 from crates.io.
- With the accessors patched in from upstream main before publication: engine parity harness renders the same stream to the same frame count, sample count and peak (0.765358) as before.
