### PR TITLE
Accept the AC-3 and DTS-HD IEC 61937 burst types

### DIFF
--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -660,7 +660,16 @@ impl FormatBridge for AtmosBridge {
                     self.eac3_active = false;
                     self.dts_active = true;
                     let payload = crate::dts_spdif::normalise_payload(data.as_slice());
-                    self.dts_buf.extend_from_slice(&payload);
+                    // Types I/II/III carry the frame directly; type IV wraps it
+                    // in a start code plus a length, and pads the burst past it.
+                    // Fed whole, the pipeline finds no sync word and decodes
+                    // nothing at all.
+                    let payload = if data_type == crate::dts_spdif::DTSHD_DATA_TYPE {
+                        crate::dts_spdif::unwrap_hd_payload(&payload).unwrap_or(&payload)
+                    } else {
+                        &payload
+                    };
+                    self.dts_buf.extend_from_slice(payload);
                     crate::dts_pipeline::drain_dts(self, &mut result);
                     return result;
                 }

--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -79,12 +79,7 @@ pub(crate) enum RawCodec {
 /// specific pattern first: the TrueHD major-sync word `0xF8726FBA` at offset 4,
 /// then the E-AC3/AC-3 sync word `0x0B77` at offset 0 (incl. byte-swapped).
 fn sniff_raw_codec(data: &[u8]) -> Option<RawCodec> {
-    if data.len() >= 8
-        && data[4] == 0xF8
-        && data[5] == 0x72
-        && data[6] == 0x6F
-        && data[7] == 0xBA
-    {
+    if data.len() >= 8 && data[4] == 0xF8 && data[5] == 0x72 && data[6] == 0x6F && data[7] == 0xBA {
         return Some(RawCodec::TrueHd);
     }
     // DTS core (0x7FFE8001) or extension substream (0x64582025) at offset 0.
@@ -183,10 +178,12 @@ pub(crate) struct AtmosBridge {
     pub(crate) frame_count: u64,
     /// Last object↔channel declaration emitted (sparse re-emission on change
     /// and after reset). Shared by the TrueHD and E-AC3 metadata paths.
-    pub(crate) declared_object_channels: Option<abi_stable::std_types::RVec<bridge_api::RObjectChannel>>,
+    pub(crate) declared_object_channels:
+        Option<abi_stable::std_types::RVec<bridge_api::RObjectChannel>>,
     /// Fixed-channel labels of the active TrueHD spatial presentation
     /// (bed labels from the OAMD bed assignment, then `Object` fillers).
-    pub(crate) truehd_spatial_labels: Option<abi_stable::std_types::RVec<bridge_api::RChannelLabel>>,
+    pub(crate) truehd_spatial_labels:
+        Option<abi_stable::std_types::RVec<bridge_api::RChannelLabel>>,
     pub(crate) perf: PerfStats,
 }
 
@@ -762,7 +759,10 @@ impl FormatBridge for AtmosBridge {
                 };
                 // Force re-resolution against the new codec on the next packet.
                 self.raw_codec = None;
-                log::debug!("atmos-bridge: input_codec set to {:?}", self.forced_raw_codec);
+                log::debug!(
+                    "atmos-bridge: input_codec set to {:?}",
+                    self.forced_raw_codec
+                );
                 true
             }
             #[cfg(feature = "bridge-perf")]
@@ -910,7 +910,10 @@ mod raw_transport_tests {
         let mut bridge = AtmosBridge::new(false);
         bridge.forced_raw_codec = Some(RawCodec::Eac3);
         // Unrecognisable bytes, but the host-declared codec wins.
-        assert_eq!(bridge.resolve_raw_codec(&[0x12, 0x34, 0x56, 0x78]), RawCodec::Eac3);
+        assert_eq!(
+            bridge.resolve_raw_codec(&[0x12, 0x34, 0x56, 0x78]),
+            RawCodec::Eac3
+        );
         assert_eq!(bridge.raw_codec, Some(RawCodec::Eac3));
     }
 
@@ -931,7 +934,10 @@ mod raw_transport_tests {
         let mut bridge = AtmosBridge::new(false);
         // No recognisable sync → treat as TrueHD for this packet but do NOT
         // lock, so a later syncful packet can still pin the codec.
-        assert_eq!(bridge.resolve_raw_codec(&[0x12, 0x34, 0x56, 0x78]), RawCodec::TrueHd);
+        assert_eq!(
+            bridge.resolve_raw_codec(&[0x12, 0x34, 0x56, 0x78]),
+            RawCodec::TrueHd
+        );
         assert_eq!(bridge.raw_codec, None);
     }
 
@@ -1013,11 +1019,17 @@ mod raw_transport_tests {
             .find(|f| f.channel_count == 12)
             .expect("expected a 12-channel 7.1.4 frame");
         assert_eq!(f.sampling_frequency, 48_000);
-        assert!(f.metadata.is_empty(), "fixed presentation must carry no metadata");
+        assert!(
+            f.metadata.is_empty(),
+            "fixed presentation must carry no metadata"
+        );
         use bridge_api::RChannelLabel::*;
         let labels: Vec<_> = f.channel_labels.iter().copied().collect();
         // Active speakers ascending (C,L,R,Ls,Rs,LFE,Lsr,Rsr) + the height quartet.
-        assert_eq!(labels, vec![C, L, R, Ls, Rs, LFE, Lb, Rb, Tfl, Tfr, Tbl, Tbr]);
+        assert_eq!(
+            labels,
+            vec![C, L, R, Ls, Rs, LFE, Lb, Rb, Tfl, Tfr, Tbl, Tbr]
+        );
     }
 
     #[test]
@@ -1092,10 +1104,7 @@ mod raw_transport_tests {
         assert!(bridge.configure("input_codec".into(), "dts".into()));
         let result = bridge.push_packet(RSlice::from_slice(&bytes), RInputTransport::Raw, 0);
         assert!(result.error_message.is_empty(), "{}", result.error_message);
-        assert!(
-            bridge.has_objects(),
-            "D3 must expose object channels"
-        );
+        assert!(bridge.has_objects(), "D3 must expose object channels");
 
         let frame = result
             .frames

--- a/bridge/src/dts_pipeline.rs
+++ b/bridge/src/dts_pipeline.rs
@@ -886,10 +886,7 @@ mod tests {
                 format!("X{source}")
             );
             assert_eq!(metadata.events[source].id, (10 + source) as u32);
-            assert_eq!(
-                metadata.events[source].pos,
-                d3_object_position(source)
-            );
+            assert_eq!(metadata.events[source].pos, d3_object_position(source));
         }
     }
 

--- a/bridge/src/dts_spdif.rs
+++ b/bridge/src/dts_spdif.rs
@@ -1,9 +1,12 @@
 //! Minimal IEC 61937 (S/PDIF) handling for DTS.
 //!
-//! Unlike E-AC3 (which needs syncframe re-framing), a DTS burst carries the DTS
-//! frame directly. We only normalise the 16-bit word order — IEC 61937 may
-//! transmit DTS byte-swapped — and hand the bytes to the DTS pipeline, which
-//! demuxes `[core][exss]` frames itself (the same path as the raw transport).
+//! For types I/II/III the burst carries the DTS frame directly: we only
+//! normalise the 16-bit word order — IEC 61937 may transmit DTS byte-swapped —
+//! and hand the bytes to the DTS pipeline, which demuxes `[core][exss]` frames
+//! itself (the same path as the raw transport).
+//!
+//! Type IV (DTS-HD) is not direct: the frame is wrapped in a 12-byte header, so
+//! the payload has to be unwrapped before the pipeline can see a sync word.
 
 use std::borrow::Cow;
 
@@ -13,13 +16,28 @@ pub(crate) fn accepts_data_type(data_type: u8) -> bool {
     matches!(data_type, 0x0B | 0x0C | 0x0D | 0x11)
 }
 
-/// Normalise an IEC 61937 DTS burst payload to native byte order. DTS sync words
-/// are `0x7FFE8001` (core) / `0x64582025` (extension substream); IEC 61937 may
-/// carry them with each 16-bit word byte-swapped (`0xFE7F0180` / `0x58642520`),
-/// which this undoes. Returns the input untouched when it is already native.
+/// IEC 61937 data type of the DTS-HD substream burst.
+pub(crate) const DTSHD_DATA_TYPE: u8 = 0x11;
+
+/// Start code opening a DTS-HD burst payload, followed by the frame length as a
+/// big-endian `u16`. Matches `dtshd_start_code` in ffmpeg's spdif muxer, which
+/// is what mpv emits.
+const DTSHD_START_CODE: [u8; 10] = [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFE, 0xFE];
+const DTSHD_HEADER_LEN: usize = DTSHD_START_CODE.len() + 2;
+
+/// Normalise an IEC 61937 DTS burst payload to native byte order.
+///
+/// DTS sync words are `0x7FFE8001` (core) / `0x64582025` (extension substream);
+/// IEC 61937 may carry them with each 16-bit word byte-swapped (`0xFE7F0180` /
+/// `0x58642520`), which this undoes. A DTS-HD burst opens on its start code
+/// rather than a sync word, so that swapped form is recognised too — otherwise
+/// the payload stays swapped and nothing downstream matches. Returns the input
+/// untouched when it is already native.
 pub(crate) fn normalise_payload(data: &[u8]) -> Cow<'_, [u8]> {
     let swapped = data.len() >= 2
-        && ((data[0] == 0xFE && data[1] == 0x7F) || (data[0] == 0x58 && data[1] == 0x64));
+        && ((data[0] == 0xFE && data[1] == 0x7F)
+            || (data[0] == 0x58 && data[1] == 0x64)
+            || (data[0] == 0x00 && data[1] == 0x01));
     if !swapped {
         return Cow::Borrowed(data);
     }
@@ -28,6 +46,23 @@ pub(crate) fn normalise_payload(data: &[u8]) -> Cow<'_, [u8]> {
         pair.swap(0, 1);
     }
     Cow::Owned(out)
+}
+
+/// Strip the DTS-HD burst wrapper, returning the DTS frame it carries.
+///
+/// The payload is `[start code][length: u16 big-endian][frame]`, and the burst
+/// is padded out to the IEC 61937 period, so the declared length — not the
+/// payload size — bounds the frame. Returns `None` when the wrapper is absent,
+/// letting the caller pass the payload through unchanged rather than guess.
+///
+/// Expects `data` already in native byte order.
+pub(crate) fn unwrap_hd_payload(data: &[u8]) -> Option<&[u8]> {
+    if data.len() < DTSHD_HEADER_LEN || data[..DTSHD_START_CODE.len()] != DTSHD_START_CODE {
+        return None;
+    }
+    let declared = u16::from_be_bytes([data[10], data[11]]) as usize;
+    let frame = &data[DTSHD_HEADER_LEN..];
+    Some(&frame[..declared.min(frame.len())])
 }
 
 #[cfg(test)]
@@ -52,5 +87,41 @@ mod tests {
         // Native payload is passed through untouched.
         let native = [0x7F, 0xFE, 0x80, 0x01];
         assert_eq!(&normalise_payload(&native)[..], &native);
+    }
+
+    /// A DTS-HD burst opens on its start code, not a sync word, so the swap
+    /// detection has to recognise it or the payload stays byte-swapped.
+    #[test]
+    fn deswaps_byte_swapped_hd_start_code() {
+        let mut swapped = vec![0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFE, 0xFE];
+        swapped.extend_from_slice(&[0xF0, 0x17]);
+        let out = normalise_payload(&swapped);
+        assert_eq!(&out[..DTSHD_START_CODE.len()], &DTSHD_START_CODE);
+    }
+
+    #[test]
+    fn unwraps_hd_payload_to_the_declared_length() {
+        let frame: Vec<u8> = (0..64u8).collect();
+        let mut payload = DTSHD_START_CODE.to_vec();
+        payload.extend_from_slice(&(frame.len() as u16).to_be_bytes());
+        payload.extend_from_slice(&frame);
+        // Burst padding beyond the declared frame must be dropped.
+        payload.extend_from_slice(&[0u8; 32]);
+        assert_eq!(unwrap_hd_payload(&payload), Some(&frame[..]));
+    }
+
+    #[test]
+    fn leaves_a_plain_dts_burst_alone() {
+        let core = [0x7F, 0xFE, 0x80, 0x01, 0x00, 0x11, 0x22, 0x33];
+        assert_eq!(unwrap_hd_payload(&core), None);
+    }
+
+    /// A truncated burst must clamp to what arrived instead of panicking.
+    #[test]
+    fn clamps_a_declared_length_past_the_payload() {
+        let mut payload = DTSHD_START_CODE.to_vec();
+        payload.extend_from_slice(&4096u16.to_be_bytes());
+        payload.extend_from_slice(&[0xAA; 16]);
+        assert_eq!(unwrap_hd_payload(&payload), Some(&[0xAA; 16][..]));
     }
 }

--- a/bridge/src/eac3_pipeline.rs
+++ b/bridge/src/eac3_pipeline.rs
@@ -156,7 +156,11 @@ pub(crate) fn process_eac3_dependent_frame_with_core(
         bridge.eac3_total_samples += sample_count as u64;
         bridge.eac3_diag_stats.dependent_pair_channel_beds += 1;
         bridge.perf.maybe_report(bridge.eac3_frame_count);
-        return Ok(Some(build_eac3_channel_bed_frame(&bed, Some(&dep_info), bridge)));
+        return Ok(Some(build_eac3_channel_bed_frame(
+            &bed,
+            Some(&dep_info),
+            bridge,
+        )));
     }
 
     match bridge

--- a/bridge/src/eac3_spdif.rs
+++ b/bridge/src/eac3_spdif.rs
@@ -17,6 +17,14 @@ use crate::logging::bridge_external_log;
 /// IEC 61937 data type for E-AC-3.
 const IEC61937_EAC3_DATA_TYPE: u8 = 0x15;
 
+/// IEC 61937 data type for AC-3 (IEC 61937-3).
+///
+/// Legacy AC-3 rides its own burst type and its own 48 kHz carrier, but the
+/// bitstream inside shares the 0x0B77 syncword with E-AC-3 and is already
+/// handled here: `ac3_frame_size_from_header` is tried before the E-AC-3 sizing
+/// on every frame boundary, and the decoder accepts `bsid <= 10`.
+const IEC61937_AC3_DATA_TYPE: u8 = 0x01;
+
 /// E-AC-3 syncword (16-bit big-endian: 0x0B77).
 const EAC3_SYNCWORD: u16 = 0x0B77;
 
@@ -154,7 +162,7 @@ impl Eac3SpdifStream {
 
     /// Returns `true` if this parser handles the given IEC 61937 data type.
     pub fn accepts_data_type(data_type: u8) -> bool {
-        data_type == IEC61937_EAC3_DATA_TYPE
+        matches!(data_type, IEC61937_EAC3_DATA_TYPE | IEC61937_AC3_DATA_TYPE)
     }
 
     /// Replace the current payload with a new one.
@@ -562,8 +570,13 @@ mod tests {
     #[test]
     fn accepts_expected_data_type() {
         assert!(Eac3SpdifStream::accepts_data_type(0x15));
+        // AC-3 rides burst type 0x01, and its frames are sized and decoded by
+        // this same parser.
+        assert!(Eac3SpdifStream::accepts_data_type(0x01));
+        // TrueHD/MAT stays with the MAT stream.
         assert!(!Eac3SpdifStream::accepts_data_type(0x16));
-        assert!(!Eac3SpdifStream::accepts_data_type(0x01));
+        // DTS types belong to the DTS path.
+        assert!(!Eac3SpdifStream::accepts_data_type(0x0B));
     }
 
     #[test]

--- a/bridge/src/labels.rs
+++ b/bridge/src/labels.rs
@@ -95,9 +95,6 @@ pub(crate) fn bed_channel_to_r(ch: eac3::BedChannel) -> RChannelLabel {
     }
 }
 
-
-
-
 /// Channel label for an OAMD bed-assignment speaker index
 /// (`truehd::structs::oamd::SpeakerLabels` order).
 pub(crate) fn oamd_speaker_to_label(speaker_index: usize) -> RChannelLabel {
@@ -106,12 +103,12 @@ pub(crate) fn oamd_speaker_to_label(speaker_index: usize) -> RChannelLabel {
         1 => RChannelLabel::R,
         2 => RChannelLabel::C,
         3 => RChannelLabel::LFE,
-        4 => RChannelLabel::Ls,  // Lss
-        5 => RChannelLabel::Rs,  // Rss
-        6 => RChannelLabel::Lb,  // Lrs
-        7 => RChannelLabel::Rb,  // Rrs
-        8 => RChannelLabel::Tfl, // Lfh (front height)
-        9 => RChannelLabel::Tfr, // Rfh
+        4 => RChannelLabel::Ls,   // Lss
+        5 => RChannelLabel::Rs,   // Rss
+        6 => RChannelLabel::Lb,   // Lrs
+        7 => RChannelLabel::Rb,   // Rrs
+        8 => RChannelLabel::Tfl,  // Lfh (front height)
+        9 => RChannelLabel::Tfr,  // Rfh
         10 => RChannelLabel::Tsl, // Lts (top side)
         11 => RChannelLabel::Tsr, // Rts
         12 => RChannelLabel::Tbl, // Lrh (rear height)

--- a/bridge/src/metadata.rs
+++ b/bridge/src/metadata.rs
@@ -445,15 +445,14 @@ fn extract_events(
 
         let id = (i + 10 - bed_index_vec.len()) as u32;
         let render = &object_data.object_render_info;
-        let (has_pos, pos, size) =
-            match pos_vec.get(i).and_then(|raw_blocks| raw_blocks.first()) {
-                Some(raw) if raw.len() >= 3 => (true, [raw[0], raw[1], raw[2]], render.object_size),
-                Some(_) => (false, [0.0; 3], [0.0; 3]),
-                None => {
-                    missing_damf_pos += 1;
-                    (false, [0.0; 3], [0.0; 3])
-                }
-            };
+        let (has_pos, pos, size) = match pos_vec.get(i).and_then(|raw_blocks| raw_blocks.first()) {
+            Some(raw) if raw.len() >= 3 => (true, [raw[0], raw[1], raw[2]], render.object_size),
+            Some(_) => (false, [0.0; 3], [0.0; 3]),
+            None => {
+                missing_damf_pos += 1;
+                (false, [0.0; 3], [0.0; 3])
+            }
+        };
 
         objects.push((id, i));
         events.push(bridge_api::REvent {

--- a/bridge/src/truehd_pipeline.rs
+++ b/bridge/src/truehd_pipeline.rs
@@ -249,16 +249,15 @@ fn drain_frames(ctx: &mut DrainContext<'_>) -> (Vec<RDecodedFrame>, Option<Strin
                         }
                         DrcMode::Heavy if ss_state.heavy_drc_active || ss_state.drc_active => {
                             if ss_state.heavy_drc_active {
-                                drc_gain =
-                                    (ss_state.heavy_drc_gain_update as f32 * 0.03125).exp2();
+                                drc_gain = (ss_state.heavy_drc_gain_update as f32 * 0.03125).exp2();
                                 drc_ramp_duration = ((1 << ss_state.heavy_drc_time_update)
                                     * decoded.sample_length)
                                     as u32;
                             } else {
                                 drc_gain = (ss_state.drc_gain_update as f32 * 0.015625).exp2();
-                                drc_ramp_duration =
-                                    ((1 << ss_state.drc_time_update) * decoded.sample_length)
-                                        as u32;
+                                drc_ramp_duration = ((1 << ss_state.drc_time_update)
+                                    * decoded.sample_length)
+                                    as u32;
                             }
                             drc_source_ss = Some(i);
                             break;
@@ -422,7 +421,11 @@ fn build_thd_frame(
         // Spatial presentation: authoritative labels come from the OAMD bed
         // assignment (cached across frames without a payload).
         Some(labels) => labels.clone(),
-        None => decoded.channel_labels.iter().map(channel_label_to_r).collect(),
+        None => decoded
+            .channel_labels
+            .iter()
+            .map(channel_label_to_r)
+            .collect(),
     };
     #[cfg(feature = "bridge-perf")]
     ctx.perf.record_build_labels(labels_started.elapsed());


### PR DESCRIPTION
Two burst types reached this bridge and decoded to silence. In both cases
the decoding was already here — only the IEC 61937 front door refused
them.

## AC-3 (burst type 0x01)

The frame splitter already tries `ac3_frame_size_from_header` before the
E-AC-3 sizing at every frame boundary, the AC-3 frame-size table sits
next to it, and the decoder accepts `bsid <= 10`. Only
`accepts_data_type` refused: it matched 0x15 alone, so 0x01 fell through
to "Unsupported IEC 61937 data type for this bridge".

AC-3 rides its own 48 kHz carrier, but the bitstream inside shares the
0x0B77 sync word with E-AC-3 and the same word-swap handling, so it needs
no path of its own.

## DTS-HD (burst type 0x11)

The module assumed every DTS burst carries the frame directly. That holds
for types I/II/III and not for type IV, whose payload is
`[10-byte start code][length: u16 big-endian][frame]`, padded out to the
IEC 61937 period. Handed over whole, the pipeline found no sync word
where it expected one.

Two defects followed from that assumption: the wrapper was never
stripped, and the byte-order detection keyed on the core and extension
sync words — a type IV burst opens on the start code instead, so it was
not recognised as swapped and stayed byte-swapped on top of being
wrapped. The declared length now bounds the frame rather than the padded
payload size, clamped so a truncated burst cannot slice past its end.

The start code matches ffmpeg's spdif muxer, which is what mpv emits.
Confirmed against a burst captured from the stream itself
(`01 00 00 00 00 00 00 00 fe fe`, then `0x17F0` = 6128 bytes, then the
core sync word) rather than from the reference alone.

## Verification

Both exercised with mpv passthrough into the Omniphony PipeWire sink:

- AC-3 640 kbps: bursts deframe to 2560-byte frames, 26 MB rendered at
  peak 0.50 with no NaN and no underrun.
- DTS-HD MA 5.1: 22 MB rendered at peak 0.37, where nothing was produced
  before.
- E-AC-3 replayed on the same running renderer afterwards, unaffected —
  the shared parser did not regress.

60 tests pass. The exclusion test that pinned the old AC-3 behaviour now
covers the three neighbouring burst types instead.

Not verified: whether the DTS-HD lossless extension is decoded or the
pipeline settles for the core. The rendered peak matches the core-only
run exactly, which is worth a closer look.

These codecs only become reachable once the sink advertises them, which
is the companion change in the Omniphony repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)