### PR TITLE
Release 0.7.4: bump every workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "damf"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "serde",
  "serde_yaml_ng",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "dca"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "log",
  "rustfft",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "eac3"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "log",
  "rustfft",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "harletty"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "harletty-bridge"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "abi_stable",
  "anyhow",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harletty-bridge"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -21,8 +21,8 @@ bridge_api = { version = "0.3.0", path = "../../Omniphony/omniphony-renderer/bri
 spdif = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/spdif" }
 sys = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/sys" }
 truehd = { version = "0.7.1" }
-eac3 = { version = "0.7.3", path = "../eac3" }
-dca = { version = "0.7.3", path = "../dca" }
+eac3 = { version = "0.7.4", path = "../eac3" }
+dca = { version = "0.7.4", path = "../dca" }
 abi_stable = "0.11"
 log = "0.4"
 anyhow = "1.0"

--- a/damf/Cargo.toml
+++ b/damf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "damf"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "Dolby Atmos Master File (DAMF) metadata writer plus CAF/WAV container writers"

--- a/dca/Cargo.toml
+++ b/dca/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dca"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "Independent DTS Coherent Acoustics (DCA) bitstream parser and decoder"

--- a/eac3/Cargo.toml
+++ b/eac3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eac3"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "Independent E-AC-3 bitstream parser and frame extractor"

--- a/harletty/Cargo.toml
+++ b/harletty/Cargo.toml
@@ -3,7 +3,7 @@ name = "harletty"
 # Every crate in the workspace shares one version line: they all come from a
 # single commit and are tagged together, so a release number means the same
 # thing everywhere. Bump them together or not at all.
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "Offline decoder for TrueHD, E-AC-3 JOC and DTS bitstreams, writing Dolby Atmos master files"
@@ -22,9 +22,9 @@ path = "src/main.rs"
 [dependencies]
 truehdd-macros = "0.1.1"
 truehd = { version = "0.7.1" }
-eac3 = { version = "0.7.3", path = "../eac3" }
-dca = { version = "0.7.3", path = "../dca" }
-damf = { version = "0.7.3", path = "../damf" }
+eac3 = { version = "0.7.4", path = "../eac3" }
+dca = { version = "0.7.4", path = "../dca" }
+damf = { version = "0.7.4", path = "../damf" }
 
 anyhow = "1.0.99"
 clap = { version = "4.5.45", features = ["derive"] }


### PR DESCRIPTION
Bumps every workspace member to 0.7.4 and the inter-crate path dependencies with them, keeping the one-version-line rule from 0.7.3. External dependencies and the Omniphony path deps (bridge_api, spdif, sys) are untouched.

Everything since v0.7.3 (#30–#39) ships with this: the switch to the published upstream `truehd` crate (0.7.1), the CAF layout and metadata-panic fixes, negative-z object support, the QMF scalar ILP work, parser hygiene for playback, and the restated-payload fix.