### PR TITLE
Gate the QMF scalar accumulator count with its consumers

### DIFF
--- a/eac3/src/eac3dec/qmf.rs
+++ b/eac3/src/eac3dec/qmf.rs
@@ -120,6 +120,7 @@ impl Default for QuadratureMirrorFilterBank {
 /// waits on the previous one. Eight partial sums break that chain so the loop
 /// becomes throughput-bound instead. This matters most where no vector unit is
 /// reachable, which is exactly the fallback's job (see [`dot_product`]).
+#[cfg(any(test, not(target_arch = "aarch64")))]
 const SCALAR_ACCUMULATORS: usize = 8;
 
 /// The NEON paths below are gated on `target_arch`, not `target_feature`: only


### PR DESCRIPTION
The v0.7.4 release build died on the macOS arm64 job: `SCALAR_ACCUMULATORS` only feeds the scalar fallbacks, both of which are compiled out on aarch64 outside of tests, and the release workflow builds with `-D warnings`. The Linux CI gate never sees that cfg combination, so this could only surface at release time.

The constant now carries the same `#[cfg(any(test, not(target_arch = "aarch64")))]` gate as the two functions that read it. Reproduced and verified locally with `RUSTFLAGS="-D warnings" cargo check -p eac3 --target aarch64-unknown-linux-musl` (fails before, clean after); x86_64 check and the eac3 test suite are green.