### PR TITLE
feat(research): probe private matrices without changing playback

### DIFF
--- a/dca/Cargo.toml
+++ b/dca/Cargo.toml
@@ -15,3 +15,8 @@ crate-type = ["lib"]
 log = "0.4"
 thiserror = "2.0"
 rustfft = "6.4"
+
+# Keep the offline parser's synthetic corruption tests in the normal CI suite.
+[[example]]
+name = "xll_private_metadata"
+test = true

--- a/dca/examples/xll_private_metadata.rs
+++ b/dca/examples/xll_private_metadata.rs
@@ -3,7 +3,7 @@
 // runs in the decoder or determines a playback presentation.
 //
 // cargo run -p dca --release --example xll_private_metadata --
-//     [--max-mb 64] input.dts [input.dts ...]
+//     [--max-mb 64] [--segments] input.dts [input.dts ...]
 
 use std::collections::BTreeMap;
 use std::io::{BufReader, Read};
@@ -76,6 +76,21 @@ struct Route {
     // Only calibration points verified against the existing Q15 downmix
     // table are exposed. Unknown codes must not silently get a default gain.
     calibrated_q15: Option<u16>,
+}
+
+// Six-bit gain codes verified against PCM so far. Every value is the decoder's
+// downmix-table entry at index `4 * code - 3`, i.e. half a decibel per code
+// with 61 as unity, but that relation is only established at these points:
+// 55 and 61 by the standard height fold, 46 and 58 by an exactly reproduced
+// object fold in the alternate corpus. Other codes stay raw.
+fn calibrated_q15(code: u8) -> Option<u16> {
+    match code {
+        46 => Some(13_818),
+        55 => Some(23_170),
+        58 => Some(27_571),
+        61 => Some(32_768),
+        _ => None,
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -170,11 +185,7 @@ fn parse_matrix(bytes: &[u8], inherited_mask: u32) -> Result<Matrix, Error> {
                 source,
                 target,
                 gain_code,
-                calibrated_q15: match gain_code {
-                    55 => Some(23_170),
-                    61 => Some(32_768),
-                    _ => None,
-                },
+                calibrated_q15: calibrated_q15(gain_code),
             });
         }
     }
@@ -272,6 +283,13 @@ fn sparse_codes(b: &mut Bits<'_>, columns: usize) -> Result<Vec<(usize, u8)>, Er
 // Consume the supported mode-1 variable form all the way to the type-3
 // boundary. Raw codes only: waveform identity and presentation are separate.
 fn type241_dynamic(bytes: &[u8]) -> Result<Dynamic241, Error> {
+    type241_variable(bytes, false)
+}
+
+// Candidate only: mode 0 appears to carry a fourth record option bit and
+// omit the reference rows. Exact consumption is evidence, not a definition
+// of the extra bit or permission to use these positions during playback.
+fn type241_variable(bytes: &[u8], allow_mode0_candidate: bool) -> Result<Dynamic241, Error> {
     let header = type241_header(bytes)?;
     let mut b = Bits {
         bytes,
@@ -279,10 +297,13 @@ fn type241_dynamic(bytes: &[u8]) -> Result<Dynamic241, Error> {
     };
     let mut positions = Vec::new();
     for declaration in &header.declarations {
-        if declaration.mode != 1 {
+        if declaration.mode == 0 && allow_mode0_candidate {
+            b.expect(4, 1, "candidate mode-0 record options")?;
+        } else if declaration.mode == 1 {
+            b.expect(3, 0, "type-241 record options")?;
+        } else {
             return Err(Error::Unsupported("type-241 dynamic mode"));
         }
-        b.expect(3, 0, "type-241 record options")?;
         b.expect(7, 0x20, "type-241 position options")?;
         b.expect(1, 1, "type-241 gain present")?;
         b.expect(1, 1, "type-241 position flag")?;
@@ -292,7 +313,11 @@ fn type241_dynamic(bytes: &[u8]) -> Result<Dynamic241, Error> {
         let azimuth_code = b.read(8)? as u8;
         let elevation_code = b.read(7)? as u8;
         b.expect(1, 0, "type-241 extent")?;
-        let present = [b.read(1)? != 0, b.read(1)? != 0];
+        let present = if declaration.mode == 1 {
+            [b.read(1)? != 0, b.read(1)? != 0]
+        } else {
+            [false, false]
+        };
         let mut reference_rows = [Vec::new(), Vec::new()];
         for (row, present) in reference_rows.iter_mut().zip(present) {
             if present {
@@ -458,7 +483,15 @@ fn describe(payload: &[u8]) -> Result<String, Error> {
                         let rows = type3_rows_candidate(&prefix[start..]);
                         let declaration = type241_header(&prefix[..start]);
                         let dynamic = type241_dynamic(&prefix[..start]);
-                        candidates.push(format!("byte={start} header={header:?} matrix={status:?} unverified_rows12={rows:?} static241={declaration:?} dynamic241={dynamic:?}"));
+                        let mode0 = if matches!(
+                            dynamic,
+                            Err(Error::Unsupported("type-241 dynamic mode"))
+                        ) {
+                            Some(type241_variable(&prefix[..start], true))
+                        } else {
+                            None
+                        };
+                        candidates.push(format!("byte={start} header={header:?} matrix={status:?} unverified_rows12={rows:?} static241={declaration:?} dynamic241={dynamic:?} unverified_mode0={mode0:?}"));
                     }
                 }
             }
@@ -471,7 +504,22 @@ fn describe(payload: &[u8]) -> Result<String, Error> {
     }
 }
 
-fn probe(path: &str, limit: usize, input_index: usize) -> Result<(), String> {
+// One run of consecutive frames carrying the same observation, reported with
+// its bed-sample span so offline PCM analysis can align metadata to audio.
+struct Segment {
+    observation: String,
+    start_frame: usize,
+    start_sample: u64,
+}
+
+fn print_segment(segment: &Segment, end_frame: usize, end_sample: u64) {
+    println!(
+        "  segment frames={}..{} samples={}..{} {}",
+        segment.start_frame, end_frame, segment.start_sample, end_sample, segment.observation
+    );
+}
+
+fn probe(path: &str, limit: usize, input_index: usize, segments: bool) -> Result<(), String> {
     let file = std::fs::File::open(path).map_err(|e| format!("open: {e}"))?;
     let mut reader = BufReader::new(file);
     let mut decoder = HdDecoder::new();
@@ -483,6 +531,8 @@ fn probe(path: &str, limit: usize, input_index: usize) -> Result<(), String> {
     let mut extension_errors = 0usize;
     let mut invalid_metadata = 0usize;
     let mut observations = BTreeMap::<String, usize>::new();
+    let mut sample_offset = 0u64;
+    let mut segment: Option<Segment> = None;
     let mut core = Vec::new();
     let mut exss = Vec::new();
     let mut incomplete_tail = false;
@@ -574,6 +624,24 @@ fn probe(path: &str, limit: usize, input_index: usize) -> Result<(), String> {
                         }
                     }
                 };
+                if segments {
+                    let changed = segment
+                        .as_ref()
+                        .is_none_or(|current| current.observation != observation);
+                    if changed {
+                        if let Some(previous) = segment.take() {
+                            print_segment(&previous, frames - 1, sample_offset);
+                        }
+                        segment = Some(Segment {
+                            observation: observation.clone(),
+                            start_frame: frames - 1,
+                            start_sample: sample_offset,
+                        });
+                    }
+                }
+                sample_offset = sample_offset
+                    .checked_add(frame.bed_sample_count() as u64)
+                    .ok_or("sample offset overflow")?;
                 *observations.entry(observation).or_default() += 1;
             }
             Err(HdError::Pending) => pending += 1,
@@ -583,6 +651,9 @@ fn probe(path: &str, limit: usize, input_index: usize) -> Result<(), String> {
     }
     if frames == 0 {
         return Err("no decoded frames; corpus was not exercised".into());
+    }
+    if let Some(last) = segment.take() {
+        print_segment(&last, frames, sample_offset);
     }
     println!(
         "input={input_index} frames={frames} pending={pending} bytes={offset} descriptor_matches={nav_matches} type69_marker_matches={type69_marker_matches} extension_errors={extension_errors} invalid_metadata={invalid_metadata} incomplete_tail={incomplete_tail}"
@@ -606,8 +677,11 @@ fn run() -> Result<(), String> {
     let mut args = std::env::args().skip(1);
     let mut limit = 64usize * 1024 * 1024;
     let mut count = 0;
+    let mut segments = false;
     while let Some(arg) = args.next() {
-        if arg == "--max-mb" {
+        if arg == "--segments" {
+            segments = true;
+        } else if arg == "--max-mb" {
             limit = args
                 .next()
                 .ok_or("missing --max-mb")?
@@ -618,11 +692,11 @@ fn run() -> Result<(), String> {
                 .ok_or("invalid byte limit")?;
         } else {
             count += 1;
-            probe(&arg, limit, count)?;
+            probe(&arg, limit, count, segments)?;
         }
     }
     if count == 0 {
-        return Err("usage: xll_private_metadata [--max-mb 64] input.dts ...".into());
+        return Err("usage: xll_private_metadata [--max-mb 64] [--segments] input.dts ...".into());
     }
     Ok(())
 }
@@ -752,6 +826,61 @@ mod tests {
     }
 
     #[test]
+    fn mode0_candidate_requires_an_option_bit_in_each_record() {
+        let header = declaration_fixture(&[0, 1], 0);
+        let mut bits: Vec<u8> = (0..100)
+            .map(|i| (header[i / 8] >> (7 - i % 8)) & 1)
+            .collect();
+        for azimuth in [100, 140] {
+            for (value, width) in [
+                (1, 4),
+                (0x20, 7),
+                (1, 1),
+                (1, 1),
+                (0, 2),
+                (61, 6),
+                (63, 6),
+                (azimuth, 8),
+                (80, 7),
+                (0, 1),
+            ] {
+                for bit in (0..width).rev() {
+                    bits.push(((value >> bit) & 1) as u8);
+                }
+            }
+        }
+        bits.push(0); // No auxiliary section.
+        let mut bytes = vec![0; bits.len().div_ceil(8)];
+        for (i, bit) in bits.into_iter().enumerate() {
+            bytes[i / 8] |= bit << (7 - i % 8);
+        }
+        assert_eq!(
+            type241_dynamic(&bytes),
+            Err(Error::Unsupported("type-241 dynamic mode"))
+        );
+        let candidate = type241_variable(&bytes, true).unwrap();
+        assert_eq!(candidate.end_bit, 187);
+        assert_eq!(candidate.positions[0].spherical_units, (-60, 60, 64));
+        assert_eq!(candidate.positions[1].spherical_units, (60, 60, 64));
+        assert!(
+            candidate
+                .positions
+                .iter()
+                .all(|p| p.reference_rows.iter().all(Vec::is_empty))
+        );
+        for option_bit in [103, 146] {
+            let mut missing = bytes.clone();
+            missing[option_bit / 8] &= !(1 << (7 - option_bit % 8));
+            assert!(type241_variable(&missing, true).is_err());
+        }
+        for end in 0..bytes.len() {
+            assert!(type241_variable(&bytes[..end], true).is_err());
+        }
+        bytes.push(0);
+        assert!(type241_variable(&bytes, true).is_err());
+    }
+
+    #[test]
     fn declaration_count_and_indices_are_read_not_inferred_from_profile() {
         for indices in [&[0][..], &[1, 0], &[3, 1, 0, 2], &[4, 2, 1, 0, 3]] {
             for mode in 0..=1 {
@@ -862,6 +991,13 @@ mod tests {
         assert_eq!(changed.routes[0].gain_code, 54);
         assert_eq!(matrix.routes[0].calibrated_q15, Some(23170));
         assert_eq!(changed.routes[0].calibrated_q15, None);
+        // The verified points and nothing in between.
+        assert_eq!(calibrated_q15(46), Some(13_818));
+        assert_eq!(calibrated_q15(58), Some(27_571));
+        assert_eq!(calibrated_q15(61), Some(32_768));
+        for code in [0, 45, 47, 54, 56, 57, 59, 60, 62, 63] {
+            assert_eq!(calibrated_q15(code), None, "code {code}");
+        }
     }
 
     #[test]

--- a/dca/examples/xll_private_metadata.rs
+++ b/dca/examples/xll_private_metadata.rs
@@ -1,0 +1,633 @@
+// SPDX-License-Identifier: Apache-2.0
+// Offline, deliberately narrow private-metadata investigation. Nothing here
+// runs in the decoder or determines a playback presentation.
+//
+// cargo run -p dca --release --example xll_private_metadata --
+//     [--max-mb 64] input.dts [input.dts ...]
+
+use std::collections::BTreeMap;
+use std::io::{BufReader, Read};
+
+use dca::{HdDecoder, HdError, exss_substream_size, parse_header};
+
+const OUTER_SUFFIX: &[u8] = &[3, 0x34, 0x38, 0x8c, 0x4f, 0];
+const MAX_PREFIX: usize = 96;
+
+#[derive(Debug, PartialEq, Eq)]
+enum Error {
+    Truncated,
+    Unsupported(&'static str),
+    Invalid(&'static str),
+}
+
+struct Bits<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl Bits<'_> {
+    fn read(&mut self, width: usize) -> Result<u32, Error> {
+        let end = self.pos.checked_add(width).ok_or(Error::Truncated)?;
+        if width > 32 || end > self.bytes.len().saturating_mul(8) {
+            return Err(Error::Truncated);
+        }
+        let mut value = 0;
+        for bit in self.pos..end {
+            value = (value << 1) | u32::from((self.bytes[bit / 8] >> (7 - bit % 8)) & 1);
+        }
+        self.pos = end;
+        Ok(value)
+    }
+
+    fn expect(&mut self, width: usize, expected: u32, field: &'static str) -> Result<(), Error> {
+        if self.read(width)? != expected {
+            return Err(Error::Unsupported(field));
+        }
+        Ok(())
+    }
+}
+
+fn crc16(bytes: &[u8]) -> u16 {
+    let mut crc = 0xffffu16;
+    for &byte in bytes {
+        crc ^= u16::from(byte) << 8;
+        for _ in 0..8 {
+            crc = (crc << 1) ^ if crc & 0x8000 != 0 { 0x1021 } else { 0 };
+        }
+    }
+    crc
+}
+
+// This investigation currently knows only the two layouts independently
+// calibrated in the fixed-height corpus. Other masks remain unsupported.
+fn channels(mask: u32) -> Result<&'static [&'static str], Error> {
+    match mask {
+        0x084b => Ok(&["C", "L", "R", "LFE", "Lb", "Rb", "Lss", "Rss"]),
+        0x8020 => Ok(&["TFL", "TFR", "TBL", "TBR"]),
+        _ => Err(Error::Unsupported("speaker mask")),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Route {
+    source: &'static str,
+    target: &'static str,
+    gain_code: u8,
+    // Only calibration points verified against the existing Q15 downmix
+    // table are exposed. Unknown codes must not silently get a default gain.
+    calibrated_q15: Option<u16>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Matrix {
+    reference_mask: u32,
+    output_mask: u32,
+    mix_code: u8,
+    routes: Vec<Route>,
+    encoded_bytes: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct LayoutHeader {
+    kind: u8,
+    reference_mask: u32,
+    output_mask: u32,
+    end_bit: usize,
+}
+
+// Read only the observed header forms. Uninterpreted flags are constrained,
+// not silently accepted as though their semantics were understood.
+fn layout_header(bytes: &[u8], inherited_mask: u32) -> Result<LayoutHeader, Error> {
+    let mut b = Bits { bytes, pos: 0 };
+    let kind = b.read(8)? as u8;
+    if !matches!(kind, 2 | 3) {
+        return Err(Error::Unsupported("element type"));
+    }
+    b.expect(8, 0, "element header byte")?;
+    b.expect(1, 0, "header flag")?;
+    b.expect(4, 1, "header field A")?;
+    b.expect(4, u32::from(kind == 3), "header field B")?;
+    let reference_mask = if b.read(1)? != 0 {
+        b.expect(1, 0, "reference flag")?;
+        b.expect(1, 1, "explicit reference mask")?;
+        b.expect(2, 0, "reference mode")?;
+        b.expect(3, 0, "reference field")?;
+        let width = 4 * (b.read(3)? as usize + 1);
+        b.read(width)?
+    } else {
+        b.expect(1, 0, "implicit reference mask")?;
+        b.expect(4, 0, "implicit reference field")?;
+        inherited_mask
+    };
+    b.expect(1, 1, "level field present")?;
+    b.expect(6, 61, "level code")?;
+    b.expect(1, 0, "additional level")?;
+    let width = 4 * (b.read(3)? as usize + 1);
+    let output_mask = b.read(width)?;
+    if output_mask & reference_mask != reference_mask {
+        return Err(Error::Unsupported("non-superset layout"));
+    }
+    Ok(LayoutHeader {
+        kind,
+        reference_mask,
+        output_mask,
+        end_bit: b.pos,
+    })
+}
+
+fn parse_matrix(bytes: &[u8], inherited_mask: u32) -> Result<Matrix, Error> {
+    let header = layout_header(bytes, inherited_mask)?;
+    let targets = channels(header.reference_mask)?;
+    let sources = channels(header.output_mask & !header.reference_mask)?;
+    let mut b = Bits {
+        bytes,
+        pos: header.end_bit,
+    };
+    b.expect(5, 2, "matrix header field")?;
+    b.expect(6, 0, "matrix header value")?;
+    b.expect(1, 1, "matrix mode")?;
+    b.expect(1, 0, "optional matrix parameters")?;
+    // The alternate type-3 declaration diverges here. Do not jump forward to
+    // coefficient-looking bits or reuse the standard matrix on these streams.
+    b.expect(1, 1, "inline matrix flag")?;
+    let mix_code = b.read(6)? as u8;
+    b.expect(1, 0, "additional scales")?;
+    let mut routes = Vec::new();
+    for &source in sources {
+        let mask = b.read(targets.len())?;
+        if mask == 0 {
+            return Err(Error::Unsupported("empty matrix row"));
+        }
+        for (index, &target) in targets.iter().enumerate() {
+            if mask & (1 << index) == 0 {
+                continue;
+            }
+            let gain_code = b.read(6)? as u8;
+            if gain_code > 61 {
+                return Err(Error::Unsupported("gain escape"));
+            }
+            routes.push(Route {
+                source,
+                target,
+                gain_code,
+                calibrated_q15: match gain_code {
+                    55 => Some(23_170),
+                    61 => Some(32_768),
+                    _ => None,
+                },
+            });
+        }
+    }
+    let padding = (8 - b.pos % 8) % 8;
+    if b.read(padding)? != 0 {
+        return Err(Error::Invalid("matrix padding"));
+    }
+    let encoded_bytes = (b.pos / 8).checked_add(2).ok_or(Error::Truncated)?;
+    let protected = bytes.get(..encoded_bytes).ok_or(Error::Truncated)?;
+    if crc16(protected) != 0 {
+        return Err(Error::Invalid("matrix CRC"));
+    }
+    Ok(Matrix {
+        reference_mask: header.reference_mask,
+        output_mask: header.output_mask,
+        mix_code,
+        routes,
+        encoded_bytes,
+    })
+}
+
+fn alternate_prefix(payload: &[u8]) -> Result<&[u8], Error> {
+    let mut result = None;
+    for end in 4..=payload.len().min(MAX_PREFIX) {
+        if payload.get(end..end + OUTER_SUFFIX.len()) == Some(OUTER_SUFFIX)
+            && crc16(&payload[..end]) == 0
+        {
+            if result.is_some() {
+                return Err(Error::Invalid("ambiguous prefix"));
+            }
+            result = Some(&payload[..end]);
+        }
+    }
+    result.ok_or(Error::Invalid("alternate prefix CRC/boundary"))
+}
+
+// Experimental type-3 reading: four sparse rows over the complete 12-channel
+// layout. Control semantics and waveform associations are NOT established.
+// Return indices/codes only, never playback routes or calibrated gains.
+fn type3_rows_candidate(bytes: &[u8]) -> Result<Vec<Vec<(usize, u8)>>, Error> {
+    let header = layout_header(bytes, 0x84b)?;
+    if header.kind != 3 || header.output_mask != 0x886b {
+        return Err(Error::Unsupported("type-3 candidate layout"));
+    }
+    let mut b = Bits {
+        bytes,
+        pos: header.end_bit,
+    };
+    b.expect(5, 2, "candidate field")?;
+    b.expect(6, 0, "candidate value")?;
+    b.expect(1, 1, "candidate flag")?;
+    b.expect(1, 0, "candidate option")?;
+    b.expect(12, 0x3fa, "unresolved type-3 control")?;
+    let mut rows = Vec::new();
+    for _ in 0..4 {
+        let mask = b.read(12)?;
+        let mut row = Vec::new();
+        for index in 0..12 {
+            if mask & (1 << index) != 0 {
+                let code = b.read(6)? as u8;
+                if code > 61 {
+                    return Err(Error::Unsupported("candidate gain escape"));
+                }
+                row.push((index, code));
+            }
+        }
+        if row.is_empty() {
+            return Err(Error::Unsupported("empty candidate row"));
+        }
+        rows.push(row);
+    }
+    let padding = (8 - b.pos % 8) % 8;
+    if b.read(padding)? != 0 || b.pos / 8 + 2 != bytes.len() {
+        return Err(Error::Invalid("candidate end/padding"));
+    }
+    Ok(rows)
+}
+
+fn describe(payload: &[u8]) -> Result<String, Error> {
+    match payload.get(..4) {
+        Some([2, 0, 8, 0x50]) => {
+            let matrix = parse_matrix(payload, 0x84b)?;
+            Ok(format!("standard matrix={matrix:?}"))
+        }
+        Some([0xf1, 0x40, 0, profile @ (0xd0 | 0xd1 | 0xd3)]) => {
+            let prefix = alternate_prefix(payload)?;
+            let mut candidates = Vec::new();
+            // Bounded offline discovery only, never a production navigation
+            // rule. A CRC for the outer envelope does not establish element
+            // boundaries or the identity of its audio waveforms.
+            for start in 4..prefix.len().saturating_sub(2) {
+                if prefix.get(start..start + 2) != Some(&[3, 0]) {
+                    continue;
+                }
+                if let Ok(header) = layout_header(&prefix[start..], 0x84b) {
+                    if header.output_mask == 0x886b {
+                        let status = parse_matrix(&prefix[start..], 0x84b);
+                        let rows = type3_rows_candidate(&prefix[start..]);
+                        candidates.push(format!("byte={start} header={header:?} matrix={status:?} unverified_rows12={rows:?}"));
+                    }
+                }
+            }
+            Ok(format!(
+                "profile={profile:02x} prefix_crc_bytes={} layout_candidates={candidates:?}",
+                prefix.len()
+            ))
+        }
+        _ => Err(Error::Unsupported("profile")),
+    }
+}
+
+fn probe(path: &str, limit: usize, input_index: usize) -> Result<(), String> {
+    let file = std::fs::File::open(path).map_err(|e| format!("open: {e}"))?;
+    let mut reader = BufReader::new(file);
+    let mut decoder = HdDecoder::new();
+    let mut offset = 0usize;
+    let mut frames = 0usize;
+    let mut pending = 0usize;
+    let mut nav_matches = 0usize;
+    let mut type69_marker_matches = 0usize;
+    let mut extension_errors = 0usize;
+    let mut invalid_metadata = 0usize;
+    let mut observations = BTreeMap::<String, usize>::new();
+    let mut core = Vec::new();
+    let mut exss = Vec::new();
+    let mut incomplete_tail = false;
+    while offset < limit {
+        let mut header = [0u8; 18];
+        // Distinguish clean EOF from a partial header; no silent self-skip.
+        let n = reader.read(&mut header[..1]).map_err(|e| e.to_string())?;
+        if n == 0 {
+            break;
+        }
+        reader
+            .read_exact(&mut header[1..])
+            .map_err(|e| format!("core header: {e}"))?;
+        let info = parse_header(&header).map_err(|e| format!("core header: {e:?}"))?;
+        if info.frame_size < header.len() {
+            return Err("short core size".into());
+        }
+        core.resize(info.frame_size, 0);
+        core[..header.len()].copy_from_slice(&header);
+        reader
+            .read_exact(&mut core[header.len()..])
+            .map_err(|e| format!("core data: {e}"))?;
+        exss.resize(16, 0);
+        reader
+            .read_exact(&mut exss)
+            .map_err(|e| format!("EXSS header: {e}"))?;
+        if exss.get(..4) != Some(&[0x64, 0x58, 0x20, 0x25]) {
+            return Err("EXSS sync".into());
+        }
+        let mut bits = Bits {
+            bytes: &exss,
+            pos: 42,
+        };
+        let wide = bits.read(1).map_err(|e| format!("{e:?}"))? as usize;
+        bits.read(8 + wide * 4).map_err(|e| format!("{e:?}"))?;
+        let size = bits.read(16 + wide * 4).map_err(|e| format!("{e:?}"))? as usize + 1;
+        if size < 16 {
+            return Err("short EXSS size".into());
+        }
+        let end = offset
+            .checked_add(core.len())
+            .and_then(|n| n.checked_add(size))
+            .ok_or("frame overflow")?;
+        if end > limit {
+            break;
+        }
+        exss.resize(size, 0);
+        if let Err(e) = reader.read_exact(&mut exss[16..]) {
+            if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                incomplete_tail = true;
+                break;
+            }
+            return Err(format!("EXSS data: {e}"));
+        }
+        if exss_substream_size(&exss) != Some(size) {
+            return Err("EXSS parser rejected frame".into());
+        }
+        match decoder.decode(&core, &exss) {
+            Ok(frame) => {
+                frames += 1;
+                if frame.x_descriptor_navigation_used
+                    && frame.x_descriptor_offset == Some(frame.x_payload_offset)
+                    && frame.x_descriptor_size == Some(frame.x_payload.len())
+                {
+                    nav_matches += 1;
+                    // A marker observation within the existing, independently
+                    // checked navigation word; not a general association parser.
+                    let mut tail = Bits {
+                        bytes: &frame.exss_descriptor_tail,
+                        pos: 37,
+                    };
+                    if tail.read(8) == Ok(69) {
+                        type69_marker_matches += 1;
+                    }
+                }
+                if frame.x_decode_error.is_some() {
+                    extension_errors += 1;
+                }
+                let observation = if frame.x_payload.is_empty() {
+                    "no extension".to_string()
+                } else {
+                    match describe(&frame.x_payload) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            if matches!(error, Error::Invalid(_) | Error::Truncated) {
+                                invalid_metadata += 1;
+                            }
+                            format!("unresolved={error:?}")
+                        }
+                    }
+                };
+                *observations.entry(observation).or_default() += 1;
+            }
+            Err(HdError::Pending) => pending += 1,
+            Err(e) => return Err(format!("decode at byte {offset}: {e:?}")),
+        }
+        offset = end;
+    }
+    if frames == 0 {
+        return Err("no decoded frames; corpus was not exercised".into());
+    }
+    println!(
+        "input={input_index} frames={frames} pending={pending} bytes={offset} descriptor_matches={nav_matches} type69_marker_matches={type69_marker_matches} extension_errors={extension_errors} invalid_metadata={invalid_metadata} incomplete_tail={incomplete_tail}"
+    );
+    for (observation, count) in observations {
+        println!("  frames={count} {observation}");
+    }
+    if incomplete_tail {
+        return Err("truncated final frame".into());
+    }
+    if extension_errors != 0 {
+        return Err("extension decode failures".into());
+    }
+    if invalid_metadata != 0 {
+        return Err("invalid private metadata".into());
+    }
+    Ok(())
+}
+
+fn run() -> Result<(), String> {
+    let mut args = std::env::args().skip(1);
+    let mut limit = 64usize * 1024 * 1024;
+    let mut count = 0;
+    while let Some(arg) = args.next() {
+        if arg == "--max-mb" {
+            limit = args
+                .next()
+                .ok_or("missing --max-mb")?
+                .parse::<usize>()
+                .map_err(|_| "invalid --max-mb")?
+                .checked_mul(1024 * 1024)
+                .filter(|n| *n > 0)
+                .ok_or("invalid byte limit")?;
+        } else {
+            count += 1;
+            probe(&arg, limit, count)?;
+        }
+    }
+    if count == 0 {
+        return Err("usage: xll_private_metadata [--max-mb 64] input.dts ...".into());
+    }
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("private metadata probe: {error}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Construct metadata from fields, not an identifying corpus excerpt.
+    fn fixture(gain: u32, first_target: u32) -> Vec<u8> {
+        let mut bits = Vec::new();
+        let mut put = |value: u32, width: usize| {
+            for bit in (0..width).rev() {
+                bits.push(((value >> bit) & 1) as u8);
+            }
+        };
+        for (value, width) in [
+            (2, 8),
+            (0, 8),
+            (0, 1),
+            (1, 4),
+            (0, 4),
+            (1, 1),
+            (0, 1),
+            (1, 1),
+            (0, 2),
+            (0, 3),
+            (2, 3),
+            (0x84b, 12),
+            (1, 1),
+            (61, 6),
+            (0, 1),
+            (3, 3),
+            (0x886b, 16),
+            (2, 5),
+            (0, 6),
+            (1, 1),
+            (0, 1),
+            (1, 1),
+            (61, 6),
+            (0, 1),
+            (first_target, 8),
+            (gain, 6),
+            (4, 8),
+            (55, 6),
+            (16, 8),
+            (55, 6),
+            (32, 8),
+            (55, 6),
+        ] {
+            put(value, width);
+        }
+        let mut bytes = vec![0u8; bits.len().div_ceil(8)];
+        for (i, bit) in bits.into_iter().enumerate() {
+            bytes[i / 8] |= bit << (7 - i % 8);
+        }
+        bytes.extend_from_slice(&crc16(&bytes).to_be_bytes());
+        bytes
+    }
+
+    #[test]
+    fn standard_matrix_reads_routes_and_gain_codes() {
+        let matrix = parse_matrix(&fixture(55, 2), 0).expect("synthetic matrix");
+        assert_eq!(matrix.reference_mask, 0x84b);
+        assert_eq!(matrix.output_mask, 0x886b);
+        assert_eq!(matrix.encoded_bytes, 21);
+        assert_eq!(
+            matrix
+                .routes
+                .iter()
+                .map(|r| (r.source, r.target, r.gain_code))
+                .collect::<Vec<_>>(),
+            vec![
+                ("TFL", "L", 55),
+                ("TFR", "R", 55),
+                ("TBL", "Lb", 55),
+                ("TBR", "Rb", 55)
+            ]
+        );
+        let changed = parse_matrix(&fixture(54, 1), 0).expect("changed matrix");
+        assert_eq!(changed.routes[0].target, "C");
+        assert_eq!(changed.routes[0].gain_code, 54);
+        assert_eq!(matrix.routes[0].calibrated_q15, Some(23170));
+        assert_eq!(changed.routes[0].calibrated_q15, None);
+    }
+
+    #[test]
+    fn every_single_bit_corruption_and_truncation_is_rejected() {
+        let bytes = fixture(55, 2);
+        for end in 0..bytes.len() {
+            assert!(parse_matrix(&bytes[..end], 0).is_err());
+        }
+        for bit in 0..bytes.len() * 8 {
+            let mut damaged = bytes.clone();
+            damaged[bit / 8] ^= 1 << (bit % 8);
+            assert!(parse_matrix(&damaged, 0).is_err(), "bit {bit}");
+        }
+    }
+
+    #[test]
+    fn gain_escape_is_not_silently_calibrated() {
+        assert_eq!(
+            parse_matrix(&fixture(63, 2), 0),
+            Err(Error::Unsupported("gain escape"))
+        );
+    }
+
+    #[test]
+    fn alternate_candidate_remains_separate_from_validated_matrix() {
+        let fields = [
+            (3, 8),
+            (0, 8),
+            (0, 1),
+            (1, 4),
+            (1, 4),
+            (0, 1),
+            (0, 1),
+            (0, 4),
+            (1, 1),
+            (61, 6),
+            (0, 1),
+            (3, 3),
+            (0x886b, 16),
+            (2, 5),
+            (0, 6),
+            (1, 1),
+            (0, 1),
+            (0x3fa, 12),
+            (0x12, 12),
+            (55, 6),
+            (61, 6),
+            (0x24, 12),
+            (55, 6),
+            (61, 6),
+            (0x440, 12),
+            (55, 6),
+            (61, 6),
+            (0x880, 12),
+            (55, 6),
+            (61, 6),
+            (0, 5),
+        ];
+        let mut bits = Vec::new();
+        for (value, width) in fields {
+            for bit in (0..width).rev() {
+                bits.push(((value >> bit) & 1) as u8);
+            }
+        }
+        let mut prefix = vec![0xf1, 0x40, 0, 0xd1];
+        for byte in bits.chunks_exact(8) {
+            prefix.push(byte.iter().fold(0, |a, b| (a << 1) | b));
+        }
+        prefix.extend_from_slice(&crc16(&prefix).to_be_bytes());
+        let body = &prefix[4..];
+        assert_eq!(
+            parse_matrix(body, 0x84b),
+            Err(Error::Unsupported("inline matrix flag"))
+        );
+        assert_eq!(
+            type3_rows_candidate(body).unwrap(),
+            vec![
+                vec![(1, 55), (4, 61)],
+                vec![(2, 55), (5, 61)],
+                vec![(6, 55), (10, 61)],
+                vec![(7, 55), (11, 61)]
+            ]
+        );
+        let prefix_len = prefix.len();
+        prefix.extend_from_slice(OUTER_SUFFIX);
+        assert_eq!(alternate_prefix(&prefix).unwrap().len(), prefix_len);
+        for bit in 0..prefix_len * 8 {
+            let mut damaged = prefix.clone();
+            damaged[bit / 8] ^= 1 << (bit % 8);
+            assert!(alternate_prefix(&damaged).is_err());
+        }
+    }
+
+    #[test]
+    fn unrelated_or_unprotected_alternate_data_is_rejected() {
+        assert!(alternate_prefix(&[0; 128]).is_err());
+        let mut bytes = vec![0xf1, 0x40, 0, 0xd3, 0, 0];
+        bytes.extend_from_slice(OUTER_SUFFIX);
+        assert!(alternate_prefix(&bytes).is_err());
+        assert!(describe(&[0xf1, 0x40, 0, 0xd4]).is_err());
+    }
+}

--- a/dca/examples/xll_private_metadata.rs
+++ b/dca/examples/xll_private_metadata.rs
@@ -211,6 +211,69 @@ fn alternate_prefix(payload: &[u8]) -> Result<&[u8], Error> {
     result.ok_or(Error::Invalid("alternate prefix CRC/boundary"))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct Declaration241 {
+    index: u8,
+    mode: u8,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Header241 {
+    reference_mask: u32,
+    declarations: Vec<Declaration241>,
+    end_bit: usize,
+}
+
+// Narrow static-declaration reader. The caller supplies only the portion
+// preceding type 3 in a CRC-validated envelope. These indices are metadata
+// indices, not yet verified PCM channel identities. Dynamic data remains unread.
+fn type241_header(bytes: &[u8]) -> Result<Header241, Error> {
+    let mut b = Bits { bytes, pos: 0 };
+    for (width, value) in [
+        (8, 241),
+        (8, 0x40),
+        (4, 0),
+        (1, 0),
+        (4, 1),
+        (1, 1),
+        (1, 0),
+        (1, 1),
+    ] {
+        b.expect(width, value, "type-241 header form")?;
+    }
+    let count = b.read(4)? as usize + 1;
+    for (width, value) in [(1, 0), (1, 0), (1, 1), (1, 1), (2, 0), (3, 0)] {
+        b.expect(width, value, "type-241 reference form")?;
+    }
+    let width = 4 * (b.read(3)? as usize + 1);
+    let reference_mask = b.read(width)?;
+    if reference_mask != 0x84b {
+        return Err(Error::Unsupported("type-241 reference layout"));
+    }
+    // No optional levels, additional layouts or timing parameters in the
+    // supported form. Precision zero gives two-bit and three-bit indices.
+    b.expect(8, 0, "type-241 optional fields/precision")?;
+    let mut declarations = Vec::with_capacity(count);
+    for _ in 0..count {
+        b.expect(1, 1, "inactive type-241 declaration")?;
+        b.expect(2, 3, "type-241 declaration field")?;
+        let index = b.read(3)? as u8;
+        let mode = b.read(2)? as u8;
+        if mode > 1 {
+            return Err(Error::Unsupported("type-241 declaration mode"));
+        }
+        // One component, component code zero, no optional parameter,
+        // parameter mode zero, one subcomponent.
+        b.expect(10, 0, "type-241 component form")?;
+        declarations.push(Declaration241 { index, mode });
+    }
+    Ok(Header241 {
+        reference_mask,
+        declarations,
+        end_bit: b.pos,
+    })
+}
+
 // Experimental type-3 reading: four sparse rows over the complete 12-channel
 // layout. Control semantics and waveform associations are NOT established.
 // Return indices/codes only, never playback routes or calibrated gains.
@@ -273,7 +336,8 @@ fn describe(payload: &[u8]) -> Result<String, Error> {
                     if header.output_mask == 0x886b {
                         let status = parse_matrix(&prefix[start..], 0x84b);
                         let rows = type3_rows_candidate(&prefix[start..]);
-                        candidates.push(format!("byte={start} header={header:?} matrix={status:?} unverified_rows12={rows:?}"));
+                        let declaration = type241_header(&prefix[..start]);
+                        candidates.push(format!("byte={start} header={header:?} matrix={status:?} unverified_rows12={rows:?} static241={declaration:?}"));
                     }
                 }
             }
@@ -452,6 +516,78 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn declaration_fixture(indices: &[u8], mode: u32) -> Vec<u8> {
+        let mut fields = vec![
+            (241, 8),
+            (0x40, 8),
+            (0, 4),
+            (0, 1),
+            (1, 4),
+            (1, 1),
+            (0, 1),
+            (1, 1),
+            (indices.len() as u32 - 1, 4),
+            (0, 1),
+            (0, 1),
+            (1, 1),
+            (1, 1),
+            (0, 2),
+            (0, 3),
+            (2, 3),
+            (0x84b, 12),
+            (0, 8),
+        ];
+        for &index in indices {
+            fields.extend([(1, 1), (3, 2), (u32::from(index), 3), (mode, 2), (0, 10)]);
+        }
+        let mut bits = Vec::new();
+        for (value, width) in fields {
+            for bit in (0..width).rev() {
+                bits.push(((value >> bit) & 1) as u8);
+            }
+        }
+        let mut bytes = vec![0; bits.len().div_ceil(8)];
+        for (i, bit) in bits.into_iter().enumerate() {
+            bytes[i / 8] |= bit << (7 - i % 8);
+        }
+        bytes
+    }
+
+    #[test]
+    fn declaration_count_and_indices_are_read_not_inferred_from_profile() {
+        for indices in [&[0][..], &[1, 0], &[3, 1, 0, 2], &[4, 2, 1, 0, 3]] {
+            for mode in 0..=1 {
+                let bytes = declaration_fixture(indices, mode);
+                let header = type241_header(&bytes).unwrap();
+                assert_eq!(header.end_bit, 64 + indices.len() * 18);
+                assert_eq!(header.reference_mask, 0x84b);
+                assert_eq!(
+                    header
+                        .declarations
+                        .iter()
+                        .map(|d| d.index)
+                        .collect::<Vec<_>>(),
+                    indices
+                );
+                assert!(header.declarations.iter().all(|d| d.mode == mode as u8));
+                for end in 0..bytes.len() {
+                    assert!(type241_header(&bytes[..end]).is_err());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn declaration_unsupported_forms_are_not_silently_skipped() {
+        assert!(type241_header(&declaration_fixture(&[0], 2)).is_err());
+        let mut bytes = declaration_fixture(&[0], 0);
+        bytes[7] = 1;
+        assert!(type241_header(&bytes).is_err());
+        bytes[7] = 0;
+        bytes[8] &= 0x7f;
+        assert!(type241_header(&bytes).is_err());
+    }
 
     // Construct metadata from fields, not an identifying corpus excerpt.
     fn fixture(gain: u32, first_target: u32) -> Vec<u8> {

--- a/dca/examples/xll_private_metadata.rs
+++ b/dca/examples/xll_private_metadata.rs
@@ -224,6 +224,126 @@ struct Header241 {
     end_bit: usize,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct Position241 {
+    index: u8,
+    azimuth_code: u8,
+    elevation_code: u8,
+    distance_code: u8,
+    // Azimuth/elevation in half-degrees, distance in units of 1/64.
+    spherical_units: (i16, i16, u8),
+    reference_rows: [Vec<(usize, u8)>; 2],
+}
+
+fn spherical_units(azimuth: u8, elevation: u8, distance: u8) -> (i16, i16, u8) {
+    let azimuth = match azimuth {
+        47 => -220,
+        193 => 220,
+        value => (3 * i16::from(value) - 360).min(357),
+    };
+    let elevation = (3 * (i16::from(elevation) - 60)).min(180);
+    let distance = if distance == 0 { 0 } else { distance + 1 };
+    (azimuth, elevation, distance)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Dynamic241 {
+    positions: Vec<Position241>,
+    // Raw auxiliary declarations; no inferred labels or PCM routing.
+    auxiliary: Vec<(u8, u32, u8)>,
+    end_bit: usize,
+}
+
+fn sparse_codes(b: &mut Bits<'_>, columns: usize) -> Result<Vec<(usize, u8)>, Error> {
+    let mask = b.read(columns)?;
+    let mut row = Vec::new();
+    for index in 0..columns {
+        if mask & (1 << index) != 0 {
+            let code = b.read(6)? as u8;
+            if code > 61 {
+                return Err(Error::Unsupported("type-241 gain escape"));
+            }
+            row.push((index, code));
+        }
+    }
+    Ok(row)
+}
+
+// Consume the supported mode-1 variable form all the way to the type-3
+// boundary. Raw codes only: waveform identity and presentation are separate.
+fn type241_dynamic(bytes: &[u8]) -> Result<Dynamic241, Error> {
+    let header = type241_header(bytes)?;
+    let mut b = Bits {
+        bytes,
+        pos: header.end_bit,
+    };
+    let mut positions = Vec::new();
+    for declaration in &header.declarations {
+        if declaration.mode != 1 {
+            return Err(Error::Unsupported("type-241 dynamic mode"));
+        }
+        b.expect(3, 0, "type-241 record options")?;
+        b.expect(7, 0x20, "type-241 position options")?;
+        b.expect(1, 1, "type-241 gain present")?;
+        b.expect(1, 1, "type-241 position flag")?;
+        b.expect(2, 0, "type-241 position mode")?;
+        b.expect(6, 61, "type-241 position gain")?;
+        let distance_code = b.read(6)? as u8;
+        let azimuth_code = b.read(8)? as u8;
+        let elevation_code = b.read(7)? as u8;
+        b.expect(1, 0, "type-241 extent")?;
+        let present = [b.read(1)? != 0, b.read(1)? != 0];
+        let mut reference_rows = [Vec::new(), Vec::new()];
+        for (row, present) in reference_rows.iter_mut().zip(present) {
+            if present {
+                *row = sparse_codes(&mut b, 8)?;
+            }
+        }
+        positions.push(Position241 {
+            index: declaration.index,
+            azimuth_code,
+            elevation_code,
+            distance_code,
+            spherical_units: spherical_units(azimuth_code, elevation_code, distance_code),
+            reference_rows,
+        });
+    }
+    let mut auxiliary = Vec::new();
+    if b.read(1)? != 0 {
+        for declaration in &header.declarations {
+            if b.read(1)? == 0 {
+                continue;
+            }
+            let count = b.read(2)? + 1;
+            let width = b.read(5)? as usize;
+            for _ in 0..count {
+                let mask = b.read(width)?;
+                // Only the observed single-channel auxiliary form is known.
+                if mask != 0x80 {
+                    return Err(Error::Unsupported("type-241 auxiliary layout"));
+                }
+                b.expect(1, 1, "type-241 auxiliary flag")?;
+                b.expect(1, 1, "type-241 auxiliary route")?;
+                let code = b.read(6)? as u8;
+                if code > 61 {
+                    return Err(Error::Unsupported("type-241 auxiliary gain"));
+                }
+                auxiliary.push((declaration.index, mask, code));
+            }
+        }
+    }
+    let end_bit = b.pos;
+    let padding = (8 - b.pos % 8) % 8;
+    if b.read(padding)? != 0 || b.pos / 8 != bytes.len() {
+        return Err(Error::Invalid("type-241 end/padding"));
+    }
+    Ok(Dynamic241 {
+        positions,
+        auxiliary,
+        end_bit,
+    })
+}
+
 // Narrow static-declaration reader. The caller supplies only the portion
 // preceding type 3 in a CRC-validated envelope. These indices are metadata
 // indices, not yet verified PCM channel identities. Dynamic data remains unread.
@@ -337,7 +457,8 @@ fn describe(payload: &[u8]) -> Result<String, Error> {
                         let status = parse_matrix(&prefix[start..], 0x84b);
                         let rows = type3_rows_candidate(&prefix[start..]);
                         let declaration = type241_header(&prefix[..start]);
-                        candidates.push(format!("byte={start} header={header:?} matrix={status:?} unverified_rows12={rows:?} static241={declaration:?}"));
+                        let dynamic = type241_dynamic(&prefix[..start]);
+                        candidates.push(format!("byte={start} header={header:?} matrix={status:?} unverified_rows12={rows:?} static241={declaration:?} dynamic241={dynamic:?}"));
                     }
                 }
             }
@@ -552,6 +673,82 @@ mod tests {
             bytes[i / 8] |= bit << (7 - i % 8);
         }
         bytes
+    }
+
+    fn dynamic_fixture(azimuth: u32, target: u32, gain: u32, auxiliary: bool) -> Vec<u8> {
+        let header = declaration_fixture(&[0], 1);
+        let mut bits: Vec<u8> = (0..82)
+            .map(|i| (header[i / 8] >> (7 - i % 8)) & 1)
+            .collect();
+        let mut fields = vec![
+            (0, 3),
+            (0x20, 7),
+            (1, 1),
+            (1, 1),
+            (0, 2),
+            (61, 6),
+            (63, 6),
+            (azimuth, 8),
+            (90, 7),
+            (0, 1),
+            (1, 1),
+            (0, 1),
+            (target, 8),
+            (gain, 6),
+            (u32::from(auxiliary), 1),
+        ];
+        if auxiliary {
+            fields.extend([(1, 1), (0, 2), (8, 5), (0x80, 8), (1, 1), (1, 1), (61, 6)]);
+        }
+        for (value, width) in fields {
+            for bit in (0..width).rev() {
+                bits.push(((value >> bit) & 1) as u8);
+            }
+        }
+        let mut bytes = vec![0; bits.len().div_ceil(8)];
+        for (i, bit) in bits.into_iter().enumerate() {
+            bytes[i / 8] |= bit << (7 - i % 8);
+        }
+        bytes
+    }
+
+    #[test]
+    fn variable_positions_routes_and_auxiliary_are_read_from_fields() {
+        for auxiliary in [false, true] {
+            let bytes = dynamic_fixture(47, 2, 55, auxiliary);
+            let result = type241_dynamic(&bytes).unwrap();
+            assert_eq!(result.positions[0].azimuth_code, 47);
+            assert_eq!(result.positions[0].elevation_code, 90);
+            assert_eq!(result.positions[0].distance_code, 63);
+            assert_eq!(result.positions[0].spherical_units, (-220, 90, 64));
+            assert_eq!(result.positions[0].reference_rows, [vec![(1, 55)], vec![]]);
+            assert_eq!(
+                result.auxiliary,
+                if auxiliary {
+                    vec![(0, 0x80, 61)]
+                } else {
+                    vec![]
+                }
+            );
+            let changed = type241_dynamic(&dynamic_fixture(193, 16, 54, auxiliary)).unwrap();
+            assert_eq!(changed.positions[0].azimuth_code, 193);
+            assert_eq!(changed.positions[0].reference_rows[0], vec![(4, 54)]);
+            for end in 0..bytes.len() {
+                assert!(type241_dynamic(&bytes[..end]).is_err());
+            }
+            let mut extended = bytes;
+            extended.push(0);
+            assert!(type241_dynamic(&extended).is_err());
+        }
+        assert!(type241_dynamic(&dynamic_fixture(47, 2, 63, false)).is_err());
+    }
+
+    #[test]
+    fn spherical_calibration_handles_special_angles_and_limits() {
+        assert_eq!(spherical_units(193, 60, 0), (220, 0, 0));
+        assert_eq!(spherical_units(120, 77, 63), (0, 51, 64));
+        assert_eq!(spherical_units(23, 79, 63), (-291, 57, 64));
+        assert_eq!(spherical_units(255, 127, 1), (357, 180, 2));
     }
 
     #[test]

--- a/docs/private-metadata-probe.md
+++ b/docs/private-metadata-probe.md
@@ -129,7 +129,9 @@ these metadata forms. Mode numbers here are raw fields, not labels such as
 "fixed" or "moving". The counts agree with the first bare-XLL set's 1, 2
 and 4 decoded waveforms, but that agreement does not establish identity,
 ordering or a route into the type-3 matrix. The second four-waveform set
-and the meaning of control `0x3fa` remain unresolved.
+and the meaning of control `0x3fa` remain unresolved. The waveform comparison
+below supplies a bounded validation for D0 and D3, rather than a general
+association-table grammar.
 
 A fresh 64 MiB prefix pass read every static declaration successfully on
 25,169 D0 frames, 12,897 D1 frames and 66,016 D3 frames: **104,082 alternate
@@ -145,6 +147,68 @@ checks execute; three unrelated legacy fixture tests self-skip because their
 local files are absent. The eight-second compatible-bed bit comparison was
 repeated for all four profiles, again with nonzero reference audio and zero
 differing float bit patterns over 384,000 samples per channel.
+
+## Mode-1 variable data and waveform validation
+
+The probe now consumes the supported mode-1 data from the static declaration
+end through the exact byte boundary before type 3. It reads one position per
+declaration, two optional sparse rows over the eight reference channels, an
+optional auxiliary section, and zero alignment padding. It rejects extra
+bytes instead of silently ignoring unexplained trailing data. Unsupported
+options remain errors inside the diagnostic result.
+
+The observed position form uses a six-bit distance, eight-bit azimuth and
+seven-bit elevation. Calibrated integer units are:
+
+- Azimuth: `min(3 * raw - 360, 357)` half-degrees, with raw 47 and 193
+  representing -220 and +220 half-degrees respectively.
+- Elevation: `min(3 * (raw - 60), 180)` half-degrees.
+- Distance: raw zero gives zero; otherwise `(raw + 1) / 64`.
+
+The mode-1 records examined have gain code 61, no extent, and only the first
+of the two reference rows present. The probe reads row masks and coefficients
+from fields; it does not substitute a fixed list of targets. D0 also has an
+auxiliary declaration with raw layout mask `0x80` and gain code 61. That
+auxiliary mask is deliberately not assigned a speaker label here.
+
+| Profile / variant | Frames completely consumed | Result |
+| --- | ---: | --- |
+| D0 | 25,169 | Position, reference row and auxiliary section |
+| D1, longer prefix | 5,413 | Two positions and reference rows |
+| D3 | 66,016 | Four positions and reference rows |
+| Total supported mode 1 | 96,598 | Exact end boundary and zero padding |
+| D1, shorter prefix | 7,484 | Explicitly unsupported variable mode 0 |
+
+Six D3 input prefixes contain changes in the first declaration's angular
+codes within the same stream. This is evidence of transmitted position
+changes, not merely different static placements across programmes. It does
+not yet establish interpolation or a general runtime object-state contract.
+
+Independent local comparisons used the external diagnostic in an isolated
+environment without network access. Its D3 coordinate export agrees with the
+field conversion, for example `(-145.5, 28.5, 1)` and `(145.5, 27, 1)` in
+degrees and distance units. D0 agrees at `(0, 25.5, 1)`. These comparisons
+verify the examined states, not every possible coordinate form.
+
+More importantly, the exported waveform samples were compared to Harletty's
+additional PCM sources over **384,000 samples per waveform**. Each D3 export
+0–3 matches exactly one source, respectively additional sources 0–3, with
+zero differing float bit patterns and over 142,000 nonzero samples each.
+The D0 export matches additional source 0 exactly, including 826 nonzero
+samples. A first one-second silent comparison was discarded as inconclusive.
+The remaining four supplemental sources and the type-3 matrix direction are
+not resolved by these matches.
+
+The shorter D1 case is a useful counterexample to trusting the reference
+blindly: following its mode-0 field consumption reproduces its exported
+coordinates, but leaves unexplained nonzero data before type 3. Those values
+are not accepted by this probe. A speculative one-bit shift also fails to
+establish a consistent grammar and is not implemented.
+
+This remains offline work. No coordinates, auxiliary labels, fold changes
+or `has_objects` changes enter playback. Nine synthetic probe tests cover
+coordinate calibration, changed positions/targets/gains, auxiliary presence,
+truncation and exact end consumption in addition to the earlier CRC checks.
 
 ## Local validation
 
@@ -194,8 +258,8 @@ truncated frames, decode failures and invalid prefix CRCs. Unsupported
 metadata remains visibly unresolved. Its byte limit excludes a final frame
 that would cross the selected limit.
 
-Next work should recover the variable type-241 prefix and association
-navigation, explain the type-3 control word, then validate waveform-to-row
+Next work should recover the shorter D1 variable form and association
+navigation, explain the type-3 control word, then validate its waveform-to-row
 identity and matrix direction against independently rendered references.
 Until those relationships are established, no alternate presentation or
 `has_objects` behavior should change.

--- a/docs/private-metadata-probe.md
+++ b/docs/private-metadata-probe.md
@@ -93,12 +93,14 @@ immediately before the envelope CRC:
 | 2 | 6, 10 | 61, 61 | 55, 61 |
 | 3 | 7, 11 | 61, 61 | 55, 61 |
 
-These indices fit lower/upper pairs in the full 12-channel mask order. This
-is a reproducible **structural hypothesis**, not a validated fold matrix.
-In particular, it does not identify which of the five, six or eight decoded
-waveforms supplies a row, explain the remaining sources, establish matrix
-direction/sign, or recover object motion. The D0 unity-looking entries must
-not be substituted for the existing experimental fold coefficients.
+These indices fit lower/upper pairs in the full 12-channel mask order. On its
+own this is a reproducible **structural hypothesis**, not a validated fold
+matrix: the bytes do not say which of the five, six or eight decoded
+waveforms supplies a row, which direction the matrix applies in, or what the
+control word means. The PCM comparison in "What the PCM says about the folds"
+below supplies the waveform identity (the last four sources, in row order),
+the direction (the first entry of each row is already in the compatible bed)
+and the gain calibration. The control word remains unread.
 
 The example keeps `matrix=Err(Unsupported(...))` separate from
 `unverified_rows12=...` so that candidates cannot accidentally be promoted to
@@ -197,18 +199,143 @@ zero differing float bit patterns and over 142,000 nonzero samples each.
 The D0 export matches additional source 0 exactly, including 826 nonzero
 samples. A first one-second silent comparison was discarded as inconclusive.
 The remaining four supplemental sources and the type-3 matrix direction are
-not resolved by these matches.
+not resolved by these matches; the PCM analysis below addresses them.
 
 The shorter D1 case is a useful counterexample to trusting the reference
 blindly: following its mode-0 field consumption reproduces its exported
 coordinates, but leaves unexplained nonzero data before type 3. Those values
-are not accepted by this probe. A speculative one-bit shift also fails to
-establish a consistent grammar and is not implemented.
+are not accepted by the mode-1 reader. A speculative global one-bit shift
+also fails to establish a consistent grammar and is not implemented. A
+per-record candidate that does consume the form exactly is described next.
 
 This remains offline work. No coordinates, auxiliary labels, fold changes
-or `has_objects` changes enter playback. Nine synthetic probe tests cover
+or `has_objects` changes enter playback. Ten synthetic probe tests cover
 coordinate calibration, changed positions/targets/gains, auxiliary presence,
-truncation and exact end consumption in addition to the earlier CRC checks.
+the mode-0 candidate, truncation and exact end consumption in addition to
+the earlier CRC checks.
+
+## Mode-0 candidate for the shorter D1 form
+
+The shorter D1 prefix declares two records in mode 0. A candidate reader
+consumes each record by reading a four-bit option field equal to 1 where
+mode 1 has three zero option bits, then the same position form, and no
+reference rows. With that one difference it ends exactly at the byte before
+type 3 (bit 187 of a 24-byte prefix, five zero padding bits) on all
+**7,484 mode-0 frames** of the single input that carries this form. The two
+positions are (-34.5°, 12°, 1) and (34.5°, 12°, 1). A synthetic test builds
+the form from fields, changes the azimuths, and checks that the extra bit is
+required in each record and that every truncation or extension is rejected.
+
+This is exact consumption, not a grammar. The extra bit's meaning is unknown,
+the form was seen in one input, and the probe reports it as
+`unverified_mode0` next to `dynamic241=Err(Unsupported(...))` instead of
+promoting it into the accepted reader. The PCM analysis below shows why a
+mode-0 record carries no reference rows.
+
+## What the PCM says about the folds
+
+The bytes above describe matrices; only the audio can say what they are
+matrices *of*. The following comparisons use `xll_pcm_range` dumps (bed in
+DCA index order, then the additional sources), sixty-second excerpts, and
+integer-domain arithmetic in 24-bit units. They are offline analysis, kept
+out of the repository together with the corpus identities; the numbers here
+are the results. Sources are numbered `X0..` in decoded order; the compatible
+bed uses the reference-layout names, with `Lb`/`Rb` for the rear pair.
+
+### The second waveform set is the four fixed heights
+
+In every alternate profile the last four additional sources sit in the
+compatible bed in `L`, `R`, `Lb`, `Rb` order, which is also the row order of
+the type-3 candidate. Independently, a least-squares fit of the external
+diagnostic's 7.1.4 output on Harletty's decoded sources places exactly those
+four at gain 1.000 on its four height outputs, reproduces the compatible bed
+at identity (largest deviation 1.5 LSB), and pans the object sources between
+rear and rear-height outputs according to their positions.
+
+### Type-3 rows: the embedded height fold plus the height's own speaker
+
+The first entry of each type-3 row is the gain at which that height already
+exists in the compatible bed; the second entry is the height's own output at
+unity. The profiles differ in the first entry, and the PCM follows the code:
+
+| Profile | Bed-column code | Measured gain of the height in its bed channel |
+| --- | ---: | --- |
+| D0, two inputs | 61 (unity) | An identical passage in both inputs, in which all five waveforms carry the same signal, reproduces `Lb = X3 + X3·(32768/32768)` with 0.5–0.6 LSB rms residual, `Rb` likewise (0.5–0.7 LSB). Sixty-second least squares: 0.996 and 1.019 for `Lb`, 0.87 and 0.99 for `Rb`. |
+| D1, shorter input (20-bit PCM) | 55 (23170/32768) | Single-source clean blocks: `R` 0.702 (19 blocks), `Lb` 0.7185 (209), `Rb` 0.7115 (126). |
+| D3, static input | 55 | `Lb` 0.7094 in the one clean block; `Rb` best blocks 0.699–0.722. The front pair is masked by continuous programme in `L`/`R`. |
+
+So the type-3 element carries, over twelve columns, the same fact the
+standard type-2 matrix carries over eight: how much of each height feed the
+compatible bed already contains, and therefore what to subtract before
+rendering the feed at its own position. The D0 unity fold is a genuine
+profile difference, not a misread: it is the value the audio reproduces to
+the LSB.
+
+### Mode-1 reference rows: the object's fold into the bed
+
+The optional sparse rows attached to a mode-1 position are the object's
+contribution to the compatible bed, quantised to gain codes:
+
+- Static D3 input, rows `Lb:61, Rb:21` / `Lb:20, Rb:61` / `Lb:61` / `Rb:61`:
+  sixty-second least squares gives `Lb` 0.976 and 0.994 for objects 0 and 2,
+  `Rb` 0.989 and 0.996 for objects 1 and 3, and cross terms 0.053 (code 21 is
+  0.0562) and 0.035 (code 20 is 0.0501).
+- Longer D1 input: `Lb` receives object 0 at 1.00–1.05 in the blocks it
+  dominates.
+- Moving-object D3 input, 160 metadata states aligned to audio with
+  `--segments`: two static objects at (0°, 25.5°) with rows `C:58, L:46,
+  R:46` measure `L` 0.406/0.419 and `R` 0.437/0.449 against 0.4217, and `C`
+  0.734 + 0.950 = 1.684 against 2 × 0.8414 (the two share position and rows
+  and are not separable), with R² 0.93–0.98 over about ninety segments. An
+  object rising at azimuth -150° keeps `Lb:61` (measured 0.93–1.17 as R²
+  climbs to 0.95) while its `Rb` code steps 13, 15, 16, 18, 19 with
+  elevation; objects at ±30° acquire a `C` entry of 12, 15, 18, 21, 23 at
+  1.5°, 3°, 4.5°, 6°, 7.5°. Codes that small (below -23 dB) are under what
+  these short segments resolve; their trend, not their value, is confirmed.
+
+### Mode-0 objects are folded without rows
+
+The shorter D1 input carries its two mode-0 objects in the bed as well, at
+gains that are not on the half-decibel grid: for the object at (-34.5°, 12°),
+`L` 0.9152 (10th–90th percentile 0.915–0.916 over 4,028 clean blocks), the
+opposite front 0.1305, `Lss` 0.3430 (25th–75th percentile 0.3427–0.3432 over
+892 dominant blocks), `Lb` 0.1039, `C` about 0.09–0.13 in the few blocks
+that expose it, nothing in LFE; the squares sum to 1.00. This is a panning
+law computed by the encoder, not coded rows. Removing a mode-0 object from
+the bed therefore means reproducing that law, and one position in one input
+is not enough to recover it.
+
+### Gain-code calibration
+
+Every verified code is the decoder's downmix-table entry at index
+`4 · code - 3`, i.e. half a decibel per code with 61 as unity: 61 → 32768,
+55 → 23170, and now 46 → 13818 and 58 → 27571. The latter two are fixed by
+the D0 passage above: `L = X1 + X1(61) + X0(46)` leaves 1.25 and 1.67 LSB
+rms in the two inputs, codes 45 and 47 leave 11.1 and 11.7; `C = X0 +
+X0(58)` leaves 1.7 and 2.9 LSB, codes 57 and 59 leave 22 and 23. The probe
+exposes exactly these four points and keeps every other code raw; the table
+relation is a hypothesis outside them.
+
+### The external diagnostic is not an oracle for the folds
+
+Rewriting the four type-3 codes 55 to 0, and separately to 61, with the
+envelope CRC recomputed on all 1,096 protected prefixes of the excerpt,
+changes no sample of the diagnostic's output (4,608,000 samples compared).
+Its bed output is Harletty's compatible bed at identity. It therefore renders
+heights and objects on top of a bed that still contains them, and cannot
+validate a subtraction. Coordinates and waveform identities from it remain
+useful; its rendering does not.
+
+### Remaining reading hypotheses
+
+- The control word `0x3fa` reads, against the type-2 grammar, as an inline
+  flag 0, a three-bit field 3, the mix code 61 and a zero flag. Every
+  alternate prefix in the corpus carries the same value, so nothing here can
+  distinguish that split from any other.
+- The auxiliary mask `0x80` is bit 7 of the DTS speaker-activity mask, the
+  centre-height position, at unity for D0's single object at (0°, 25.5°).
+  This agrees with the existing top-front-centre D0 presentation but is not
+  assigned a label in code.
 
 ## Local validation
 
@@ -236,9 +363,11 @@ known channel permutation, and maximum absolute error zero. This comparison
 covers the compatible bed, not an authored clean bed or an alternate spatial
 render.
 
-The complete suite passes **206 tests** with readable corpus/reference
-environment variables, including D0/D1 PCM checks and the D3 bridge test,
-and no corpus self-skip messages. The build with warnings denied passes.
+At the latest checkpoint the complete suite passes **211 tests** with
+readable corpus/reference environment variables, including D0/D1 PCM checks
+and the D3 bridge test, with no DTS:X corpus self-skip; three unrelated
+legacy fixture tests self-skip because their local inputs are absent. The
+ten probe tests run in normal CI. The build with warnings denied passes.
 No A/B listening claim is made; playback behavior has not changed.
 
 ## Reproduction and next boundary
@@ -246,10 +375,17 @@ No A/B listening claim is made; playback behavior has not changed.
 ```sh
 cargo run -p dca --release --example xll_private_metadata -- \
   --max-mb 64 "$STANDARD_CORPUS" "$D0_CORPUS" "$D1_CORPUS" "$D3_CORPUS"
+cargo run -p dca --release --example xll_private_metadata -- \
+  --max-mb 64 --segments "$D3_CORPUS"
+cargo run -p dca --release --example xll_pcm_range -- "$D3_CORPUS" d3.f32 0 60
 cargo test -p dca --example xll_private_metadata
 RUSTFLAGS='-D warnings' cargo build --all-targets
 RUSTFLAGS='-D warnings' cargo test -- --nocapture
 ```
+
+`--segments` prints one line per run of consecutive frames with the same
+observation, with its frame and bed-sample span, so metadata states can be
+aligned to a PCM dump for offline analysis.
 
 The full suite additionally needs its existing `HARLETTY_*_CORPUS` and
 `HARLETTY_*_REFERENCE` variables. Check output for self-skips. The new probe
@@ -258,11 +394,27 @@ truncated frames, decode failures and invalid prefix CRCs. Unsupported
 metadata remains visibly unresolved. Its byte limit excludes a final frame
 that would cross the selected limit.
 
-Next work should recover the shorter D1 variable form and association
-navigation, explain the type-3 control word, then validate its waveform-to-row
-identity and matrix direction against independently rendered references.
-Until those relationships are established, no alternate presentation or
-`has_objects` behavior should change.
+The reading questions that gated playback work are now answered by the
+audio itself: which sources the type-3 rows describe, in which direction,
+at which gains, and what the mode-1 rows are. What remains is
+implementation-side:
+
+1. Subtract the embedded folds from the compatible bed using the decoded
+   metadata: the type-3 first entries for the four fixed heights and the
+   mode-1 reference rows for objects, with gain codes limited to the four
+   verified calibration points until the table relation is confirmed on
+   more codes.
+2. Recover the mode-0 panning law, which needs more mode-0 inputs than the
+   single one at hand; until then a mode-0 object cannot be removed from the
+   bed and must not be rendered a second time.
+3. Read positions per frame in playback and decide, with the renderer, how
+   transmitted positions replace the static D3 defaults, including the
+   auxiliary centre-height declaration.
+4. Explain the type-3 control word and the general association navigation,
+   which the corpus cannot distinguish from constants.
+5. A/B listen before any of this changes a presentation.
+
+Until then no alternate presentation or `has_objects` behavior changes.
 
 ## Research provenance
 

--- a/docs/private-metadata-probe.md
+++ b/docs/private-metadata-probe.md
@@ -1,0 +1,170 @@
+# Private metadata: standard matrix and alternate-profile candidates
+
+Status: offline research only. The decoder, ABI, fold configuration and output
+presentations are unchanged. `dca/examples/xll_private_metadata.rs` is an
+independent diagnostic; it is not a general DTS:X navigation parser.
+
+## Confirmed standard result
+
+The standard extension prefix contains a readable sparse matrix, not just an
+opaque wrapper. Its reference mask is `0x084b` (eight compatible channels),
+its output mask is `0x886b`, and the difference `0x8020` describes the two
+height pairs. The four rows specify:
+
+| Supplemental source | Compatible target | Six-bit gain code | Calibrated Q15 gain |
+| --- | --- | ---: | ---: |
+| TFL | L | 55 | 23170 / 32768 |
+| TFR | R | 55 | 23170 / 32768 |
+| TBL | Lb | 55 | 23170 / 32768 |
+| TBR | Rb | 55 | 23170 / 32768 |
+
+The coefficients agree with the existing fixed-height PCM calibration.
+Code 61 is unity. The probe exposes only these verified numerical calibration
+points; other codes remain raw codes, not guessed gains.
+
+Important offsets in the supported type-2 form, relative to the extension
+prefix, with MSB-first bit numbering:
+
+| Bit offset | Width | Observed field |
+| ---: | ---: | --- |
+| 0 | 8 | Element type 2 |
+| 36 | 12 | Explicit reference mask `0x084b` |
+| 59 | 16 | Output mask `0x886b` |
+| 89 | 6 | Mix code 61 |
+| 96 | 8 | First sparse target mask, `0x02` |
+| 104 | 6 | First gain code, 55 |
+| 110 | 14 | Second row: target mask `0x04`, gain 55 |
+| 124 | 14 | Third row: target mask `0x10`, gain 55 |
+| 138 | 14 | Fourth row: target mask `0x20`, gain 55 |
+| 152 | 16 | CRC16-CCITT |
+
+CRC16 with polynomial `0x1021` and initial state `0xffff` over the first
+**21 bytes** has zero remainder. The existing bare XLL header starts at byte
+22. This independently establishes the protected prefix boundary; it does
+not establish that the first five bytes alone are a separately protected
+metadata element.
+
+The implementation reads the masks and sparse rows from fields. It does not
+return a fixed matrix merely because a sync marker matched. Synthetic tests
+change a target and a coefficient while regenerating the CRC and verify that
+the reported matrix changes accordingly. All single-bit corruptions and all
+truncations of the synthetic standard block are rejected. Uninterpreted
+header flags are restricted to the observed form, rather than silently
+assuming their meanings.
+
+## Navigation: what is and is not established
+
+The existing descriptor navigation resolves the extension offset and extent
+on 310,905 of the 311,648 standard frames in this pass. All those words also
+carry the value 69 at bit 37 of the captured descriptor tail. The other 743
+frames use the existing decoder fallback; their matrix CRCs still validate.
+
+This is evidence for the type-69 association lead, but **not a recovered
+general association-table grammar**. The diagnostic deliberately does not
+reinterpret arbitrary payload matches as chunk boundaries.
+
+The external diagnostic reports type 68 for alternate associations. Its
+JSON extent fields are not a safe oracle: an initial standard frame reports
+extent 6146 for a 132-byte XLL frame, and alternate frames also report extents
+larger than their assets. Some reported descriptor consumption extends beyond
+the declared descriptor. Those values were not used as buffer lengths or
+incorporated into the production parser.
+
+## D0, D1 and D3
+
+Each observed alternate prefix has a valid outer CRC and terminates before
+the established compact-control suffix. Within that bounded prefix, the
+probe finds a candidate type-3 declaration of `0x084b -> 0x886b`. Its position
+moves with the outer prefix. It occupies the final 25 bytes of the protected
+prefix, including the envelope CRC. The type-3 body does **not** have an
+independently validated standalone CRC.
+
+Applying the strict standard matrix grammar stops at the inline-matrix flag.
+It would be incorrect to reuse the standard matrix at this point.
+
+A separate candidate reading consumes four sparse rows over **12 columns**
+after the unresolved control word `0x3fa`, ending with five zero padding bits
+immediately before the envelope CRC:
+
+| Row | Column indices | D0 codes | D1 / D3 codes |
+| ---: | --- | --- | --- |
+| 0 | 1, 4 | 61, 61 | 55, 61 |
+| 1 | 2, 5 | 61, 61 | 55, 61 |
+| 2 | 6, 10 | 61, 61 | 55, 61 |
+| 3 | 7, 11 | 61, 61 | 55, 61 |
+
+These indices fit lower/upper pairs in the full 12-channel mask order. This
+is a reproducible **structural hypothesis**, not a validated fold matrix.
+In particular, it does not identify which of the five, six or eight decoded
+waveforms supplies a row, explain the remaining sources, establish matrix
+direction/sign, or recover object motion. The D0 unity-looking entries must
+not be substituted for the existing experimental fold coefficients.
+
+The example keeps `matrix=Err(Unsupported(...))` separate from
+`unverified_rows12=...` so that candidates cannot accidentally be promoted to
+accepted playback metadata.
+
+## Local validation
+
+A bounded 64 MiB prefix pass, using anonymous input indices in output:
+
+| Profile | Input streams | Decoded frames | Result |
+| --- | ---: | ---: | --- |
+| Standard | 31 | 311,648 | Same parsed matrix; all prefix CRCs valid |
+| D0 | 3 | 25,169 | Same type-3 candidate rows; outer CRCs valid |
+| D1 | 2 | 12,897 | Same type-3 candidate rows; outer CRCs valid |
+| D3 | 10 | 66,016 | Same type-3 candidate rows; outer CRCs valid |
+| Total | 46 | 415,730 | No extension errors or invalid-prefix results |
+
+Input streams are not necessarily independent programmes. The results describe
+the examined prefixes, not full-stream or universal format coverage.
+
+Observed alternate prefix lengths: D0 48 bytes; D1 49 and 54 bytes; D3
+72, 73, 74, 75, 76, 78, 79 and 81 bytes. The moving type-3 location is why a
+single hard-coded alternate offset would be insufficient.
+
+The eight compatible bed channels were also compared directly to FFmpeg on
+one eight-second excerpt per profile: **384,000 samples/channel**, nonzero
+reference audio in every case, zero differing float bit patterns after the
+known channel permutation, and maximum absolute error zero. This comparison
+covers the compatible bed, not an authored clean bed or an alternate spatial
+render.
+
+The complete suite passes **206 tests** with readable corpus/reference
+environment variables, including D0/D1 PCM checks and the D3 bridge test,
+and no corpus self-skip messages. The build with warnings denied passes.
+No A/B listening claim is made; playback behavior has not changed.
+
+## Reproduction and next boundary
+
+```sh
+cargo run -p dca --release --example xll_private_metadata -- \
+  --max-mb 64 "$STANDARD_CORPUS" "$D0_CORPUS" "$D1_CORPUS" "$D3_CORPUS"
+cargo test -p dca --example xll_private_metadata
+RUSTFLAGS='-D warnings' cargo build --all-targets
+RUSTFLAGS='-D warnings' cargo test -- --nocapture
+```
+
+The full suite additionally needs its existing `HARLETTY_*_CORPUS` and
+`HARLETTY_*_REFERENCE` variables. Check output for self-skips. The new probe
+requires actual input, rejects empty input, reports counts, and fails on
+truncated frames, decode failures and invalid prefix CRCs. Unsupported
+metadata remains visibly unresolved. Its byte limit excludes a final frame
+that would cross the selected limit.
+
+Next work should recover the variable type-241 prefix and association
+navigation, explain the type-3 control word, then validate waveform-to-row
+identity and matrix direction against independently rendered references.
+Until those relationships are established, no alternate presentation or
+`has_objects` behavior should change.
+
+## Research provenance
+
+The investigation was prompted by the author's first-hand
+[legacy DTS:X article](https://touch-max.ru/zvuk/dts-iznutri-gde-v-dts-hd-ma-spryatany-vysotnye-kanaly-i-obekty).
+The author's v0.2.5 diagnostic was inspected and run locally against anonymous
+excerpts in an isolated environment without network access. Its reported
+fields and parser behavior supplied hypotheses; original field readers,
+synthetic fixtures, corpus CRCs and existing Harletty/FFmpeg comparisons were
+used here. No external binary, decoder implementation or corpus audio is
+vendored. The offline tool neither invokes nor depends on that executable.

--- a/docs/private-metadata-probe.md
+++ b/docs/private-metadata-probe.md
@@ -104,6 +104,48 @@ The example keeps `matrix=Err(Unsupported(...))` separate from
 `unverified_rows12=...` so that candidates cannot accidentally be promoted to
 accepted playback metadata.
 
+## Type-241 static declarations
+
+The offline probe now reads the initial type-241 declaration fields inside
+the CRC-validated alternate envelope, bounded before the candidate type-3
+element. This is a partial reader: it stops before the variable data and
+does not claim to decode coordinates, motion or waveform associations.
+
+In the supported form, the four-bit count-minus-one is at bit 28. The
+explicit reference mask starts at bit 44 and is `0x084b`. Declarations start
+at bit 64; each consumes 18 bits: an active flag, a two-bit field equal to
+3, a three-bit index, a two-bit mode and ten component/parameter bits equal
+to zero. Other flag or component forms remain visibly unsupported.
+
+| Profile / observed variant | Declaration indices | Raw modes | End bit | Type-3 byte offset |
+| --- | --- | --- | ---: | --- |
+| D0 | 0 | 1 | 82 | 23 |
+| D1, shorter prefix | 0, 1 | 0, 0 | 100 | 24 |
+| D1, longer prefix | 0, 1 | 1, 1 | 100 | 29 |
+| D3 | 0, 1, 2, 3 | 1, 1, 1, 1 | 136 | 47–56, observed subset |
+
+The D1 distinction is material: its sync marker alone does not distinguish
+these metadata forms. Mode numbers here are raw fields, not labels such as
+"fixed" or "moving". The counts agree with the first bare-XLL set's 1, 2
+and 4 decoded waveforms, but that agreement does not establish identity,
+ordering or a route into the type-3 matrix. The second four-waveform set
+and the meaning of control `0x3fa` remain unresolved.
+
+A fresh 64 MiB prefix pass read every static declaration successfully on
+25,169 D0 frames, 12,897 D1 frames and 66,016 D3 frames: **104,082 alternate
+frames across 15 inputs**, with valid outer CRCs and no extension errors.
+Of the D1 frames, 7,484 use mode 0 and 5,413 use mode 1. Counts and indices
+are read from fields; synthetic tests also change their order and exercise
+a five-declaration form, rather than inferring them from a profile marker.
+All byte truncations of those synthetic declarations are rejected.
+
+At this follow-up checkpoint the warnings-denied all-target build passes,
+and the full suite reports 208 passing tests. All configured DTS:X corpus
+checks execute; three unrelated legacy fixture tests self-skip because their
+local files are absent. The eight-second compatible-bed bit comparison was
+repeated for all four profiles, again with nonzero reference audio and zero
+differing float bit patterns over 384,000 samples per channel.
+
 ## Local validation
 
 A bounded 64 MiB prefix pass, using anonymous input indices in output:


### PR DESCRIPTION
The extension wrappers contain authored matrices and spatial metadata that the current audio path does not fully interpret. Add an offline probe for the standard sparse matrix and the alternate static/variable declarations, keeping unsupported forms visibly separate from accepted results. Playback and the public ABI are unchanged.

The standard routes carry gain code 55 (Q15 23170/32768). The partial type-241 reader reads declaration counts and indices from fields, then fully consumes the supported mode-1 positions, sparse reference rows, auxiliary data and padding. D1 has two distinct metadata forms; the shorter mode-0 form is consumed exactly by a per-record candidate (one extra option bit, no rows) that stays separate from the accepted reader. `--segments` aligns metadata states to bed-sample spans for offline audio analysis.

The audio now answers the reading questions that were open. Sixty-second PCM comparisons (details in `docs/private-metadata-probe.md`) establish that:
- the last four additional sources of every alternate profile are the fixed heights, folded into L/R/Lb/Rb in type-3 row order;
- the first entry of each type-3 row is the gain at which that height already exists in the compatible bed: unity in D0 (reproduced to the LSB on a passage present in both D0 inputs), 23170/32768 in D1/D3 (within 2%); the second entry is the height's own output. Type 3 is the alternate-profile counterpart of the standard type-2 fold matrix, written over twelve columns;
- mode-1 reference rows are the object's fold into the bed (moving-object D3 input, 160 states aligned with `--segments`: codes 46/58 reproduced within 5%, codes stepping with elevation as the object rises);
- mode-0 objects are folded by an energy-normalised panning law (gains off the half-decibel grid, squares summing to 1.00), which is why they carry no rows and why one input is not enough to recover the law;
- gain codes follow the decoder's downmix table at index `4·code − 3` at the four verified points 46, 55, 58, 61 (the new two discriminated from their ±1 neighbours by a 10× residual ratio). The probe exposes only these points.

The external diagnostic renders heights and objects on top of a bed that still contains them: rewriting the four type-3 codes with CRCs recomputed changes none of its output samples, and its bed output is Harletty's compatible bed at identity. It is useful for coordinates and waveform identity, not for validating a subtraction. Type-3 control semantics and general association navigation remain unread; the corpus carries constants there.

Local validation:
- Warnings-denied all-target build; full suite reports 211 passing tests. Configured DTS:X corpus checks actually ran; three unrelated legacy fixture tests self-skip because their local inputs are absent. Ten synthetic probe tests run in normal CI.
- Initial 64 MiB survey: 46 streams, 415,730 frames; 311,648 standard matrices decoded, no extension failures or invalid prefix CRCs.
- Alternate survey: static declarations read on 104,082 frames; variable mode-1 data fully consumed on 96,598 (25,169 D0, 5,413 longer D1, 66,016 D3); the mode-0 candidate consumes the shorter D1's 7,484 frames exactly.
- Non-silent waveform comparisons: D3 metadata indices 0–3 uniquely match additional PCM sources 0–3, and D0 index 0 matches source 0, bit-exact over 384,000 samples per waveform.
- Repeated compatible-bed comparison against FFmpeg: zero differing float bit patterns over 384,000 samples/channel on each of the four profiles.

No presentation A/B claim is made, and no external decoder implementation, executable or corpus audio is included. This PR remains a research checkpoint; no spatial metadata or fold changes enter playback. The next boundary is implementation-side: subtract the embedded folds from the decoded metadata, recover the mode-0 law from more inputs, carry per-frame positions to the renderer, then A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
