### PR TITLE
A restated payload is not an Atmos event

### DIFF
--- a/damf/src/damf.rs
+++ b/damf/src/damf.rs
@@ -435,6 +435,9 @@ pub struct Configuration {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sample_rate: Option<u32>,
     pub events: Vec<Event>,
+    /// The payload carried no update timing, so it restates what is already in force.
+    #[serde(skip)]
+    pub restates_current_state: bool,
 }
 
 impl Configuration {
@@ -467,6 +470,7 @@ impl Configuration {
             return Ok(Self {
                 sample_rate: Some(sample_rate),
                 events: vec![],
+                restates_current_state: false,
             });
         };
 
@@ -503,6 +507,13 @@ impl Configuration {
         }
 
         let sample_offset = object_element.md_update_info.sample_offset as u64;
+        let restates_current_state = sample_offset == 0
+            && object_element
+                .md_update_info
+                .block_update_info
+                .iter()
+                .all(|block| block.block_offset_factor_bits == 0 && block.ramp_duration == 0);
+
         let ramp_duration =
             object_element.md_update_info.block_update_info[0].ramp_duration as usize;
 
@@ -577,6 +588,7 @@ impl Configuration {
         Ok(Self {
             sample_rate: Some(sample_rate),
             events,
+            restates_current_state,
         })
     }
 }
@@ -719,6 +731,21 @@ impl Event {
             .zip(events2)
             .map(|(event1, event2)| event1.diff(event2))
             .collect()
+    }
+
+    /// A payload that restates values already in force zeroes its timing, which leaves the ramp as
+    /// the only field that moved. A ramp to values that did not change is not an event.
+    pub fn drop_re_asserted_ramps(events: &mut [Event]) {
+        for event in events.iter_mut() {
+            let mut rest = event.clone();
+            rest.id = None;
+            rest.sample_pos = None;
+            rest.ramp_length = None;
+
+            if event.ramp_length == Some(0) && rest == Event::default() {
+                *event = Event::default();
+            }
+        }
     }
 }
 
@@ -1078,4 +1105,68 @@ fn unsupported_payload_shapes_are_reported_rather_than_asserted() {
         Configuration::with_oamd_payload(&beds, 48000, 0),
         Err(UnsupportedPayload::MultipleBedInstances(2))
     ));
+}
+
+/// An encoder that has no fresh metadata for a while re-asserts the last payload it sent, with
+/// the timing zeroed. The values are unchanged, so it says nothing new, and it must not turn
+/// into an event: the source never had one there.
+#[test]
+fn a_re_asserted_payload_writes_no_event() {
+    use truehd::structs::oamd::TEST_DATA_TRIM;
+
+    let oamd = ObjectAudioMetadataPayload::read(TEST_DATA_TRIM).unwrap();
+    let first = Configuration::with_oamd_payload(&oamd, 48000, 0).unwrap();
+
+    let mut repeat = oamd.clone();
+    let update = &mut repeat.object_element.as_mut().unwrap().md_update_info;
+    update.sample_offset = 0;
+    for block in update.block_update_info.iter_mut() {
+        block.block_offset_factor_bits = 0;
+        block.ramp_duration = 0;
+    }
+
+    let mut later = Configuration::with_oamd_payload(&repeat, 48000, 5120).unwrap();
+    assert!(later.restates_current_state);
+
+    let mut events = Event::compare_event_vectors(&first.events, &later.events);
+    Event::drop_re_asserted_ramps(&mut events);
+    later.events = events;
+
+    assert_eq!(
+        later.serialize_events(true),
+        "",
+        "a re-assert of the same values is not an event"
+    );
+}
+
+/// The re-assert rule keys on the values being unchanged, so a payload that zeroes its timing
+/// and moves an object is still an event.
+#[test]
+fn a_re_asserted_payload_still_reports_a_move() {
+    use truehd::structs::oamd::TEST_DATA_TRIM;
+
+    let oamd = ObjectAudioMetadataPayload::read(TEST_DATA_TRIM).unwrap();
+    let first = Configuration::with_oamd_payload(&oamd, 48000, 0).unwrap();
+
+    let mut repeat = oamd.clone();
+    let object_element = repeat.object_element.as_mut().unwrap();
+
+    let update = &mut object_element.md_update_info;
+    update.sample_offset = 0;
+    for block in update.block_update_info.iter_mut() {
+        block.block_offset_factor_bits = 0;
+        block.ramp_duration = 0;
+    }
+
+    let render = &mut object_element.object_data[1][0].object_render_info;
+    render.pos3d = [0.25, 0.75, 0.5];
+
+    let mut later = Configuration::with_oamd_payload(&repeat, 48000, 5120).unwrap();
+    let mut events = Event::compare_event_vectors(&first.events, &later.events);
+    Event::drop_re_asserted_ramps(&mut events);
+    later.events = events;
+
+    let written = later.serialize_events(true);
+    assert!(written.contains("pos: [-0.5, -0.5, 0.5]"), "{written}");
+    assert!(written.contains("samplePos: 5120"), "{written}");
 }

--- a/harletty/src/cli/decode/eac3_handler.rs
+++ b/harletty/src/cli/decode/eac3_handler.rs
@@ -264,11 +264,16 @@ impl Eac3DecodeHandler {
         base_path: &PathBuf,
     ) -> Result<()> {
         let mut conf = Configuration::with_oamd_payload(oamd, sample_rate, self.decoded_samples)?;
-        let (events_diff, remove_header) = if !self.prev_events.is_empty() {
+        let (mut events_diff, remove_header) = if !self.prev_events.is_empty() {
             (Event::compare_event_vectors(&self.prev_events, &conf.events), true)
         } else {
             (conf.events.clone(), false)
         };
+
+        if conf.restates_current_state && remove_header {
+            Event::drop_re_asserted_ramps(&mut events_diff);
+        }
+
         self.prev_events = conf.events.clone();
         conf.events = events_diff;
         let serialized = conf.serialize_events(remove_header);

--- a/harletty/src/cli/decode/handler.rs
+++ b/harletty/src/cli/decode/handler.rs
@@ -711,7 +711,7 @@ impl DecodeHandler {
         let mut conf =
             Configuration::with_oamd_payload(oamd, sample_rate, segment_relative_sample_pos)?;
 
-        let (events_diff, remove_header) = if !self.prev_events.is_empty() {
+        let (mut events_diff, remove_header) = if !self.prev_events.is_empty() {
             (
                 Event::compare_event_vectors(&self.prev_events, &conf.events),
                 true,
@@ -719,6 +719,10 @@ impl DecodeHandler {
         } else {
             (conf.events.clone(), false)
         };
+
+        if conf.restates_current_state && remove_header {
+            Event::drop_re_asserted_ramps(&mut events_diff);
+        }
 
         self.prev_events = conf.events.clone();
         conf.events = events_diff;


### PR DESCRIPTION
Port of upstream truehdd/truehdd@f65f75a4 (released in truehdd 0.6.1).

## The bug

An encoder that has no fresh object metadata to send re-emits the last payload with its update timing zeroed. That changes nothing about the objects, but it does change the ramp length — and a ramp was enough for the event diff to bring the whole event back with a new sample position. Any gap long enough to trigger a restatement gained an event the source never had, once per object. Beyond bloating the metadata, those false events are noise in any per-track activity metric computed from them.

## The fix

`Configuration::with_oamd_payload` now flags a payload whose timing is entirely zero (`restates_current_state`), and `Event::drop_re_asserted_ramps` empties the diffed events whose only surviving field is a zeroed ramp over unchanged values. `serialize_events` already drops default events, so such a payload is written as nothing at all. A restatement that does move an object is still an event — the rule keys on the values being unchanged.

## Beyond the upstream patch

The same guard is wired into the E-AC-3 handler: its synthesized OAMD takes the ramp duration from the JOC block updates, so a frame that re-asserts unchanged values with a zeroed ramp after a nonzero one would write the same false event. The DTS handler is left alone — its synthesized timing is always zero, so the ramp never changes and the guard would never fire there.

## Verification

Both upstream regression tests are ported (they run against `TEST_DATA_TRIM` from the published `truehd` 0.7.1): a pure restatement writes nothing, a restatement that moves an object still reports the move. Full workspace suite green (185 tests, 0 failed).

Note for existing outputs: `.atmos.metadata` files produced before this fix may carry these false events; affected titles need a re-decode to clean them up.
