### PR TITLE
feat(dts): remove the stated bed folds and present extension feeds from metadata

### DIFF
--- a/bridge/dts-fold.yaml
+++ b/bridge/dts-fold.yaml
@@ -1,4 +1,9 @@
-# Experimental compatibility folds. Entries are applied in this order.
+# Fallback fold for a standard-profile DTS:X frame whose type-2 fold matrix
+# could not be read: the four height feeds' contribution to the compatible
+# 7.1 bed. Every stream examined states code 55 (Q15 23170/32768) here. A
+# `dts-fold.yaml` in the working directory overrides this bundled default.
+# Alternate profiles carry their folds in per-frame metadata and ignore this
+# file.
 sources:
   - source: TFL
     routes: [{target: L, gain_db: -3.0104780234}]
@@ -7,16 +12,4 @@ sources:
   - source: TBL
     routes: [{target: Lb, gain_db: -3.0104780234}]
   - source: TBR
-    routes: [{target: Rb, gain_db: -3.0104780234}]
-  - source: X0
-    routes: [{target: C, gain_db: -6.0206}, {target: L, gain_db: -3.0104780234}]
-  - source: X1
-    routes: [{target: L, gain_db: -3.0104780234}, {target: R, gain_db: -3.0104780234}]
-  - source: X2
-    routes: [{target: R, gain_db: -3.0104780234}, {target: Ls, gain_db: -3.0104780234}, {target: L, gain_db: -3.0104780234}]
-  - source: X3
-    routes: [{target: Lb, gain_db: -3.0104780234}, {target: Rs, gain_db: -3.0104780234}, {target: R, gain_db: -3.0104780234}]
-  - source: X4
-    routes: [{target: Rb, gain_db: -3.0104780234}, {target: Lb, gain_db: -3.0104780234}]
-  - source: X5
     routes: [{target: Rb, gain_db: -3.0104780234}]

--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -1167,6 +1167,62 @@ mod raw_transport_tests {
 }
 
 #[cfg(test)]
+mod dts_object_motion_tests {
+    use super::*;
+    use abi_stable::std_types::RSlice;
+    use bridge_api::RInputTransport;
+
+    /// A D3 stream with moving objects must produce position events whose
+    /// coordinates change over time: the bridge follows the per-frame
+    /// metadata rather than freezing the first position.
+    #[test]
+    fn d3_object_positions_follow_the_stream() {
+        let Some(path) = std::env::var("HARLETTY_D3_MOTION_CORPUS")
+            .ok()
+            .filter(|p| std::path::Path::new(p).is_file())
+        else {
+            eprintln!("skipping: HARLETTY_D3_MOTION_CORPUS is not set to a readable file");
+            return;
+        };
+        let bytes = std::fs::read(&path).expect("read corpus");
+        let bytes = &bytes[..bytes.len().min(8_000_000)];
+        let mut bridge = AtmosBridge::new(false);
+        assert!(bridge.configure("input_codec".into(), "dts".into()));
+        let mut positions: std::collections::BTreeMap<u32, Vec<[i64; 3]>> = Default::default();
+        let mut frames = 0usize;
+        for chunk in bytes.chunks(256 * 1024) {
+            let result = bridge.push_packet(RSlice::from_slice(chunk), RInputTransport::Raw, 0);
+            assert!(result.error_message.is_empty(), "{}", result.error_message);
+            for frame in result.frames.iter() {
+                frames += 1;
+                for metadata in frame.metadata.iter() {
+                    for event in metadata.events.iter() {
+                        let quantised =
+                            [event.pos[0], event.pos[1], event.pos[2]].map(|v| (v * 1000.0) as i64);
+                        let list = positions.entry(event.id).or_default();
+                        if list.last() != Some(&quantised) {
+                            list.push(quantised);
+                        }
+                    }
+                }
+            }
+        }
+        assert!(frames > 100, "corpus was not exercised ({frames} frames)");
+        assert!(bridge.has_objects());
+        let moving = positions.values().filter(|list| list.len() > 3).count();
+        eprintln!(
+            "frames={frames} objects={} distinct positions per object={:?}",
+            positions.len(),
+            positions.values().map(Vec::len).collect::<Vec<_>>()
+        );
+        assert!(
+            moving >= 2,
+            "at least two objects must change position: {positions:?}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod stack_footprint_tests {
     use super::*;
 

--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use truehd::process::{MAX_PRESENTATIONS, decode::Decoder, extract::Extractor, parse::Parser};
 
 use crate::ac3_native::NativeAc3Decoder;
-use crate::dts_pipeline::DtsFoldConfig;
+use crate::dts_pipeline::{DtsFoldConfig, DtsXState};
 use crate::eac3_pipeline::{
     diagnose_eac3_frame, is_dependent_eac3_frame, is_legacy_ac3_frame,
     is_temporary_eac3_silence_frame, process_eac3_dependent_frame_with_core, process_eac3_frame,
@@ -154,10 +154,9 @@ pub(crate) struct AtmosBridge {
     /// DTS-HD Master Audio lossless (5.1/7.1) decoder.
     pub(crate) dts_hd_decoder: Box<dca::HdDecoder>,
     pub(crate) dts_frame_count: u64,
-    /// Latches once a valid XLL-X height quartet has been emitted: fallback
-    /// frames then keep the 12-channel shape (composite bed + silent heights)
-    /// instead of renegotiating to 8 channels. Cleared with the pipeline.
-    pub(crate) dts_height_locked: bool,
+    /// DTS:X extension state: latched presentation shape, last readable
+    /// metadata, announced object positions. Cleared with the pipeline.
+    pub(crate) dts_x: DtsXState,
     /// True when the most recent `push_packet` used the DTS path.
     pub(crate) dts_active: bool,
     pub(crate) dts_fold_config: DtsFoldConfig,
@@ -239,7 +238,7 @@ impl AtmosBridge {
             dts_decoder: Box::new(dca::PcmDecoder::new()),
             dts_hd_decoder: Box::new(dca::HdDecoder::new()),
             dts_frame_count: 0,
-            dts_height_locked: false,
+            dts_x: DtsXState::default(),
             dts_active: false,
             dts_fold_config: DtsFoldConfig::from_env(),
             dts_objects_active: false,
@@ -299,7 +298,7 @@ impl AtmosBridge {
         self.dts_decoder.reset();
         self.dts_hd_decoder.reset();
         self.dts_frame_count = 0;
-        self.dts_height_locked = false;
+        self.dts_x = DtsXState::default();
         self.dts_active = false;
         self.dts_objects_active = false;
         // Re-sniff after reset, but keep any host-declared codec.
@@ -704,10 +703,10 @@ impl FormatBridge for AtmosBridge {
             if self.dts_objects_active {
                 return true;
             }
-            // DTS core and the standard/D0/D1 extension presentations are
+            // DTS core and the standard/D0 extension presentations are
             // labeled fixed channels. Whether they are placed directly or
-            // virtualized remains the renderer's channel-mode decision. D3 is
-            // the only current DTS presentation that declares object channels.
+            // virtualized remains the renderer's channel-mode decision. D1
+            // and D3 declare object channels for their object waveforms.
             return false;
         }
         if self.eac3_active {
@@ -1087,19 +1086,28 @@ mod raw_transport_tests {
         assert!(bridge.configure("input_codec".into(), "dts".into()));
         let result = bridge.push_packet(RSlice::from_slice(&bytes), RInputTransport::Raw, 0);
         assert!(result.error_message.is_empty(), "{}", result.error_message);
-        assert!(!bridge.has_objects(), "D1 must remain fixed-channel");
+        assert!(bridge.has_objects(), "D1 declares its two objects");
 
         let frame = result
             .frames
             .iter()
             .find(|frame| {
-                [Tfl, Tfr, Lw, Rw, Tbl, Tbr]
+                [Tfl, Tfr, Tbl, Tbr]
                     .iter()
                     .all(|label| frame.channel_labels.contains(label))
+                    && frame
+                        .channel_labels
+                        .iter()
+                        .filter(|&&label| label == Object)
+                        .count()
+                        == 2
             })
-            .expect("no experimental fixed D1 declaration");
-        assert!(frame.metadata.is_empty());
-        assert!(!frame.channel_labels.contains(&Object));
+            .expect("no D1 presentation with four heights and two objects");
+        assert_eq!(frame.channel_count, 8 + 6);
+        assert!(
+            !frame.channel_labels.contains(&Lw),
+            "D1 carries no wide channels; its first two feeds are objects"
+        );
 
         let Some(d3_path) = corpus_path("HARLETTY_D3_CORPUS") else {
             eprintln!("skipping: HARLETTY_D3_CORPUS is not set to a readable file");
@@ -1124,25 +1132,37 @@ mod raw_transport_tests {
                     .iter()
                     .filter(|&&label| label == Object)
                     .count()
-                    == 8
+                    == 4
                     && frame
                         .metadata
                         .iter()
-                        .any(|metadata| metadata.name_updates.len() == 8)
+                        .any(|metadata| metadata.name_updates.len() == 4)
             })
-            .expect("no experimental D3 object declaration");
+            .expect("no D3 object declaration");
         assert_eq!(frame.channel_count, 16);
+        assert!(
+            [Tfl, Tfr, Tbl, Tbr]
+                .iter()
+                .all(|label| frame.channel_labels.contains(label)),
+            "the last four D3 feeds are the fixed heights"
+        );
         let metadata = frame
             .metadata
             .iter()
-            .find(|metadata| metadata.name_updates.len() == 8)
+            .find(|metadata| metadata.name_updates.len() == 4)
             .expect("no D3 name declaration");
-        for source in 0..8 {
+        for source in 0..4 {
             assert_eq!(
                 metadata.name_updates[source].name.as_str(),
                 format!("X{source}")
             );
         }
+        assert_eq!(
+            metadata.events.len(),
+            4,
+            "every object announces a position"
+        );
+        assert!(metadata.events.iter().all(|event| event.has_pos));
     }
 }
 

--- a/bridge/src/dts_pipeline.rs
+++ b/bridge/src/dts_pipeline.rs
@@ -4,10 +4,16 @@
 // routes each frame to either the DTS-HD MA lossless decoder (5.1/7.1, when an
 // EXSS substream follows the core) or the plain DTS core decoder (5.1). Every
 // decoded core channel is emitted as a bed channel, placed at its canonical
-// speaker by the renderer. XLL-X's standard four-source profile is mapped to
-// the four 7.1.4 height positions after undoing its -3 dB contribution to the
-// backward-compatible 7.1 bed. Alternate decoded profiles use their current
-// experimental presentations automatically.
+// speaker by the renderer.
+//
+// DTS:X extension waveforms are presented the way the stream describes them
+// (`dca::XPresentation` + `dca::XMetadata`): fixed heights as labeled
+// channels, objects as object channels with transmitted positions. Every
+// waveform was also mixed into the backward-compatible bed by the encoder, at
+// gains the stream's private metadata states; that contribution is removed
+// from the bed before the waveform is emitted at its own position, so nothing
+// plays twice. A waveform whose fold is not stated (an object record without
+// reference rows) stays in the bed and its own channel is silent.
 
 use abi_stable::std_types::{RString, RVec};
 use bridge_api::RPushResult;
@@ -15,7 +21,8 @@ use bridge_api::{
     RChannelLabel, RDecodedFrame, REvent, RMetadataFrame, RNameUpdate, RObjectChannel,
 };
 use dca::{
-    CorePcmFrame, HdError, HdFrame, XPresentation, exss_has_xll, exss_substream_size, parse_header,
+    CorePcmFrame, FoldPlan, HdError, HdFrame, MAX_SOURCES, SourceRole, SphericalPosition,
+    XMetadata, XPresentation, exss_has_xll, exss_substream_size, parse_header,
 };
 use serde::Deserialize;
 
@@ -26,26 +33,18 @@ use crate::metadata::declare_object_channels;
 
 const CORE_SYNC: [u8; 4] = 0x7FFE_8001u32.to_be_bytes();
 const SUBSTREAM_SYNC: [u8; 4] = 0x6458_2025u32.to_be_bytes();
-// Exact Q15 -3 dB coefficient used by the DTS downmix table. The regular 7.1
-// presentation contains this contribution from each corresponding height feed.
-#[cfg(test)]
-const XLL_X_HEIGHT_DOWNMIX_GAIN: f32 = 23_170.0 / 32_768.0;
+/// Object ids start past the legacy bed-id range.
+const OBJECT_ID_BASE: u32 = 10;
+/// Re-emit unchanged object positions at this rate so monitoring clients
+/// whose stream-idle timeout is shorter than a second keep the objects
+/// alive, while staying far below the per-audio-frame rate that could
+/// overwhelm Studio.
+const HEARTBEAT_HZ: u64 = 2;
 
-// Research-only D0 partial-unfold coefficients. The source-to-speaker
-// associations are repeatable across the two measured programmes, but these
-// gains are conservative presentation choices, not decoded metadata or a proven
-// profile-exact matrix. In particular, the partial subtraction deliberately
-// preserves some programme material authored in both the lower and top feeds.
-#[cfg(test)]
-const D0_TFC_CENTER_DOWNMIX_GAIN: f32 = 0.5;
-#[cfg(test)]
-const ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN: f32 = 1.0 / std::f32::consts::SQRT_2;
-
-// Research-only D1 compatibility-fold estimates, measured on strict,
-// well-conditioned full-programme matrices in the D1 corpus. These are
-// intentionally isolated from the lossless decoder. They are not claimed to be
-// a normative/profile-exact matrix yet.
-
+/// Fallback fold for a standard-profile frame whose type-2 matrix could not
+/// be read: the four height feeds at one configured gain. Every stream in
+/// the corpus states code 55 (Q15 23170/32768, -3.01 dB), which is also the
+/// bundled default; a local `dts-fold.yaml` overrides it.
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct FoldRoute {
     pub target: String,
@@ -93,16 +92,57 @@ impl DtsFoldConfig {
             })
             .map_or(0.0, |route| 10.0_f32.powf(route.gain_db / 20.0))
     }
-}
-// The D0/D1 channel identities and the D3 inferred object positions moved to
-// `dca::spatial`, which documents their (research-only) provenance. Both this
-// pipeline and the offline ADM exporter read them from there.
-const D3_OBJECT_SOURCE_INDICES: [usize; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
 
-enum FoldSources<'a> {
-    None,
-    One(&'a [f32], f32),
-    Two(&'a [f32], f32, &'a [f32], f32),
+    /// The standard-profile fallback plan: TFL→L, TFR→R, TBL→Lb, TBR→Rb.
+    fn standard_fallback(&self) -> FoldPlan {
+        FoldPlan::standard_heights(self.gain("L", "TFL"))
+    }
+}
+
+/// Per-stream DTS:X extension state. Cleared with the pipeline.
+#[derive(Default)]
+pub(crate) struct DtsXState {
+    /// Presentation latched from the first frame with usable extension
+    /// waveforms. A later frame whose waveforms are missing or invalid keeps
+    /// this channel shape (composite bed + silent extension channels) instead
+    /// of renegotiating, and no content is lost: the folded contribution stays
+    /// in the bed for that frame.
+    pub(crate) locked: Option<XPresentation>,
+    /// The most recent metadata that parsed. A frame whose own metadata does
+    /// not parse reuses it, so a transient failure neither clicks nor changes
+    /// which waveforms play.
+    pub(crate) last_metadata: Option<XMetadata>,
+    /// Position last announced per object feed, for sparse events.
+    emitted_positions: [Option<SphericalPosition>; MAX_SOURCES],
+    parse_failures: u64,
+    feed_dropouts: u64,
+}
+
+impl DtsXState {
+    fn note_parse_failure(&mut self, error: dca::XMetadataError) {
+        self.parse_failures += 1;
+        if self.parse_failures == 1 || self.parse_failures.is_power_of_two() {
+            log::warn!(
+                "dts: extension metadata unreadable ({error:?}, {} frames so far); {}",
+                self.parse_failures,
+                if self.last_metadata.is_some() {
+                    "reusing the last readable frame"
+                } else {
+                    "keeping the bed as authored and muting the extension channels"
+                }
+            );
+        }
+    }
+
+    fn note_feed_dropout(&mut self, reason: &str) {
+        self.feed_dropouts += 1;
+        if self.feed_dropouts == 1 || self.feed_dropouts.is_power_of_two() {
+            log::warn!(
+                "dts: extension waveforms unavailable ({reason}, {} frames so far); emitting silent extension channels",
+                self.feed_dropouts
+            );
+        }
+    }
 }
 
 /// Demux and decode all complete DTS frames buffered in `bridge.dts_buf`.
@@ -150,7 +190,7 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
                         let n = hd_samples(&hd);
                         if let Some((frame, emitted_objects)) = build_hd_frame_with_extensions(
                             &hd,
-                            &mut bridge.dts_height_locked,
+                            &mut bridge.dts_x,
                             &bridge.dts_fold_config,
                             bridge.total_samples,
                             &mut bridge.declared_object_channels,
@@ -235,27 +275,6 @@ fn hd_samples(hd: &HdFrame) -> usize {
     hd.bed_sample_count()
 }
 
-/// ABI labels for a presentation's extension feeds, in feed order.
-///
-/// The feed->position tables themselves live in `dca::spatial` so the offline
-/// ADM exporter reads the same ones; this only projects them onto the ABI.
-fn spatial_labels(presentation: XPresentation) -> impl Iterator<Item = RChannelLabel> {
-    presentation
-        .channels()
-        .iter()
-        .copied()
-        .map(dca_spatial_channel_to_r)
-}
-
-/// Static position of D3 object feed `source`. Research-only defaults; see
-/// `dca::spatial` for their provenance.
-fn d3_object_position(source: usize) -> [f64; 3] {
-    XPresentation::ObjectsD3
-        .object_positions()
-        .and_then(|positions| positions.get(source).copied())
-        .unwrap_or([0.0; 3])
-}
-
 /// DCA speaker index -> renderer channel label, for the DTS-HD bed.
 fn speaker_to_label(spkr: usize) -> RChannelLabel {
     match spkr {
@@ -272,19 +291,37 @@ fn speaker_to_label(spkr: usize) -> RChannelLabel {
     }
 }
 
-/// Build a frame from decoded DTS-HD per-speaker PCM. The normal path remains
-/// fixed-channel only. Decoded alternate profiles use the current experimental
-/// presentation: inferred fixed channels for D0/D1 and unchanged named objects
-/// at inferred static positions for D3.
-///
-/// `height_locked` latches once a valid XLL-X quartet has been emitted: from
-/// then on a frame with a missing/invalid quartet keeps the 12-channel shape
-/// (composite bed + silent heights) instead of collapsing to 8 channels, so
-/// the host never renegotiates mid-stream and no content is lost (the folded
-/// height contribution stays in the bed for that frame).
+/// The fold plan for this frame: its own metadata when readable, otherwise
+/// the last readable metadata, otherwise the profile's fallback.
+fn resolve_plan(
+    hd: &HdFrame,
+    presentation: XPresentation,
+    state: &mut DtsXState,
+    fold_config: &DtsFoldConfig,
+) -> FoldPlan {
+    match XMetadata::parse(&hd.x_payload, presentation.feed_count()) {
+        Ok(metadata) => {
+            state.last_metadata = Some(metadata);
+            FoldPlan::from_metadata(&metadata)
+        }
+        Err(error) => {
+            state.note_parse_failure(error);
+            match (&state.last_metadata, presentation) {
+                (Some(metadata), _) => FoldPlan::from_metadata(metadata),
+                (None, XPresentation::Height) => fold_config.standard_fallback(),
+                (None, _) => FoldPlan::all_unknown(presentation.feed_count()),
+            }
+        }
+    }
+}
+
+/// Build a frame from decoded DTS-HD per-speaker PCM: the bed with every
+/// stated extension contribution removed, then the fixed extension channels,
+/// then the object channels. Returns the frame and whether it carries object
+/// channels (the live `has_objects` fact).
 fn build_hd_frame_with_extensions(
     hd: &HdFrame,
-    height_locked: &mut bool,
+    state: &mut DtsXState,
     fold_config: &DtsFoldConfig,
     sample_pos: u64,
     declared_object_channels: &mut Option<RVec<RObjectChannel>>,
@@ -310,163 +347,55 @@ fn build_hd_frame_with_extensions(
         bed.push(channel.as_slice());
     }
 
-    // The XLL-X channel set carries four full-coded waveforms but no
-    // one-to-one speaker mask. Treat its stable stereo pairs as front-height
-    // L/R followed by rear-height L/R. Keep the mapping isolated here so it
-    // can be replaced without touching the lossless decoder if later metadata
-    // proves otherwise.
-    let height_samples: Option<&[Vec<f32>; 4]> =
-        hd.x_samples
-            .as_slice()
-            .try_into()
-            .ok()
-            .filter(|channels: &&[Vec<f32>; 4]| {
-                channels.iter().all(|channel| channel.len() == sample_count)
-            });
-    if height_samples.is_none() && hd.x_present && *height_locked {
-        let err = hd.x_decode_error.unwrap_or("no quartet");
-        log::warn!("dts: XLL-X quartet unavailable ({err}); emitting silent heights");
-    }
-
-    let emit_heights = height_samples.is_some() || *height_locked;
-    let height_count = if emit_heights {
-        XPresentation::Height.feed_count()
-    } else {
-        0
-    };
-    let alternate_samples = hd
-        .x_imax
-        .then_some(hd.x_samples.as_slice())
-        .filter(|channels| matches!(channels.len(), 5 | 6 | 8))
-        .filter(|channels| channels.iter().all(|channel| channel.len() == sample_count));
-    let d0_fixed_samples = alternate_samples
-        .filter(|channels| channels.len() == 5)
-        .map(|channels| {
-            [
-                &channels[0][..],
-                &channels[1][..],
-                &channels[2][..],
-                &channels[3][..],
-                &channels[4][..],
-            ]
-        });
-    let d1_fixed_samples = alternate_samples
-        .filter(|channels| channels.len() == 6)
-        .map(|channels| {
-            [
-                &channels[0][..],
-                &channels[1][..],
-                &channels[2][..],
-                &channels[3][..],
-                &channels[4][..],
-                &channels[5][..],
-            ]
-        });
-    let object_source_indices: &[usize] = match alternate_samples.map(<[Vec<f32>]>::len) {
-        Some(8) => &D3_OBJECT_SOURCE_INDICES,
-        _ => &[],
-    };
-    let d0_fixed_count = d0_fixed_samples.map_or(0, |_| XPresentation::FixedD0.feed_count());
-    let d1_fixed_count = d1_fixed_samples.map_or(0, |_| XPresentation::FixedD1.feed_count());
-    let object_count = object_source_indices.len();
-    let channel_count =
-        active.len() + height_count + d0_fixed_count + d1_fixed_count + object_count;
-
-    // Per-channel source and coefficient for the unfold, hoisted out of the
-    // sample loop (no per-sample speaker/profile branching). The D0 choices
-    // below are conservative research settings, not a normative matrix.
-    let fold_sources: Vec<FoldSources<'_>> = active
-        .iter()
-        .map(|&spkr| {
-            if let Some(heights) = height_samples {
-                let height_idx = match spkr {
-                    1 => 0usize,
-                    2 => 1,
-                    7 => 2,
-                    8 => 3,
-                    _ => return FoldSources::None,
-                };
-                return FoldSources::One(
-                    heights[height_idx].as_slice(),
-                    match spkr {
-                        1 => fold_config.gain("L", "TFL"),
-                        2 => fold_config.gain("R", "TFR"),
-                        7 => fold_config.gain("Lb", "TBL"),
-                        8 => fold_config.gain("Rb", "TBR"),
-                        _ => 0.0,
-                    },
+    // A presentation is detected only when every extension waveform is
+    // present at the bed length; otherwise the latched one keeps the shape.
+    let detected = XPresentation::detect(hd);
+    let presentation = match (detected, state.locked) {
+        (Some(detected), _) => {
+            if state.locked.is_some_and(|locked| locked != detected) {
+                log::warn!(
+                    "dts: extension presentation changed {:?} -> {detected:?}; channel shape changes",
+                    state.locked
                 );
             }
-            if let Some(fixed) = d0_fixed_samples {
-                return match spkr {
-                    0 => FoldSources::One(fixed[0], fold_config.gain("C", "X0")),
-                    1 => FoldSources::One(fixed[1], fold_config.gain("L", "X1")),
-                    2 => FoldSources::One(fixed[2], fold_config.gain("R", "X2")),
-                    7 => FoldSources::One(fixed[3], fold_config.gain("Lb", "X3")),
-                    8 => FoldSources::One(fixed[4], fold_config.gain("Rb", "X4")),
-                    _ => FoldSources::None,
-                };
+            state.locked = Some(detected);
+            detected
+        }
+        (None, Some(locked)) => {
+            if hd.x_present || hd.x_imax {
+                state.note_feed_dropout(hd.x_decode_error.unwrap_or("no usable waveform set"));
             }
-            if let Some(fixed) = d1_fixed_samples {
-                return match spkr {
-                    1 => FoldSources::Two(
-                        fixed[0],
-                        fold_config.gain("L", "X0"),
-                        fixed[2],
-                        fold_config.gain("L", "X2"),
-                    ),
-                    2 => FoldSources::Two(
-                        fixed[1],
-                        fold_config.gain("R", "X1"),
-                        fixed[3],
-                        fold_config.gain("R", "X3"),
-                    ),
-                    3 => FoldSources::One(fixed[2], fold_config.gain("Ls", "X2")),
-                    4 => FoldSources::One(fixed[3], fold_config.gain("Rs", "X3")),
-                    7 => FoldSources::One(fixed[4], fold_config.gain("Lb", "X4")),
-                    8 => FoldSources::One(fixed[5], fold_config.gain("Rb", "X5")),
-                    _ => FoldSources::None,
-                };
-            }
-            FoldSources::None
-        })
-        .collect();
+            locked
+        }
+        (None, None) => return Some((bed_only_frame(hd, &active, &bed, sample_count), false)),
+    };
+    let feeds: &[Vec<f32>] = if detected.is_some() {
+        hd.x_samples.as_slice()
+    } else {
+        &[]
+    };
+    let plan = if detected.is_some() {
+        resolve_plan(hd, presentation, state, fold_config)
+    } else {
+        FoldPlan::all_unknown(presentation.feed_count())
+    };
+    let metadata = detected.and(state.last_metadata);
+
+    let fixed_feeds = presentation.fixed_feeds();
+    let object_feeds = presentation.object_feeds();
+    let channel_count = active.len() + presentation.feed_count();
 
     let mut pcm: RVec<i32> = RVec::with_capacity(sample_count * channel_count);
     for s in 0..sample_count {
-        for (channel, fold) in bed.iter().zip(fold_sources.iter()) {
-            let sample = match *fold {
-                FoldSources::None => channel[s],
-                FoldSources::One(source, gain) => channel[s] - source[s] * gain,
-                FoldSources::Two(first, first_gain, second, second_gain) => {
-                    channel[s] - first[s] * first_gain - second[s] * second_gain
-                }
+        for (channel, &spkr) in bed.iter().zip(&active) {
+            pcm.push(float_to_pcm_i32(plan.clean(spkr, channel[s], s, feeds)));
+        }
+        for feed in fixed_feeds.clone().chain(object_feeds.clone()) {
+            let sample = match feeds.get(feed) {
+                Some(waveform) if plan.source_is_known(feed) => waveform[s],
+                _ => 0.0,
             };
             pcm.push(float_to_pcm_i32(sample));
-        }
-        if let Some(height_samples) = height_samples {
-            for channel in height_samples.iter() {
-                pcm.push(float_to_pcm_i32(channel[s]));
-            }
-        } else {
-            for _ in 0..height_count {
-                pcm.push(0);
-            }
-        }
-        if let Some(fixed) = d0_fixed_samples {
-            for channel in fixed {
-                pcm.push(float_to_pcm_i32(channel[s]));
-            }
-        }
-        if let Some(fixed) = d1_fixed_samples {
-            for channel in fixed {
-                pcm.push(float_to_pcm_i32(channel[s]));
-            }
-        }
-        if let Some(alternate) = alternate_samples {
-            for &source in object_source_indices {
-                pcm.push(float_to_pcm_i32(alternate[source][s]));
-            }
         }
     }
 
@@ -474,21 +403,25 @@ fn build_hd_frame_with_extensions(
     for &spkr in &active {
         channel_labels.push(speaker_to_label(spkr));
     }
-    channel_labels.extend(spatial_labels(XPresentation::Height).take(height_count));
-    channel_labels.extend(spatial_labels(XPresentation::FixedD0).take(d0_fixed_count));
-    channel_labels.extend(spatial_labels(XPresentation::FixedD1).take(d1_fixed_count));
-    channel_labels.extend(std::iter::repeat_n(RChannelLabel::Object, object_count));
+    channel_labels.extend(
+        presentation
+            .fixed_channels()
+            .iter()
+            .map(|&channel| dca_spatial_channel_to_r(channel)),
+    );
+    channel_labels.extend(std::iter::repeat_n(
+        RChannelLabel::Object,
+        object_feeds.len(),
+    ));
 
-    if height_samples.is_some() {
-        *height_locked = true;
-    }
-
-    let metadata = build_d3_metadata(
-        object_source_indices,
-        active.len() + height_count + d0_fixed_count + d1_fixed_count,
+    let metadata = build_object_metadata(
+        presentation,
+        metadata.as_ref(),
+        active.len() + fixed_feeds.len(),
         sample_pos,
         hd.sample_rate,
         sample_count,
+        state,
         declared_object_channels,
     );
 
@@ -505,85 +438,121 @@ fn build_hd_frame_with_extensions(
             dialogue_level: None.into(),
             is_new_segment: false,
         },
-        object_count > 0,
+        !object_feeds.is_empty(),
     ))
 }
 
-fn build_d3_metadata(
-    object_source_indices: &[usize],
+/// A frame with no extension presentation: the lossless bed as decoded.
+fn bed_only_frame(
+    hd: &HdFrame,
+    active: &[usize],
+    bed: &[&[f32]],
+    sample_count: usize,
+) -> RDecodedFrame {
+    let mut pcm: RVec<i32> = RVec::with_capacity(sample_count * active.len());
+    for s in 0..sample_count {
+        for channel in bed {
+            pcm.push(float_to_pcm_i32(channel[s]));
+        }
+    }
+    let channel_labels: RVec<RChannelLabel> =
+        active.iter().map(|&spkr| speaker_to_label(spkr)).collect();
+    RDecodedFrame {
+        sampling_frequency: hd.sample_rate,
+        sample_count: sample_count as u32,
+        channel_count: active.len() as u32,
+        pcm,
+        channel_labels,
+        metadata: RVec::new(),
+        drc_gain: 1.0,
+        drc_ramp_duration: 0,
+        dialogue_level: None.into(),
+        is_new_segment: false,
+    }
+}
+
+/// Object channel declaration and position events for a presentation with
+/// objects. Declarations are sparse (re-emitted on change); positions are
+/// emitted when they change, when the declaration changes, and on the
+/// heartbeat. A fixed presentation emits nothing.
+#[allow(clippy::too_many_arguments)]
+fn build_object_metadata(
+    presentation: XPresentation,
+    metadata: Option<&XMetadata>,
     first_object_channel: usize,
     sample_pos: u64,
     sample_rate: u32,
     sample_count: usize,
+    state: &mut DtsXState,
     declared_object_channels: &mut Option<RVec<RObjectChannel>>,
 ) -> RVec<RMetadataFrame> {
-    const HEARTBEAT_HZ: u64 = 2;
-
-    let object_count = object_source_indices.len();
-    if object_count == 0 {
+    let object_feeds = presentation.object_feeds();
+    if object_feeds.is_empty() {
         return RVec::new();
     }
 
-    let declaration_unchanged = declared_object_channels.as_deref().is_some_and(|channels| {
-        channels.len() == object_count
-            && channels.iter().zip(object_source_indices).enumerate().all(
-                |(index, (channel, source))| {
-                    channel.id == (10 + source) as u32
-                        && channel.channel == (first_object_channel + index) as u32
-                },
-            )
-    });
-    // Keep static presentations alive in monitoring clients whose stream-idle
-    // timeout is shorter than one second, while staying far below the former
-    // per-audio-frame metadata rate that could overwhelm Studio.
-    let heartbeat_period = (sample_rate as u64) / HEARTBEAT_HZ;
+    let current: RVec<RObjectChannel> = object_feeds
+        .clone()
+        .enumerate()
+        .map(|(index, feed)| RObjectChannel {
+            id: OBJECT_ID_BASE + feed as u32,
+            channel: (first_object_channel + index) as u32,
+        })
+        .collect();
+    let declaration_unchanged = declared_object_channels.as_deref() == Some(current.as_slice());
+    let heartbeat_period = u64::from(sample_rate) / HEARTBEAT_HZ;
     let heartbeat_due = heartbeat_period > 0 && sample_pos % heartbeat_period < sample_count as u64;
-    if declaration_unchanged && !heartbeat_due {
-        return RVec::new();
-    }
-    let object_channels = if declaration_unchanged {
-        RVec::new()
-    } else {
-        log::warn!(
-            "dts: EXPERIMENTAL D3 presentation declaring X0..X{} at inferred positions; mapping is not source metadata",
-            object_count - 1,
-        );
-        let current: RVec<RObjectChannel> = object_source_indices
-            .iter()
-            .enumerate()
-            .map(|(index, &source)| RObjectChannel {
-                id: (10 + source) as u32,
-                channel: (first_object_channel + index) as u32,
-            })
-            .collect();
-        declare_object_channels(declared_object_channels, current)
-    };
 
-    let events: RVec<REvent> = object_source_indices
-        .iter()
-        .map(|&source| REvent {
-            id: (10 + source) as u32,
+    let mut events: RVec<REvent> = RVec::new();
+    for feed in object_feeds.clone() {
+        let Some(SourceRole::Object { position, .. }) = metadata
+            .and_then(|metadata| metadata.source(feed))
+            .map(|source| source.role)
+        else {
+            continue;
+        };
+        let slot = &mut state.emitted_positions[feed];
+        if *slot == Some(position) && declaration_unchanged && !heartbeat_due {
+            continue;
+        }
+        *slot = Some(position);
+        events.push(REvent {
+            id: OBJECT_ID_BASE + feed as u32,
             sample_pos,
             has_pos: true,
-            pos: d3_object_position(source),
+            pos: position.to_adm_cartesian(),
             gain_db: 0,
             size: [0.0; 3],
             ramp_duration: 0,
-        })
-        .collect();
-    let name_updates = if declaration_unchanged {
-        RVec::new()
+        });
+    }
+    if declaration_unchanged && events.is_empty() {
+        return RVec::new();
+    }
+
+    let (object_channels, name_updates) = if declaration_unchanged {
+        (RVec::new(), RVec::new())
     } else {
-        object_source_indices
-            .iter()
-            .map(|&source| RNameUpdate {
-                id: (10 + source) as u32,
-                name: RString::from(format!("X{source}")),
+        log::info!(
+            "dts: {presentation:?} declares object channels for extension waveforms {}..{}",
+            object_feeds.start,
+            object_feeds.end
+        );
+        let names = object_feeds
+            .clone()
+            .map(|feed| RNameUpdate {
+                id: OBJECT_ID_BASE + feed as u32,
+                name: RString::from(format!("X{feed}")),
             })
-            .collect()
+            .collect();
+        (
+            declare_object_channels(declared_object_channels, current),
+            names,
+        )
     };
-    let mut metadata = RVec::with_capacity(1);
-    metadata.push(RMetadataFrame {
+
+    let mut frames = RVec::with_capacity(1);
+    frames.push(RMetadataFrame {
         events,
         object_channels,
         channel_gains: RVec::new(),
@@ -591,13 +560,7 @@ fn build_d3_metadata(
         sample_pos,
         ramp_duration: 0,
     });
-    metadata
-}
-
-#[cfg(test)]
-fn build_hd_frame(hd: &HdFrame, height_locked: &mut bool) -> Option<RDecodedFrame> {
-    build_hd_frame_with_extensions(hd, height_locked, &DtsFoldConfig::default(), 0, &mut None)
-        .map(|(frame, _)| frame)
+    frames
 }
 
 /// Build a bed frame from a plain DTS core PCM frame (DCA primary order + LFE).
@@ -639,49 +602,103 @@ fn build_core_frame(core: &CorePcmFrame) -> RDecodedFrame {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dca::{BedFold, SourceMetadata, SpatialChannel, gain_code_linear};
 
     const SAMPLE_COUNT: usize = 2;
+    const Q55: f32 = 23170.0 / 32768.0;
 
     fn hd_frame(samples: Vec<Option<Vec<f32>>>, x_samples: Vec<Vec<f32>>) -> HdFrame {
         HdFrame {
             sample_rate: 48_000,
-            output_mask: 0,
-            samples,
             x_present: !x_samples.is_empty(),
-            x_imax: false,
-            x_payload: Vec::new(),
-            x_payload_offset: 0,
-            x_samples,
             x_pcm_bit_res: 24,
-            x_bits_consumed: 0,
-            x_decode_error: None,
-            x_header_tail_bits: 0,
             xll_frame_segments: 1,
             xll_segment_samples: SAMPLE_COUNT,
-            xll_segment_size_bits: 0,
-            xll_band_crc_present: 0,
-            xll_scalable_lsbs: false,
-            exss_descriptor_tail: Vec::new(),
-            exss_descriptor_tail_bits: 0,
-            x_descriptor_offset: None,
-            x_descriptor_size: None,
-            x_descriptor_navigation_used: false,
+            samples,
+            x_samples,
+            ..HdFrame::default()
         }
     }
 
     fn assert_pcm_close(actual: i32, expected: f32) {
         let expected = float_to_pcm_i32(expected);
         assert!(
-            // YAML dB values are converted back to linear amplitude; allow
-            // the bounded float32/PCM quantisation difference.
+            // Allow the bounded float32/PCM quantisation difference.
             actual.abs_diff(expected) <= 64,
             "actual={actual}, expected={expected}"
         );
     }
 
+    fn height(channel: SpatialChannel, column: usize, gain: f32) -> SourceMetadata {
+        let mut columns = [0.0; 8];
+        columns[column] = gain;
+        SourceMetadata {
+            role: SourceRole::Height(channel),
+            fold: BedFold::Known(columns),
+        }
+    }
+
+    fn object(azimuth: i16, elevation: i16, fold: BedFold) -> SourceMetadata {
+        SourceMetadata {
+            role: SourceRole::Object {
+                position: SphericalPosition {
+                    azimuth_half_degrees: azimuth,
+                    elevation_half_degrees: elevation,
+                    distance_64ths: 64,
+                },
+                centre_height_alternative: false,
+            },
+            fold,
+        }
+    }
+
+    /// The four fixed heights folded into L, R, Lb, Rb at `gain`.
+    fn heights(gain: f32) -> [SourceMetadata; 4] {
+        [
+            height(SpatialChannel::TopFrontLeft, 1, gain),
+            height(SpatialChannel::TopFrontRight, 2, gain),
+            height(SpatialChannel::TopBackLeft, 4, gain),
+            height(SpatialChannel::TopBackRight, 5, gain),
+        ]
+    }
+
+    fn state_with(metadata: Option<XMetadata>) -> DtsXState {
+        DtsXState {
+            last_metadata: metadata,
+            ..DtsXState::default()
+        }
+    }
+
+    fn build(hd: &HdFrame, state: &mut DtsXState) -> (RDecodedFrame, bool) {
+        let mut declared = None;
+        build_hd_frame_with_extensions(hd, state, &DtsFoldConfig::default(), 0, &mut declared)
+            .expect("valid frame")
+    }
+
+    fn folded(dry: &[f32], sources: &[(&[f32], f32)]) -> Vec<f32> {
+        dry.iter()
+            .enumerate()
+            .map(|(s, &value)| {
+                value
+                    + sources
+                        .iter()
+                        .map(|(source, gain)| source[s] * gain)
+                        .sum::<f32>()
+            })
+            .collect()
+    }
+
+    fn full_bed() -> Vec<Option<Vec<f32>>> {
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        for idx in [0usize, 1, 2, 3, 4, 5, 7, 8] {
+            samples[idx] = Some(vec![0.01 * idx as f32, -0.01 * idx as f32]);
+        }
+        samples
+    }
+
     #[test]
-    fn xll_x_heights_are_removed_from_the_compatible_bed() {
-        let heights = [
+    fn standard_heights_are_removed_from_the_bed_with_the_stated_gain() {
+        let heights_pcm = [
             vec![0.40, -0.20],
             vec![-0.30, 0.10],
             vec![0.20, -0.40],
@@ -693,46 +710,18 @@ mod tests {
             vec![0.09, -0.10],
             vec![-0.11, 0.12],
         ];
-        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
-        samples[0] = Some(vec![0.01, -0.01]);
-        samples[1] = Some(
-            dry[0]
-                .iter()
-                .zip(&heights[0])
-                .map(|(&bed, &height)| bed + height * XLL_X_HEIGHT_DOWNMIX_GAIN)
-                .collect(),
-        );
-        samples[2] = Some(
-            dry[1]
-                .iter()
-                .zip(&heights[1])
-                .map(|(&bed, &height)| bed + height * XLL_X_HEIGHT_DOWNMIX_GAIN)
-                .collect(),
-        );
-        samples[3] = Some(vec![0.02, -0.02]);
-        samples[4] = Some(vec![0.03, -0.03]);
-        samples[5] = Some(vec![0.04, -0.04]);
-        samples[7] = Some(
-            dry[2]
-                .iter()
-                .zip(&heights[2])
-                .map(|(&bed, &height)| bed + height * XLL_X_HEIGHT_DOWNMIX_GAIN)
-                .collect(),
-        );
-        samples[8] = Some(
-            dry[3]
-                .iter()
-                .zip(&heights[3])
-                .map(|(&bed, &height)| bed + height * XLL_X_HEIGHT_DOWNMIX_GAIN)
-                .collect(),
-        );
+        // The stream states unity here, unlike the bundled -3 dB fallback.
+        let mut samples = full_bed();
+        samples[1] = Some(folded(&dry[0], &[(&heights_pcm[0], 1.0)]));
+        samples[2] = Some(folded(&dry[1], &[(&heights_pcm[1], 1.0)]));
+        samples[7] = Some(folded(&dry[2], &[(&heights_pcm[2], 1.0)]));
+        samples[8] = Some(folded(&dry[3], &[(&heights_pcm[3], 1.0)]));
+        let hd = hd_frame(samples, heights_pcm.to_vec());
 
-        let hd = hd_frame(samples, heights.into());
-        let mut locked = false;
-        let frame = build_hd_frame(&hd, &mut locked).expect("valid frame");
-        assert!(locked, "a valid quartet must latch the height lock");
-
-        assert_eq!(frame.sample_count, SAMPLE_COUNT as u32);
+        let mut state = state_with(XMetadata::from_sources(&heights(1.0)));
+        let (frame, emitted) = build(&hd, &mut state);
+        assert!(!emitted, "a fixed presentation carries no objects");
+        assert_eq!(state.locked, Some(XPresentation::Height));
         assert_eq!(frame.channel_count, 12);
         assert_eq!(
             frame.channel_labels.as_slice(),
@@ -755,7 +744,6 @@ mod tests {
             frame.metadata.is_empty(),
             "a fixed presentation must not fabricate metadata"
         );
-
         for sample in 0..SAMPLE_COUNT {
             let row = &frame.pcm[sample * 12..(sample + 1) * 12];
             assert_pcm_close(row[1], dry[0][sample]);
@@ -769,24 +757,33 @@ mod tests {
     }
 
     #[test]
-    fn invalid_xll_x_quartet_keeps_the_compatible_bed_unchanged() {
+    fn unreadable_standard_metadata_falls_back_to_the_configured_gain() {
+        let left_height = vec![0.40, -0.20];
+        let dry = vec![0.05, -0.06];
+        let mut samples = full_bed();
+        samples[1] = Some(folded(&dry, &[(&left_height, Q55)]));
+        let hd = hd_frame(samples, vec![left_height; 4]);
+
+        let mut state = DtsXState::default();
+        let (frame, _) = build(&hd, &mut state);
+        assert_eq!(frame.channel_count, 12);
+        assert_eq!(state.parse_failures, 1);
+        for sample in 0..SAMPLE_COUNT {
+            assert_pcm_close(frame.pcm[sample * 12 + 1], dry[sample]);
+        }
+    }
+
+    #[test]
+    fn invalid_quartet_keeps_the_compatible_bed_unchanged() {
         let composite_left = vec![0.25, -0.25];
-        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
-        samples[0] = Some(vec![0.0; SAMPLE_COUNT]);
+        let mut samples = full_bed();
         samples[1] = Some(composite_left.clone());
-        samples[2] = Some(vec![0.0; SAMPLE_COUNT]);
-        samples[3] = Some(vec![0.0; SAMPLE_COUNT]);
-        samples[4] = Some(vec![0.0; SAMPLE_COUNT]);
-        samples[5] = Some(vec![0.0; SAMPLE_COUNT]);
-        samples[7] = Some(vec![0.0; SAMPLE_COUNT]);
-        samples[8] = Some(vec![0.0; SAMPLE_COUNT]);
         let hd = hd_frame(samples, vec![vec![0.5; SAMPLE_COUNT]; 3]);
 
         // Not locked yet: an invalid quartet keeps the plain 8-channel bed.
-        let mut locked = false;
-        let frame = build_hd_frame(&hd, &mut locked).expect("valid frame");
-        assert!(!locked, "an invalid quartet must not latch the lock");
-
+        let mut state = DtsXState::default();
+        let (frame, _) = build(&hd, &mut state);
+        assert_eq!(state.locked, None, "an invalid quartet must not latch");
         assert_eq!(frame.channel_count, 8);
         assert!(frame.metadata.is_empty());
         for sample in 0..SAMPLE_COUNT {
@@ -798,23 +795,22 @@ mod tests {
     }
 
     #[test]
-    fn locked_stream_keeps_shape_with_silent_heights_on_quartet_dropout() {
+    fn locked_stream_keeps_shape_with_silent_feeds_on_dropout() {
         let composite_left = vec![0.25, -0.25];
-        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
-        for idx in [0usize, 2, 3, 4, 5, 7, 8] {
-            samples[idx] = Some(vec![0.0; SAMPLE_COUNT]);
-        }
+        let mut samples = full_bed();
         samples[1] = Some(composite_left.clone());
         // Invalid quartet (3 channels) after a previous frame locked heights.
         let hd = hd_frame(samples, vec![vec![0.5; SAMPLE_COUNT]; 3]);
 
-        let mut locked = true;
-        let frame = build_hd_frame(&hd, &mut locked).expect("valid frame");
+        let mut state = state_with(XMetadata::from_sources(&heights(Q55)));
+        state.locked = Some(XPresentation::Height);
+        let (frame, _) = build(&hd, &mut state);
 
-        // Stable 12-channel shape: composite bed (no unfold without a
-        // quartet) + silent height channels — the host never renegotiates.
+        // Stable 12-channel shape: composite bed (nothing to subtract without
+        // a quartet) + silent height channels — the host never renegotiates.
         assert_eq!(frame.channel_count, 12);
         assert!(frame.metadata.is_empty());
+        assert_eq!(state.feed_dropouts, 1);
         for sample in 0..SAMPLE_COUNT {
             let row = &frame.pcm[sample * 12..(sample + 1) * 12];
             assert_eq!(row[1], float_to_pcm_i32(composite_left[sample]));
@@ -823,23 +819,49 @@ mod tests {
     }
 
     #[test]
-    fn d3_emits_named_objects_without_unfolding_the_bed() {
-        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
-        samples[0] = Some(vec![0.10, -0.10]);
-        samples[1] = Some(vec![0.20, -0.20]);
-        samples[2] = Some(vec![0.30, -0.30]);
+    fn d3_unfolds_objects_and_heights_and_positions_the_objects() {
         let extension: Vec<Vec<f32>> = (0..8)
-            .map(|index| vec![0.01 * (index + 1) as f32; SAMPLE_COUNT])
+            .map(|index| vec![0.01 * (index + 1) as f32, -0.02 * (index + 1) as f32])
             .collect();
+        let code21 = gain_code_linear(21).unwrap();
+        let dry_lb = vec![0.10, -0.10];
+        let dry_l = vec![0.20, -0.20];
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        samples[0] = Some(vec![0.30, -0.30]);
+        // L carries TFL (feed 4) at -3 dB; Lb carries objects 0 (unity), 1
+        // (code 21) and TBL (feed 6) at -3 dB.
+        samples[1] = Some(folded(&dry_l, &[(&extension[4], Q55)]));
+        samples[7] = Some(folded(
+            &dry_lb,
+            &[
+                (&extension[0], 1.0),
+                (&extension[1], code21),
+                (&extension[6], Q55),
+            ],
+        ));
         let mut hd = hd_frame(samples, extension);
         hd.x_present = false;
         hd.x_imax = true;
 
-        let mut locked = false;
+        let mut columns0 = [0.0; 8];
+        columns0[4] = 1.0;
+        let mut columns1 = [0.0; 8];
+        columns1[4] = code21;
+        let sources = [
+            object(-291, 57, BedFold::Known(columns0)),
+            object(291, 54, BedFold::Known(columns1)),
+            object(-300, 0, BedFold::Known([0.0; 8])),
+            object(300, 0, BedFold::Known([0.0; 8])),
+            heights(Q55)[0],
+            heights(Q55)[1],
+            heights(Q55)[2],
+            heights(Q55)[3],
+        ];
+        let mut state = state_with(XMetadata::from_sources(&sources));
         let mut declared = None;
         let (frame, emitted) = build_hd_frame_with_extensions(
             &hd,
-            &mut locked,
+            &mut state,
             &DtsFoldConfig::default(),
             48_000,
             &mut declared,
@@ -847,51 +869,79 @@ mod tests {
         .expect("valid D3 frame");
 
         assert!(emitted);
-        assert!(!locked);
-        assert_eq!(frame.channel_count, 11);
+        assert_eq!(state.locked, Some(XPresentation::ObjectsD3));
+        assert_eq!(frame.channel_count, 3 + 8);
         assert_eq!(
-            &frame.channel_labels[..3],
-            &[RChannelLabel::C, RChannelLabel::L, RChannelLabel::R]
-        );
-        assert!(
-            frame.channel_labels[3..]
-                .iter()
-                .all(|&label| label == RChannelLabel::Object)
+            frame.channel_labels.as_slice(),
+            &[
+                RChannelLabel::C,
+                RChannelLabel::L,
+                RChannelLabel::Lb,
+                RChannelLabel::Tfl,
+                RChannelLabel::Tfr,
+                RChannelLabel::Tbl,
+                RChannelLabel::Tbr,
+                RChannelLabel::Object,
+                RChannelLabel::Object,
+                RChannelLabel::Object,
+                RChannelLabel::Object,
+            ]
         );
         for sample in 0..SAMPLE_COUNT {
             let row = &frame.pcm[sample * 11..(sample + 1) * 11];
-            for bed in 0..3 {
-                assert_pcm_close(row[bed], hd.samples[bed].as_ref().unwrap()[sample]);
-            }
-            for source in 0..8 {
-                assert_pcm_close(row[3 + source], hd.x_samples[source][sample]);
+            assert_pcm_close(row[0], 0.30 * if sample == 0 { 1.0 } else { -1.0 });
+            assert_pcm_close(row[1], dry_l[sample]);
+            assert_pcm_close(row[2], dry_lb[sample]);
+            for (slot, feed) in (4..8).chain(0..4).enumerate() {
+                assert_pcm_close(row[3 + slot], hd.x_samples[feed][sample]);
             }
         }
 
         assert_eq!(frame.metadata.len(), 1);
         let metadata = &frame.metadata[0];
         assert_eq!(metadata.sample_pos, 48_000);
-        assert_eq!(metadata.events.len(), 8);
-        assert_eq!(metadata.object_channels.len(), 8);
-        assert_eq!(metadata.name_updates.len(), 8);
-        for source in 0..8 {
-            assert_eq!(metadata.object_channels[source].id, (10 + source) as u32);
+        assert_eq!(metadata.events.len(), 4);
+        assert_eq!(metadata.object_channels.len(), 4);
+        assert_eq!(metadata.name_updates.len(), 4);
+        for feed in 0..4 {
+            assert_eq!(metadata.object_channels[feed].id, 10 + feed as u32);
+            assert_eq!(metadata.object_channels[feed].channel, (7 + feed) as u32);
             assert_eq!(
-                metadata.object_channels[source].channel,
-                (3 + source) as u32
+                metadata.name_updates[feed].name.as_str(),
+                format!("X{feed}")
             );
-            assert_eq!(metadata.name_updates[source].id, (10 + source) as u32);
-            assert_eq!(
-                metadata.name_updates[source].name.as_str(),
-                format!("X{source}")
-            );
-            assert_eq!(metadata.events[source].id, (10 + source) as u32);
-            assert_eq!(metadata.events[source].pos, d3_object_position(source));
+            let event = &metadata.events[feed];
+            assert_eq!(event.id, 10 + feed as u32);
+            assert!(event.has_pos);
+            let SourceRole::Object { position, .. } = sources[feed].role else {
+                panic!()
+            };
+            assert_eq!(event.pos, position.to_adm_cartesian());
         }
+        // Rear-left object: negative x, negative y, raised.
+        assert!(metadata.events[0].pos[0] < 0.0 && metadata.events[0].pos[1] < 0.0);
+        assert!(metadata.events[0].pos[2] > 0.0);
+
+        // Same positions again: the declaration is cached and no event is due
+        // between heartbeats.
+        let (again, _) = build_hd_frame_with_extensions(
+            &hd,
+            &mut state,
+            &DtsFoldConfig::default(),
+            48_000 + 512,
+            &mut declared,
+        )
+        .expect("valid D3 frame");
+        assert!(again.metadata.is_empty());
     }
 
     #[test]
-    fn d0_emits_fixed_7_1_5_with_partial_unfold() {
+    fn d0_presents_its_object_as_a_fixed_channel_and_unfolds_it() {
+        let extension: Vec<Vec<f32>> = (0..5)
+            .map(|index| vec![0.01 * (index + 1) as f32, -0.01 * (index + 1) as f32])
+            .collect();
+        let code58 = gain_code_linear(58).unwrap();
+        let code46 = gain_code_linear(46).unwrap();
         let dry = [
             vec![0.10, -0.10],
             vec![0.20, -0.20],
@@ -899,72 +949,43 @@ mod tests {
             vec![0.40, -0.40],
             vec![0.50, -0.50],
         ];
-        let extension: Vec<Vec<f32>> = (0..5)
-            .map(|index| vec![0.01 * (index + 1) as f32; SAMPLE_COUNT])
-            .collect();
-        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
-        samples[0] = Some(
-            dry[0]
-                .iter()
-                .zip(&extension[0])
-                .map(|(&bed, &top)| bed + top * D0_TFC_CENTER_DOWNMIX_GAIN)
-                .collect(),
-        );
-        samples[1] = Some(
-            dry[1]
-                .iter()
-                .zip(&extension[1])
-                .map(|(&bed, &top)| bed + top * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN)
-                .collect(),
-        );
-        samples[2] = Some(
-            dry[2]
-                .iter()
-                .zip(&extension[2])
-                .map(|(&bed, &top)| bed + top * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN)
-                .collect(),
-        );
-        samples[3] = Some(vec![0.60, -0.60]);
-        samples[4] = Some(vec![0.70, -0.70]);
-        samples[5] = Some(vec![0.80, -0.80]);
-        samples[7] = Some(
-            dry[3]
-                .iter()
-                .zip(&extension[3])
-                .map(|(&bed, &top)| bed + top * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN)
-                .collect(),
-        );
-        samples[8] = Some(
-            dry[4]
-                .iter()
-                .zip(&extension[4])
-                .map(|(&bed, &top)| bed + top * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN)
-                .collect(),
-        );
+        let mut samples = full_bed();
+        samples[0] = Some(folded(&dry[0], &[(&extension[0], code58)]));
+        samples[1] = Some(folded(
+            &dry[1],
+            &[(&extension[0], code46), (&extension[1], 1.0)],
+        ));
+        samples[2] = Some(folded(
+            &dry[2],
+            &[(&extension[0], code46), (&extension[2], 1.0)],
+        ));
+        samples[7] = Some(folded(&dry[3], &[(&extension[3], 1.0)]));
+        samples[8] = Some(folded(&dry[4], &[(&extension[4], 1.0)]));
         let mut hd = hd_frame(samples, extension);
         hd.x_present = false;
         hd.x_imax = true;
 
-        let mut locked = false;
-        let mut declared = None;
-        let (frame, emitted) = build_hd_frame_with_extensions(
-            &hd,
-            &mut locked,
-            &DtsFoldConfig::default(),
-            100,
-            &mut declared,
-        )
-        .expect("valid D0 frame");
+        let mut columns = [0.0; 8];
+        columns[0] = code58;
+        columns[1] = code46;
+        columns[2] = code46;
+        let mut sources = vec![SourceMetadata {
+            role: SourceRole::Object {
+                position: SphericalPosition {
+                    azimuth_half_degrees: 0,
+                    elevation_half_degrees: 51,
+                    distance_64ths: 64,
+                },
+                centre_height_alternative: true,
+            },
+            fold: BedFold::Known(columns),
+        }];
+        sources.extend(heights(1.0));
+        let mut state = state_with(XMetadata::from_sources(&sources));
+        let (frame, emitted) = build(&hd, &mut state);
 
-        assert!(
-            !emitted,
-            "fixed channels must not set the object stream fact"
-        );
-        assert!(
-            !locked,
-            "alternate fixed channels must not latch standard heights"
-        );
-        assert!(declared.is_none());
+        assert!(!emitted, "the D0 object is presented as a fixed channel");
+        assert_eq!(state.locked, Some(XPresentation::FixedD0));
         assert!(frame.metadata.is_empty());
         assert_eq!(frame.channel_count, 13);
         assert_eq!(
@@ -991,8 +1012,6 @@ mod tests {
                 assert_pcm_close(row[channel], dry[channel][sample]);
             }
             assert_pcm_close(row[3], hd.samples[3].as_ref().unwrap()[sample]);
-            assert_pcm_close(row[4], hd.samples[4].as_ref().unwrap()[sample]);
-            assert_pcm_close(row[5], hd.samples[5].as_ref().unwrap()[sample]);
             assert_pcm_close(row[6], dry[3][sample]);
             assert_pcm_close(row[7], dry[4][sample]);
             for source in 0..5 {
@@ -1002,103 +1021,87 @@ mod tests {
     }
 
     #[test]
-    fn d1_emits_fixed_wides_and_partial_unfold() {
-        let left_wide = vec![0.20, -0.10];
-        let right_wide = vec![-0.15, 0.25];
-        let dry_l = vec![0.03, -0.04];
-        let dry_r = vec![-0.05, 0.06];
-        let dry_ls = vec![0.07, -0.08];
-        let dry_rs = vec![-0.09, 0.10];
-        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
-        samples[0] = Some(vec![0.0; SAMPLE_COUNT]);
-        samples[1] = Some(
-            dry_l
-                .iter()
-                .zip(&left_wide)
-                .map(|(&dry, &wide)| dry + wide * 0.707107)
-                .collect(),
-        );
-        samples[2] = Some(
-            dry_r
-                .iter()
-                .zip(&right_wide)
-                .map(|(&dry, &wide)| dry + wide * 0.707107)
-                .collect(),
-        );
-        samples[3] = Some(
-            dry_ls
-                .iter()
-                .zip(&left_wide)
-                .map(|(&dry, &wide)| dry + wide * 0.707107)
-                .collect(),
-        );
-        samples[4] = Some(
-            dry_rs
-                .iter()
-                .zip(&right_wide)
-                .map(|(&dry, &wide)| dry + wide * 0.707107)
-                .collect(),
-        );
-        let extension = vec![
-            vec![0.01; SAMPLE_COUNT],
-            vec![0.02; SAMPLE_COUNT],
-            left_wide.clone(),
-            right_wide.clone(),
-            vec![0.05; SAMPLE_COUNT],
-            vec![0.06; SAMPLE_COUNT],
-        ];
+    fn d1_objects_without_a_stated_fold_stay_in_the_bed_and_are_muted() {
+        let extension: Vec<Vec<f32>> = (0..6)
+            .map(|index| vec![0.01 * (index + 1) as f32, -0.01 * (index + 1) as f32])
+            .collect();
+        let dry_l = vec![0.20, -0.20];
+        let mut samples = full_bed();
+        // L holds the mode-0 object at an unstated gain plus TFL (feed 2).
+        samples[1] = Some(folded(
+            &dry_l,
+            &[(&extension[0], 0.9152), (&extension[2], Q55)],
+        ));
         let mut hd = hd_frame(samples, extension);
         hd.x_present = false;
         hd.x_imax = true;
 
-        let mut locked = false;
-        let mut declared = None;
-        let (frame, emitted) = build_hd_frame_with_extensions(
-            &hd,
-            &mut locked,
-            &DtsFoldConfig::default(),
-            100,
-            &mut declared,
-        )
-        .expect("valid D1 frame");
+        let mut sources = vec![
+            object(-69, 24, BedFold::Unknown),
+            object(69, 24, BedFold::Unknown),
+        ];
+        sources.extend(heights(Q55));
+        let mut state = state_with(XMetadata::from_sources(&sources));
+        let (frame, emitted) = build(&hd, &mut state);
 
-        assert!(!emitted, "D1 sources are fixed channels");
-        assert_eq!(frame.channel_count, 11);
+        assert!(emitted, "D1 declares object channels");
+        assert_eq!(state.locked, Some(XPresentation::ObjectsD1));
+        assert_eq!(frame.channel_count, 8 + 6);
         assert_eq!(
-            frame.channel_labels.as_slice(),
+            &frame.channel_labels[8..],
             &[
-                RChannelLabel::C,
-                RChannelLabel::L,
-                RChannelLabel::R,
-                RChannelLabel::Ls,
-                RChannelLabel::Rs,
                 RChannelLabel::Tfl,
                 RChannelLabel::Tfr,
-                RChannelLabel::Lw,
-                RChannelLabel::Rw,
                 RChannelLabel::Tbl,
                 RChannelLabel::Tbr,
+                RChannelLabel::Object,
+                RChannelLabel::Object,
             ]
         );
         for sample in 0..SAMPLE_COUNT {
-            let row = &frame.pcm[sample * 11..(sample + 1) * 11];
-            assert_pcm_close(
-                row[1],
-                dry_l[sample]
-                    - hd.x_samples[0][sample] * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN,
-            );
-            assert_pcm_close(
-                row[2],
-                dry_r[sample]
-                    - hd.x_samples[1][sample] * ALTERNATE_CORNER_HEIGHT_PARTIAL_UNFOLD_GAIN,
-            );
-            assert_pcm_close(row[3], dry_ls[sample]);
-            assert_pcm_close(row[4], dry_rs[sample]);
-            for (slot, source) in (0usize..6).enumerate() {
-                assert_pcm_close(row[5 + slot], hd.x_samples[source][sample]);
+            let row = &frame.pcm[sample * 14..(sample + 1) * 14];
+            // Only the height leaves L; the object's share stays.
+            assert_pcm_close(row[1], dry_l[sample] + hd.x_samples[0][sample] * 0.9152);
+            for (slot, feed) in (2..6).enumerate() {
+                assert_pcm_close(row[8 + slot], hd.x_samples[feed][sample]);
             }
+            assert_eq!(row[12], 0, "an unfoldable object must not play twice");
+            assert_eq!(row[13], 0);
         }
-        assert!(frame.metadata.is_empty());
+        assert_eq!(frame.metadata.len(), 1);
+        assert_eq!(
+            frame.metadata[0].events.len(),
+            2,
+            "positions are still announced"
+        );
+        assert_eq!(frame.metadata[0].object_channels.len(), 2);
+    }
+
+    #[test]
+    fn alternate_frame_without_any_readable_metadata_mutes_its_feeds() {
+        let extension: Vec<Vec<f32>> = (0..8).map(|_| vec![0.1; SAMPLE_COUNT]).collect();
+        let composite_left = vec![0.25, -0.25];
+        let mut samples = full_bed();
+        samples[1] = Some(composite_left.clone());
+        let mut hd = hd_frame(samples, extension);
+        hd.x_present = false;
+        hd.x_imax = true;
+
+        let mut state = DtsXState::default();
+        let (frame, emitted) = build(&hd, &mut state);
+        assert!(emitted);
+        assert_eq!(frame.channel_count, 16);
+        assert_eq!(state.parse_failures, 1);
+        for sample in 0..SAMPLE_COUNT {
+            let row = &frame.pcm[sample * 16..(sample + 1) * 16];
+            assert_eq!(row[1], float_to_pcm_i32(composite_left[sample]));
+            assert!(row[8..16].iter().all(|&s| s == 0));
+        }
+        assert_eq!(frame.metadata.len(), 1, "channels are still declared");
+        assert!(
+            frame.metadata[0].events.is_empty(),
+            "no positions to announce"
+        );
     }
 
     #[test]
@@ -1107,8 +1110,17 @@ mod tests {
         samples[0] = Some(vec![0.0; SAMPLE_COUNT]);
         samples[1] = Some(vec![0.0; SAMPLE_COUNT + 1]); // corrupt length
         let hd = hd_frame(samples, Vec::new());
-
-        let mut locked = false;
-        assert!(build_hd_frame(&hd, &mut locked).is_none());
+        let mut state = DtsXState::default();
+        let mut declared = None;
+        assert!(
+            build_hd_frame_with_extensions(
+                &hd,
+                &mut state,
+                &DtsFoldConfig::default(),
+                0,
+                &mut declared
+            )
+            .is_none()
+        );
     }
 }

--- a/bridge/src/dts_pipeline.rs
+++ b/bridge/src/dts_pipeline.rs
@@ -503,28 +503,39 @@ fn build_object_metadata(
     let heartbeat_period = u64::from(sample_rate) / HEARTBEAT_HZ;
     let heartbeat_due = heartbeat_period > 0 && sample_pos % heartbeat_period < sample_count as u64;
 
+    // The engine broadcasts the objects present in each metadata frame and
+    // clears the others as stale, so a frame must carry every object or none:
+    // emitting only the objects that moved makes the static ones flicker in
+    // monitoring clients.
+    let positions: Vec<(usize, SphericalPosition)> = object_feeds
+        .clone()
+        .filter_map(|feed| {
+            match metadata
+                .and_then(|metadata| metadata.source(feed))
+                .map(|source| source.role)
+            {
+                Some(SourceRole::Object { position, .. }) => Some((feed, position)),
+                _ => None,
+            }
+        })
+        .collect();
+    let moved = positions
+        .iter()
+        .any(|&(feed, position)| state.emitted_positions[feed] != Some(position));
     let mut events: RVec<REvent> = RVec::new();
-    for feed in object_feeds.clone() {
-        let Some(SourceRole::Object { position, .. }) = metadata
-            .and_then(|metadata| metadata.source(feed))
-            .map(|source| source.role)
-        else {
-            continue;
-        };
-        let slot = &mut state.emitted_positions[feed];
-        if *slot == Some(position) && declaration_unchanged && !heartbeat_due {
-            continue;
+    if moved || !declaration_unchanged || heartbeat_due {
+        for &(feed, position) in &positions {
+            state.emitted_positions[feed] = Some(position);
+            events.push(REvent {
+                id: OBJECT_ID_BASE + feed as u32,
+                sample_pos,
+                has_pos: true,
+                pos: position.to_adm_cartesian(),
+                gain_db: 0,
+                size: [0.0; 3],
+                ramp_duration: 0,
+            });
         }
-        *slot = Some(position);
-        events.push(REvent {
-            id: OBJECT_ID_BASE + feed as u32,
-            sample_pos,
-            has_pos: true,
-            pos: position.to_adm_cartesian(),
-            gain_db: 0,
-            size: [0.0; 3],
-            ramp_duration: 0,
-        });
     }
     if declaration_unchanged && events.is_empty() {
         return RVec::new();
@@ -921,6 +932,33 @@ mod tests {
         // Rear-left object: negative x, negative y, raised.
         assert!(metadata.events[0].pos[0] < 0.0 && metadata.events[0].pos[1] < 0.0);
         assert!(metadata.events[0].pos[2] > 0.0);
+
+        // One object moves: every object is announced again, so the engine's
+        // per-frame object list keeps its size and nothing flickers.
+        let mut moved = sources;
+        moved[2] = object(-280, 20, BedFold::Known([0.0; 8]));
+        state.last_metadata = XMetadata::from_sources(&moved);
+        let mut moved_hd = hd_frame(hd.samples.clone(), hd.x_samples.clone());
+        moved_hd.x_present = false;
+        moved_hd.x_imax = true;
+        let (frame_moved, _) = build_hd_frame_with_extensions(
+            &moved_hd,
+            &mut state,
+            &DtsFoldConfig::default(),
+            48_000 + 1024,
+            &mut declared,
+        )
+        .expect("valid D3 frame");
+        assert_eq!(frame_moved.metadata.len(), 1);
+        assert_eq!(
+            frame_moved.metadata[0].events.len(),
+            4,
+            "all objects, not only the mover"
+        );
+        assert!(
+            frame_moved.metadata[0].object_channels.is_empty(),
+            "declaration unchanged"
+        );
 
         // Same positions again: the declaration is cached and no event is due
         // between heartbeats.

--- a/dca/examples/xmeta_survey.rs
+++ b/dca/examples/xmeta_survey.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Per-frame survey of the private DTS:X metadata as the library reads it:
+// parse result per frame, and every change of object position or fold.
+// Research tool only; it is not used by the realtime decoder.
+//
+// cargo run -p dca --release --example xmeta_survey -- [--max-mb 64] input.dts
+
+use std::collections::BTreeMap;
+use std::io::{BufReader, Read};
+
+use dca::{
+    BedFold, HdDecoder, HdError, SourceRole, XMetadata, XPresentation, exss_substream_size,
+    parse_header,
+};
+
+fn describe(metadata: &XMetadata) -> String {
+    metadata
+        .sources()
+        .enumerate()
+        .map(|(feed, source)| {
+            let fold = match source.fold {
+                BedFold::Known(columns) => columns
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, gain)| **gain != 0.0)
+                    .map(|(column, gain)| format!("{column}:{:.3}", *gain))
+                    .collect::<Vec<_>>()
+                    .join(","),
+                BedFold::Unknown => "unknown".to_string(),
+            };
+            match source.role {
+                SourceRole::Height(channel) => format!("X{feed}={channel:?}[{fold}]"),
+                SourceRole::Object {
+                    position,
+                    centre_height_alternative,
+                } => format!(
+                    "X{feed}=obj({:.1},{:.1},{:.2}){}[{fold}]",
+                    position.azimuth_degrees(),
+                    position.elevation_degrees(),
+                    position.distance(),
+                    if centre_height_alternative { "+Ch" } else { "" }
+                ),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn run() -> Result<(), String> {
+    let mut args = std::env::args().skip(1);
+    let mut limit = 64usize * 1024 * 1024;
+    let mut path = None;
+    while let Some(arg) = args.next() {
+        if arg == "--max-mb" {
+            limit = args
+                .next()
+                .ok_or("missing --max-mb")?
+                .parse::<usize>()
+                .map_err(|_| "invalid --max-mb")?
+                .saturating_mul(1024 * 1024);
+        } else {
+            path = Some(arg);
+        }
+    }
+    let path = path.ok_or("usage: xmeta_survey [--max-mb 64] input.dts")?;
+    let mut reader = BufReader::new(std::fs::File::open(&path).map_err(|e| e.to_string())?);
+    let mut bytes = Vec::new();
+    reader
+        .by_ref()
+        .take(limit as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|e| e.to_string())?;
+
+    let mut decoder = HdDecoder::new();
+    let mut offset = 0;
+    let mut frames = 0usize;
+    let mut sample_offset = 0u64;
+    let mut ok = 0usize;
+    let mut errors = BTreeMap::<String, usize>::new();
+    let mut last = None::<String>;
+    let mut changes = 0usize;
+    while offset + 18 <= bytes.len() {
+        let info = parse_header(&bytes[offset..]).map_err(|e| format!("core header: {e:?}"))?;
+        let core_end = offset + info.frame_size;
+        if core_end + 16 > bytes.len() {
+            break;
+        }
+        let Some(exss_size) = exss_substream_size(&bytes[core_end..]) else {
+            break;
+        };
+        let exss_end = core_end + exss_size;
+        if exss_end > bytes.len() {
+            break;
+        }
+        match decoder.decode(&bytes[offset..core_end], &bytes[core_end..exss_end]) {
+            Ok(frame) => {
+                frames += 1;
+                let presentation = XPresentation::detect(&frame);
+                let description = match presentation {
+                    Some(presentation) => {
+                        match XMetadata::parse(&frame.x_payload, presentation.feed_count()) {
+                            Ok(metadata) => {
+                                ok += 1;
+                                describe(&metadata)
+                            }
+                            Err(error) => {
+                                let kind = format!("{error:?}");
+                                *errors.entry(kind.clone()).or_default() += 1;
+                                format!("ERROR {kind}")
+                            }
+                        }
+                    }
+                    None => "no presentation".to_string(),
+                };
+                if last.as_deref() != Some(&description) {
+                    changes += 1;
+                    println!(
+                        "frame={} sample={} t={:.2}s {description}",
+                        frames - 1,
+                        sample_offset,
+                        sample_offset as f64 / f64::from(frame.sample_rate.max(1))
+                    );
+                    last = Some(description);
+                }
+                sample_offset += frame.bed_sample_count() as u64;
+            }
+            Err(HdError::Pending) => {}
+            Err(error) => return Err(format!("decode error at byte {offset}: {error:?}")),
+        }
+        offset = exss_end;
+    }
+    println!("frames={frames} parsed_ok={ok} changes={changes} errors={errors:?} bytes={offset}");
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("xmeta survey: {error}");
+        std::process::exit(1);
+    }
+}

--- a/dca/src/dcadec/mod.rs
+++ b/dca/src/dcadec/mod.rs
@@ -9,3 +9,4 @@ pub(crate) mod huffman;
 pub(crate) mod synth;
 pub(crate) mod tables;
 pub(crate) mod xll;
+pub(crate) mod xmeta;

--- a/dca/src/dcadec/xll.rs
+++ b/dca/src/dcadec/xll.rs
@@ -19,15 +19,15 @@ const DCA_XLL_CHANNELS_MAX: usize = 8;
 const DCA_XLL_CHSETS_MAX: usize = 3;
 const DCA_XLL_PRED_ORDER_MAX: usize = 16;
 /// XLL-X (DTS:X spatial extension) end-of-frame syncword.
-const DCA_SYNCWORD_XLL_X: u32 = 0x0200_0850;
-const DCA_SYNCWORD_XLL_X_ALT_D0: u32 = 0xF140_00D0;
-const DCA_SYNCWORD_XLL_X_ALT_D1: u32 = 0xF140_00D1;
-const DCA_SYNCWORD_XLL_X_ALT_D3: u32 = 0xF140_00D3;
+pub(crate) const DCA_SYNCWORD_XLL_X: u32 = 0x0200_0850;
+pub(crate) const DCA_SYNCWORD_XLL_X_ALT_D0: u32 = 0xF140_00D0;
+pub(crate) const DCA_SYNCWORD_XLL_X_ALT_D1: u32 = 0xF140_00D1;
+pub(crate) const DCA_SYNCWORD_XLL_X_ALT_D3: u32 = 0xF140_00D3;
 const DCA_SYNCWORD_XLL: u32 = 0x41A2_9547;
 const XLL_X_ALT_FRAME_SAMPLES: usize = 512;
 const XLL_X_ALT_MAX_SEGMENTS: usize = 8;
 const XLL_X_ALT_MAX_INTERSTITIAL: usize = 20;
-const XLL_X_ALT_OUTER_SUFFIX: [u8; 6] = [0x03, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+pub(crate) const XLL_X_ALT_OUTER_SUFFIX: [u8; 6] = [0x03, 0x34, 0x38, 0x8c, 0x4f, 0x00];
 const XLL_X_ALT_INNER_SUFFIX: [u8; 6] = [0x02, 0x34, 0x38, 0x8c, 0x4f, 0x00];
 const FF_DCA_DMIXTABLE_OFFSET: usize = 242 - 201; // SIZE - INV_SIZE
 const FF_DCA_DMIXTABLE_SIZE: usize = 242;
@@ -94,7 +94,7 @@ fn seek(gb: &mut BitReader, pos: usize) -> R<()> {
     }
 }
 
-fn crc16_ccitt(data: &[u8]) -> u16 {
+pub(crate) fn crc16_ccitt(data: &[u8]) -> u16 {
     let mut crc = 0xffffu16;
     for &byte in data {
         crc ^= (byte as u16) << 8;

--- a/dca/src/dcadec/xmeta.rs
+++ b/dca/src/dcadec/xmeta.rs
@@ -1,0 +1,1312 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Private DTS:X extension metadata: what the wrapper around the XLL-X channel
+//! sets says about the extension waveforms.
+//!
+//! Two facts matter for playback and both come from the same bytes:
+//!
+//! - **How each waveform was mixed into the compatible bed.** The encoder
+//!   folded every height feed and every object into the 7.1 bed it also
+//!   transmits, at gains it writes down here. Rendering a feed at its own
+//!   position without first removing that contribution plays it twice. The
+//!   standard profile states the fold in its type-2 matrix; the alternate
+//!   profiles state the height fold in their type-3 rows and each object's
+//!   fold in the sparse reference rows attached to its position record.
+//! - **Where the objects sit.** Alternate-profile records carry a spherical
+//!   position per object.
+//!
+//! Which waveform each row describes was established against the corpus
+//! audio, not from the bytes alone: the last four extension waveforms of an
+//! alternate profile are the fixed heights, in type-3 row order, and object
+//! record `index` is the extension waveform of the same index. See
+//! `docs/private-metadata-probe.md` in the repository for the evidence.
+//!
+//! This module is realtime code: it reads a bounded prefix with a checked bit
+//! reader, allocates nothing, and reports every unfamiliar form as an error
+//! instead of guessing. A frame whose metadata does not parse simply has no
+//! usable fold, which the consumer must treat as "keep the bed as authored".
+
+use crate::dcadec::tables::DMIXTABLE;
+use crate::dcadec::xll::{
+    DCA_SYNCWORD_XLL_X, DCA_SYNCWORD_XLL_X_ALT_D0, DCA_SYNCWORD_XLL_X_ALT_D1,
+    DCA_SYNCWORD_XLL_X_ALT_D3, XLL_X_ALT_OUTER_SUFFIX, crc16_ccitt,
+};
+use crate::spatial::SpatialChannel;
+
+/// Most extension waveforms any known profile carries (four objects plus the
+/// four fixed heights).
+pub const MAX_SOURCES: usize = 8;
+/// Channels of the compatible reference layout the folds are expressed over.
+pub const REFERENCE_CHANNELS: usize = 8;
+/// DCA speaker index behind each reference-layout column. The reference mask
+/// `0x084b` lists, in bit order, C, L/R, LFE, Lsr/Rsr and Lss/Rss.
+pub const REFERENCE_SPEAKERS: [usize; REFERENCE_CHANNELS] = [0, 1, 2, 5, 7, 8, 3, 4];
+/// DCA speaker indices a [`FoldPlan`] can address.
+pub const FOLD_SPEAKERS: usize = 16;
+
+const REFERENCE_MASK: u32 = 0x084b;
+const FULL_MASK: u32 = 0x886b;
+const HEIGHT_MASK: u32 = 0x8020;
+const FULL_COLUMNS: usize = 12;
+/// Reference column of each column of the full 12-channel layout (`0x886b`:
+/// C, L, R, LFE, Lh, Rh, Lsr, Rsr, Lss, Rss, Lhr, Rhr), `None` for a height.
+const FULL_TO_REFERENCE: [Option<usize>; FULL_COLUMNS] = [
+    Some(0),
+    Some(1),
+    Some(2),
+    Some(3),
+    None,
+    None,
+    Some(4),
+    Some(5),
+    Some(6),
+    Some(7),
+    None,
+    None,
+];
+/// Height speaker of each height column of the full layout.
+const FULL_TO_HEIGHT: [Option<SpatialChannel>; FULL_COLUMNS] = [
+    None,
+    None,
+    None,
+    None,
+    Some(SpatialChannel::TopFrontLeft),
+    Some(SpatialChannel::TopFrontRight),
+    None,
+    None,
+    None,
+    None,
+    Some(SpatialChannel::TopBackLeft),
+    Some(SpatialChannel::TopBackRight),
+];
+/// The standard profile's height mask `0x8020` lists Lh/Rh then Lhr/Rhr.
+const STANDARD_HEIGHTS: [SpatialChannel; 4] = [
+    SpatialChannel::TopFrontLeft,
+    SpatialChannel::TopFrontRight,
+    SpatialChannel::TopBackLeft,
+    SpatialChannel::TopBackRight,
+];
+const FIXED_HEIGHT_COUNT: usize = 4;
+/// Unread type-3 control word; every corpus stream carries this value.
+const TYPE3_CONTROL: u32 = 0x3fa;
+const MAX_PREFIX: usize = 96;
+const UNITY_CODE: u32 = 61;
+const CENTRE_HEIGHT_MASK: u32 = 0x80;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum XMetadataError {
+    /// The payload ends before the metadata does.
+    Truncated,
+    /// A form this reader has no verified interpretation for.
+    Unsupported(&'static str),
+    /// A CRC, boundary or padding check failed.
+    Invalid(&'static str),
+}
+
+type R<T> = Result<T, XMetadataError>;
+
+struct Bits<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl Bits<'_> {
+    fn read(&mut self, width: usize) -> R<u32> {
+        let end = self
+            .pos
+            .checked_add(width)
+            .ok_or(XMetadataError::Truncated)?;
+        if width > 32 || end > self.bytes.len().saturating_mul(8) {
+            return Err(XMetadataError::Truncated);
+        }
+        let mut value = 0u32;
+        for bit in self.pos..end {
+            value = (value << 1) | u32::from((self.bytes[bit / 8] >> (7 - bit % 8)) & 1);
+        }
+        self.pos = end;
+        Ok(value)
+    }
+
+    fn expect(&mut self, width: usize, expected: u32, field: &'static str) -> R<()> {
+        if self.read(width)? != expected {
+            return Err(XMetadataError::Unsupported(field));
+        }
+        Ok(())
+    }
+
+    fn align(&mut self, field: &'static str) -> R<()> {
+        let padding = (8 - self.pos % 8) % 8;
+        if self.read(padding)? != 0 {
+            return Err(XMetadataError::Invalid(field));
+        }
+        Ok(())
+    }
+}
+
+/// Linear gain of a six-bit gain code.
+///
+/// Every code verified against the corpus audio is the decoder's downmix
+/// table entry at index `4 * code - 3`, i.e. half a decibel per code with 61
+/// as unity (61 → 32768, 55 → 23170, 58 → 27571, 46 → 13818). Code 0 and the
+/// escape codes 62/63 have no verified meaning and are rejected.
+pub fn gain_code_linear(code: u32) -> Option<f32> {
+    match code {
+        1..=UNITY_CODE => Some(f32::from(DMIXTABLE[4 * code as usize - 3]) / 32768.0),
+        _ => None,
+    }
+}
+
+/// A transmitted object position in the stream's own units.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SphericalPosition {
+    /// 0 = front, negative = left, in half-degrees.
+    pub azimuth_half_degrees: i16,
+    /// Positive = up, in half-degrees.
+    pub elevation_half_degrees: i16,
+    /// Distance in 1/64 units; 64 is the reference distance.
+    pub distance_64ths: u8,
+}
+
+impl SphericalPosition {
+    fn from_codes(azimuth: u32, elevation: u32, distance: u32) -> Self {
+        let azimuth_half_degrees = match azimuth {
+            47 => -220,
+            193 => 220,
+            value => (3 * value as i16 - 360).min(357),
+        };
+        let elevation_half_degrees = (3 * (elevation as i16 - 60)).min(180);
+        let distance_64ths = if distance == 0 { 0 } else { distance as u8 + 1 };
+        Self {
+            azimuth_half_degrees,
+            elevation_half_degrees,
+            distance_64ths,
+        }
+    }
+
+    pub fn azimuth_degrees(self) -> f64 {
+        f64::from(self.azimuth_half_degrees) / 2.0
+    }
+
+    pub fn elevation_degrees(self) -> f64 {
+        f64::from(self.elevation_half_degrees) / 2.0
+    }
+
+    pub fn distance(self) -> f64 {
+        f64::from(self.distance_64ths) / 64.0
+    }
+
+    /// ADM Cartesian `[x, y, z]`: x left-to-right, y back-to-front, z
+    /// floor-to-ceiling, the same spherical conversion the renderer applies
+    /// to polar events.
+    pub fn to_adm_cartesian(self) -> [f64; 3] {
+        let azimuth = self.azimuth_degrees().to_radians();
+        let elevation = self.elevation_degrees().to_radians();
+        let distance = self.distance();
+        let horizontal = distance * elevation.cos();
+        [
+            horizontal * azimuth.sin(),
+            horizontal * azimuth.cos(),
+            distance * elevation.sin(),
+        ]
+    }
+}
+
+/// How one extension waveform was mixed into the compatible bed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BedFold {
+    /// Linear gain of the waveform in each reference column; 0.0 is absent.
+    Known([f32; REFERENCE_CHANNELS]),
+    /// The waveform is in the bed, but the stream does not say at which
+    /// gains (an object record without reference rows). Nothing can be
+    /// subtracted, so the waveform must not be rendered a second time.
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SourceRole {
+    /// A fixed height feed.
+    Height(SpatialChannel),
+    /// An object at a transmitted position.
+    Object {
+        position: SphericalPosition,
+        /// The record also declares the centre-height speaker as a
+        /// fixed-channel alternative for this object.
+        centre_height_alternative: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SourceMetadata {
+    pub role: SourceRole,
+    pub fold: BedFold,
+}
+
+/// One frame's metadata for every extension waveform, in waveform order.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct XMetadata {
+    sources: [Option<SourceMetadata>; MAX_SOURCES],
+    count: usize,
+}
+
+impl XMetadata {
+    /// Parse the metadata of an extension payload that decoded into
+    /// `source_count` waveforms. `payload` is `HdFrame::x_payload`.
+    pub fn parse(payload: &[u8], source_count: usize) -> R<Self> {
+        let syncword = payload
+            .get(..4)
+            .and_then(|bytes| bytes.try_into().ok())
+            .map(u32::from_be_bytes)
+            .ok_or(XMetadataError::Truncated)?;
+        match syncword {
+            DCA_SYNCWORD_XLL_X => parse_standard(payload, source_count),
+            DCA_SYNCWORD_XLL_X_ALT_D0 | DCA_SYNCWORD_XLL_X_ALT_D1 | DCA_SYNCWORD_XLL_X_ALT_D3 => {
+                parse_alternate(payload, source_count)
+            }
+            _ => Err(XMetadataError::Unsupported("extension profile")),
+        }
+    }
+
+    /// Assemble metadata from already-decoded sources (consumers' tests and
+    /// fallbacks). `None` when there are more than [`MAX_SOURCES`].
+    pub fn from_sources(sources: &[SourceMetadata]) -> Option<Self> {
+        if sources.len() > MAX_SOURCES {
+            return None;
+        }
+        let mut stored = [None; MAX_SOURCES];
+        for (slot, source) in stored.iter_mut().zip(sources) {
+            *slot = Some(*source);
+        }
+        Some(Self {
+            sources: stored,
+            count: sources.len(),
+        })
+    }
+
+    pub fn source_count(&self) -> usize {
+        self.count
+    }
+
+    pub fn source(&self, index: usize) -> Option<&SourceMetadata> {
+        self.sources.get(index).and_then(Option::as_ref)
+    }
+
+    pub fn sources(&self) -> impl Iterator<Item = &SourceMetadata> {
+        self.sources[..self.count].iter().flatten()
+    }
+}
+
+/// Per-frame subtraction table: for each DCA speaker, the gain of every
+/// extension waveform already present in that speaker's bed channel. Built
+/// once per frame and applied per sample without branching on profile.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FoldPlan {
+    gains: [[f32; MAX_SOURCES]; FOLD_SPEAKERS],
+    /// Bit `k` set when waveform `k` contributes to that speaker.
+    used: [u8; FOLD_SPEAKERS],
+    /// Bit `k` set when waveform `k` has no known fold.
+    unknown: u8,
+    count: usize,
+}
+
+impl FoldPlan {
+    /// No metadata: nothing can be subtracted and no waveform may be
+    /// rendered, since each is still in the bed at an unknown gain.
+    pub fn all_unknown(source_count: usize) -> Self {
+        let count = source_count.min(MAX_SOURCES);
+        Self {
+            gains: [[0.0; MAX_SOURCES]; FOLD_SPEAKERS],
+            used: [0; FOLD_SPEAKERS],
+            unknown: ((1u16 << count) - 1) as u8,
+            count,
+        }
+    }
+
+    /// The standard profile's fixed-height fold at one gain for all four
+    /// feeds (TFL→L, TFR→R, TBL→Lsr, TBR→Rsr), for a frame whose matrix could
+    /// not be read.
+    pub fn standard_heights(gain: f32) -> Self {
+        let mut plan = Self::all_unknown(0);
+        plan.count = FIXED_HEIGHT_COUNT;
+        for (feed, &speaker) in [1usize, 2, 7, 8].iter().enumerate() {
+            plan.gains[speaker][feed] = gain;
+            plan.used[speaker] |= 1 << feed;
+        }
+        plan
+    }
+
+    pub fn from_metadata(metadata: &XMetadata) -> Self {
+        let mut plan = Self::all_unknown(0);
+        plan.count = metadata.source_count();
+        for (feed, source) in metadata.sources().enumerate() {
+            match source.fold {
+                BedFold::Known(columns) => {
+                    for (column, &gain) in columns.iter().enumerate() {
+                        if gain != 0.0 {
+                            let speaker = REFERENCE_SPEAKERS[column];
+                            plan.gains[speaker][feed] = gain;
+                            plan.used[speaker] |= 1 << feed;
+                        }
+                    }
+                }
+                BedFold::Unknown => plan.unknown |= 1 << feed,
+            }
+        }
+        plan
+    }
+
+    pub fn source_count(&self) -> usize {
+        self.count
+    }
+
+    /// Whether waveform `feed` may be rendered on its own channel.
+    pub fn source_is_known(&self, feed: usize) -> bool {
+        feed < self.count && self.unknown & (1 << feed) == 0
+    }
+
+    /// Whether any subtraction applies to `speaker`.
+    pub fn touches(&self, speaker: usize) -> bool {
+        self.used.get(speaker).is_some_and(|&used| used != 0)
+    }
+
+    /// The bed sample of `speaker` with every known contribution removed.
+    /// `sources` are the extension waveforms; a missing sample contributes
+    /// nothing rather than panicking.
+    #[inline]
+    pub fn clean(&self, speaker: usize, bed: f32, sample: usize, sources: &[Vec<f32>]) -> f32 {
+        let Some(&used) = self.used.get(speaker) else {
+            return bed;
+        };
+        if used == 0 {
+            return bed;
+        }
+        let gains = &self.gains[speaker];
+        let mut value = bed;
+        for (feed, source) in sources.iter().enumerate().take(self.count) {
+            if used & (1 << feed) != 0 {
+                value -= gains[feed] * source.get(sample).copied().unwrap_or(0.0);
+            }
+        }
+        value
+    }
+}
+
+fn parse_standard(payload: &[u8], source_count: usize) -> R<XMetadata> {
+    if source_count != FIXED_HEIGHT_COUNT {
+        return Err(XMetadataError::Unsupported("standard waveform count"));
+    }
+    let mut b = Bits {
+        bytes: payload,
+        pos: 0,
+    };
+    let (reference_mask, output_mask) = layout_header(&mut b, 2)?;
+    if reference_mask != REFERENCE_MASK || output_mask & !reference_mask != HEIGHT_MASK {
+        return Err(XMetadataError::Unsupported("standard matrix layout"));
+    }
+    b.expect(5, 2, "matrix header field")?;
+    b.expect(6, 0, "matrix header value")?;
+    b.expect(1, 1, "matrix mode")?;
+    b.expect(1, 0, "optional matrix parameters")?;
+    b.expect(1, 1, "inline matrix flag")?;
+    b.expect(6, UNITY_CODE, "matrix scale")?;
+    b.expect(1, 0, "additional scales")?;
+    let mut sources = [None; MAX_SOURCES];
+    for (feed, &height) in STANDARD_HEIGHTS.iter().enumerate() {
+        let mask = b.read(REFERENCE_CHANNELS)?;
+        if mask == 0 {
+            return Err(XMetadataError::Unsupported("empty matrix row"));
+        }
+        let columns = sparse_row(&mut b, mask, REFERENCE_CHANNELS)?;
+        sources[feed] = Some(SourceMetadata {
+            role: SourceRole::Height(height),
+            fold: BedFold::Known(columns),
+        });
+    }
+    b.align("matrix padding")?;
+    let protected = b.pos / 8 + 2;
+    let bytes = payload.get(..protected).ok_or(XMetadataError::Truncated)?;
+    if crc16_ccitt(bytes) != 0 {
+        return Err(XMetadataError::Invalid("matrix CRC"));
+    }
+    Ok(XMetadata {
+        sources,
+        count: FIXED_HEIGHT_COUNT,
+    })
+}
+
+/// Read the element header shared by the type-2 and type-3 layout elements.
+/// Every flag without a verified meaning is pinned to its observed value.
+fn layout_header(b: &mut Bits<'_>, kind: u32) -> R<(u32, u32)> {
+    b.expect(8, kind, "element type")?;
+    b.expect(8, 0, "element header byte")?;
+    b.expect(1, 0, "header flag")?;
+    b.expect(4, 1, "header field A")?;
+    b.expect(4, u32::from(kind == 3), "header field B")?;
+    let reference_mask = if b.read(1)? != 0 {
+        b.expect(1, 0, "reference flag")?;
+        b.expect(1, 1, "explicit reference mask")?;
+        b.expect(2, 0, "reference mode")?;
+        b.expect(3, 0, "reference field")?;
+        let width = 4 * (b.read(3)? as usize + 1);
+        b.read(width)?
+    } else {
+        b.expect(1, 0, "implicit reference mask")?;
+        b.expect(4, 0, "implicit reference field")?;
+        REFERENCE_MASK
+    };
+    b.expect(1, 1, "level field present")?;
+    b.expect(6, UNITY_CODE, "level code")?;
+    b.expect(1, 0, "additional level")?;
+    let width = 4 * (b.read(3)? as usize + 1);
+    let output_mask = b.read(width)?;
+    if output_mask & reference_mask != reference_mask {
+        return Err(XMetadataError::Unsupported("non-superset layout"));
+    }
+    Ok((reference_mask, output_mask))
+}
+
+/// Read the gain codes of the set bits of `mask` over `columns` reference
+/// columns into a dense gain row.
+fn sparse_row(b: &mut Bits<'_>, mask: u32, columns: usize) -> R<[f32; REFERENCE_CHANNELS]> {
+    let mut row = [0.0; REFERENCE_CHANNELS];
+    for (column, slot) in row.iter_mut().enumerate().take(columns) {
+        if mask & (1 << column) != 0 {
+            *slot = gain_code_linear(b.read(6)?).ok_or(XMetadataError::Unsupported("gain code"))?;
+        }
+    }
+    Ok(row)
+}
+
+/// Length of the CRC-protected alternate prefix: the bytes before the outer
+/// control suffix whose CRC16 is zero. The same rule locates the audio.
+fn alternate_prefix_len(payload: &[u8]) -> R<usize> {
+    let mut result = None;
+    for end in 4..=payload.len().min(MAX_PREFIX) {
+        if payload.get(end..end + XLL_X_ALT_OUTER_SUFFIX.len()) == Some(&XLL_X_ALT_OUTER_SUFFIX)
+            && crc16_ccitt(&payload[..end]) == 0
+        {
+            if result.is_some() {
+                return Err(XMetadataError::Invalid("ambiguous alternate prefix"));
+            }
+            result = Some(end);
+        }
+    }
+    result.ok_or(XMetadataError::Invalid("alternate prefix CRC"))
+}
+
+fn parse_alternate(payload: &[u8], source_count: usize) -> R<XMetadata> {
+    let object_count = source_count
+        .checked_sub(FIXED_HEIGHT_COUNT)
+        .filter(|&count| (1..=MAX_SOURCES - FIXED_HEIGHT_COUNT).contains(&count))
+        .ok_or(XMetadataError::Unsupported("alternate waveform count"))?;
+    let prefix = &payload[..alternate_prefix_len(payload)?];
+    let mut sources = [None; MAX_SOURCES];
+    // The type-241 element is byte-aligned and self-delimiting; the type-3
+    // element follows it and must end exactly at the envelope CRC.
+    let type3_start = parse_type241(prefix, &mut sources[..object_count])?;
+    let heights = parse_type3(&prefix[type3_start..])?;
+    for (slot, height) in sources[object_count..source_count].iter_mut().zip(heights) {
+        *slot = Some(height);
+    }
+    Ok(XMetadata {
+        sources,
+        count: source_count,
+    })
+}
+
+/// The type-3 element: four rows over the full 12-channel layout, one per
+/// fixed height in the order the second channel set decodes them. A row's
+/// height column names the feed; its reference columns are the feed's fold.
+fn parse_type3(bytes: &[u8]) -> R<[SourceMetadata; FIXED_HEIGHT_COUNT]> {
+    let mut b = Bits { bytes, pos: 0 };
+    let (reference_mask, output_mask) = layout_header(&mut b, 3)?;
+    if reference_mask != REFERENCE_MASK || output_mask != FULL_MASK {
+        return Err(XMetadataError::Unsupported("type-3 layout"));
+    }
+    b.expect(5, 2, "type-3 field")?;
+    b.expect(6, 0, "type-3 value")?;
+    b.expect(1, 1, "type-3 flag")?;
+    b.expect(1, 0, "type-3 option")?;
+    b.expect(12, TYPE3_CONTROL, "type-3 control")?;
+    let mut heights = [SourceMetadata {
+        role: SourceRole::Height(SpatialChannel::TopFrontLeft),
+        fold: BedFold::Unknown,
+    }; FIXED_HEIGHT_COUNT];
+    for height in &mut heights {
+        let mask = b.read(FULL_COLUMNS)?;
+        let mut identity = None;
+        let mut columns = [0.0; REFERENCE_CHANNELS];
+        for column in 0..FULL_COLUMNS {
+            if mask & (1 << column) == 0 {
+                continue;
+            }
+            let code = b.read(6)?;
+            match (FULL_TO_REFERENCE[column], FULL_TO_HEIGHT[column]) {
+                (Some(reference), _) => {
+                    columns[reference] = gain_code_linear(code)
+                        .ok_or(XMetadataError::Unsupported("type-3 gain code"))?;
+                }
+                (None, Some(speaker)) => {
+                    if identity.replace(speaker).is_some() || code != UNITY_CODE {
+                        return Err(XMetadataError::Unsupported("type-3 height column"));
+                    }
+                }
+                (None, None) => return Err(XMetadataError::Unsupported("type-3 column")),
+            }
+        }
+        let speaker = identity.ok_or(XMetadataError::Unsupported("type-3 row without height"))?;
+        *height = SourceMetadata {
+            role: SourceRole::Height(speaker),
+            fold: BedFold::Known(columns),
+        };
+    }
+    b.align("type-3 padding")?;
+    if b.pos / 8 + 2 != bytes.len() {
+        return Err(XMetadataError::Invalid("type-3 end"));
+    }
+    Ok(heights)
+}
+
+/// The type-241 element: object declarations, then one position record per
+/// object with optional reference rows, then optional auxiliary
+/// fixed-channel alternatives. Fills `objects` by declared index and returns
+/// the byte offset at which the next element starts.
+fn parse_type241(bytes: &[u8], objects: &mut [Option<SourceMetadata>]) -> R<usize> {
+    let mut b = Bits { bytes, pos: 0 };
+    for (width, value) in [
+        (8, 241),
+        (8, 0x40),
+        (4, 0),
+        (1, 0),
+        (4, 1),
+        (1, 1),
+        (1, 0),
+        (1, 1),
+    ] {
+        b.expect(width, value, "type-241 header")?;
+    }
+    let count = b.read(4)? as usize + 1;
+    if count != objects.len() {
+        return Err(XMetadataError::Unsupported("type-241 declaration count"));
+    }
+    for (width, value) in [(1, 0), (1, 0), (1, 1), (1, 1), (2, 0), (3, 0)] {
+        b.expect(width, value, "type-241 reference form")?;
+    }
+    let width = 4 * (b.read(3)? as usize + 1);
+    if b.read(width)? != REFERENCE_MASK {
+        return Err(XMetadataError::Unsupported("type-241 reference layout"));
+    }
+    // No optional levels, additional layouts or timing parameters; precision
+    // zero gives three-bit indices and two-bit modes.
+    b.expect(8, 0, "type-241 optional fields")?;
+    let mut indices = [0usize; MAX_SOURCES];
+    let mut modes = [0u32; MAX_SOURCES];
+    for record in 0..count {
+        b.expect(1, 1, "inactive type-241 declaration")?;
+        b.expect(2, 3, "type-241 declaration field")?;
+        let index = b.read(3)? as usize;
+        if index >= count || indices[..record].contains(&index) {
+            return Err(XMetadataError::Unsupported("type-241 declaration index"));
+        }
+        let mode = b.read(2)?;
+        if mode > 1 {
+            return Err(XMetadataError::Unsupported("type-241 declaration mode"));
+        }
+        // One component, component code zero, no optional parameter,
+        // parameter mode zero, one subcomponent.
+        b.expect(10, 0, "type-241 component form")?;
+        indices[record] = index;
+        modes[record] = mode;
+    }
+    for record in 0..count {
+        // Mode 0 carries a four-bit option field and no reference rows; the
+        // field's meaning is not established, only its exact consumption.
+        if modes[record] == 0 {
+            b.expect(4, 1, "mode-0 record options")?;
+        } else {
+            b.expect(3, 0, "type-241 record options")?;
+        }
+        b.expect(7, 0x20, "type-241 position options")?;
+        b.expect(1, 1, "type-241 gain present")?;
+        b.expect(1, 1, "type-241 position flag")?;
+        b.expect(2, 0, "type-241 position mode")?;
+        b.expect(6, UNITY_CODE, "type-241 position gain")?;
+        let distance = b.read(6)?;
+        let azimuth = b.read(8)?;
+        let elevation = b.read(7)?;
+        b.expect(1, 0, "type-241 extent")?;
+        let fold = if modes[record] == 1 {
+            let first = b.read(1)? != 0;
+            let second = b.read(1)? != 0;
+            let columns = if first {
+                let mask = b.read(REFERENCE_CHANNELS)?;
+                sparse_row(&mut b, mask, REFERENCE_CHANNELS)?
+            } else {
+                [0.0; REFERENCE_CHANNELS]
+            };
+            if second {
+                return Err(XMetadataError::Unsupported("type-241 second reference row"));
+            }
+            BedFold::Known(columns)
+        } else {
+            BedFold::Unknown
+        };
+        objects[indices[record]] = Some(SourceMetadata {
+            role: SourceRole::Object {
+                position: SphericalPosition::from_codes(azimuth, elevation, distance),
+                centre_height_alternative: false,
+            },
+            fold,
+        });
+    }
+    if b.read(1)? != 0 {
+        for record in 0..count {
+            if b.read(1)? == 0 {
+                continue;
+            }
+            let entries = b.read(2)? + 1;
+            let width = b.read(5)? as usize;
+            for _ in 0..entries {
+                // Only the observed single-channel form is known: bit 7 of the
+                // speaker mask, the centre-height position, at unity.
+                if b.read(width)? != CENTRE_HEIGHT_MASK {
+                    return Err(XMetadataError::Unsupported("type-241 auxiliary layout"));
+                }
+                b.expect(1, 1, "type-241 auxiliary flag")?;
+                b.expect(1, 1, "type-241 auxiliary route")?;
+                b.expect(6, UNITY_CODE, "type-241 auxiliary gain")?;
+                if let Some(SourceMetadata {
+                    role:
+                        SourceRole::Object {
+                            centre_height_alternative,
+                            ..
+                        },
+                    ..
+                }) = objects[indices[record]].as_mut()
+                {
+                    *centre_height_alternative = true;
+                }
+            }
+        }
+    }
+    b.align("type-241 padding")?;
+    Ok(b.pos / 8)
+}
+
+#[cfg(test)]
+pub(crate) mod fixtures {
+    //! Synthetic payloads built field by field, so tests exercise the reader
+    //! on values the corpus never shows.
+
+    use super::*;
+
+    pub(crate) struct BitWriter {
+        bits: Vec<u8>,
+    }
+
+    impl BitWriter {
+        pub(crate) fn new() -> Self {
+            Self { bits: Vec::new() }
+        }
+
+        pub(crate) fn push(&mut self, value: u32, width: usize) -> &mut Self {
+            for bit in (0..width).rev() {
+                self.bits.push(((value >> bit) & 1) as u8);
+            }
+            self
+        }
+
+        pub(crate) fn align(&mut self) -> &mut Self {
+            while self.bits.len() % 8 != 0 {
+                self.bits.push(0);
+            }
+            self
+        }
+
+        pub(crate) fn bytes(&self) -> Vec<u8> {
+            let mut bytes = vec![0u8; self.bits.len().div_ceil(8)];
+            for (i, bit) in self.bits.iter().enumerate() {
+                bytes[i / 8] |= bit << (7 - i % 8);
+            }
+            bytes
+        }
+    }
+
+    fn crc_appended(mut bytes: Vec<u8>) -> Vec<u8> {
+        let crc = crc16_ccitt(&bytes);
+        bytes.extend_from_slice(&crc.to_be_bytes());
+        bytes
+    }
+
+    fn layout_header_bits(w: &mut BitWriter, kind: u32, output_mask: u32, explicit_mask: bool) {
+        w.push(kind, 8)
+            .push(0, 8)
+            .push(0, 1)
+            .push(1, 4)
+            .push(u32::from(kind == 3), 4);
+        if explicit_mask {
+            w.push(1, 1)
+                .push(0, 1)
+                .push(1, 1)
+                .push(0, 2)
+                .push(0, 3)
+                .push(2, 3)
+                .push(REFERENCE_MASK, 12);
+        } else {
+            w.push(0, 1).push(0, 1).push(0, 4);
+        }
+        w.push(1, 1)
+            .push(UNITY_CODE, 6)
+            .push(0, 1)
+            .push(3, 3)
+            .push(output_mask, 16);
+    }
+
+    /// A standard type-2 matrix: `rows[i]` is `(target mask, gain code)` for
+    /// height `i`, followed by the bare XLL bytes the decoder would find.
+    pub(crate) fn standard_payload(rows: [(u32, u32); 4]) -> Vec<u8> {
+        let mut w = BitWriter::new();
+        layout_header_bits(&mut w, 2, FULL_MASK, true);
+        w.push(2, 5)
+            .push(0, 6)
+            .push(1, 1)
+            .push(0, 1)
+            .push(1, 1)
+            .push(UNITY_CODE, 6)
+            .push(0, 1);
+        for (mask, code) in rows {
+            w.push(mask, 8);
+            for column in 0..8 {
+                if mask & (1 << column) != 0 {
+                    w.push(code, 6);
+                }
+            }
+        }
+        w.align();
+        let mut payload = crc_appended(w.bytes());
+        // Something after the protected prefix, as in a real frame.
+        payload.extend_from_slice(&[0x41, 0xa0, 0x00, 0x00]);
+        payload
+    }
+
+    pub(crate) struct ObjectRecord {
+        pub mode: u32,
+        pub index: u32,
+        pub distance: u32,
+        pub azimuth: u32,
+        pub elevation: u32,
+        /// `(reference mask, gain code)`; `None` when the row is absent.
+        pub row: Option<(u32, u32)>,
+        pub centre_height: bool,
+    }
+
+    /// An alternate prefix (type 241 + type 3, CRC-delimited) followed by
+    /// the outer control suffix and a few bytes, as `x_payload` carries it.
+    /// `height_rows[i]` is `(full-layout mask, bed gain code)` for height
+    /// row `i`; its height column is set at unity by `height_column`.
+    pub(crate) fn alternate_payload(
+        records: &[ObjectRecord],
+        height_rows: [(u32, u32); 4],
+    ) -> Vec<u8> {
+        alternate_payload_with(records, height_rows, false)
+    }
+
+    /// `explicit_type3_mask` writes the type-3 reference mask explicitly
+    /// instead of inheriting it, a form the corpus never uses.
+    pub(crate) fn alternate_payload_with(
+        records: &[ObjectRecord],
+        height_rows: [(u32, u32); 4],
+        explicit_type3_mask: bool,
+    ) -> Vec<u8> {
+        let mut w = BitWriter::new();
+        // The profile byte (0xd0/0xd1/0xd3) is the header fields below with
+        // the declaration count in its low nibble, not a separate field.
+        w.push(0xf1, 8)
+            .push(0x40, 8)
+            .push(0, 4)
+            .push(0, 1)
+            .push(1, 4)
+            .push(1, 1)
+            .push(0, 1)
+            .push(1, 1)
+            .push(records.len() as u32 - 1, 4);
+        w.push(0, 1)
+            .push(0, 1)
+            .push(1, 1)
+            .push(1, 1)
+            .push(0, 2)
+            .push(0, 3);
+        w.push(2, 3).push(REFERENCE_MASK, 12).push(0, 8);
+        for record in records {
+            w.push(1, 1)
+                .push(3, 2)
+                .push(record.index, 3)
+                .push(record.mode, 2)
+                .push(0, 10);
+        }
+        for record in records {
+            if record.mode == 0 {
+                w.push(1, 4);
+            } else {
+                w.push(0, 3);
+            }
+            w.push(0x20, 7)
+                .push(1, 1)
+                .push(1, 1)
+                .push(0, 2)
+                .push(UNITY_CODE, 6);
+            w.push(record.distance, 6)
+                .push(record.azimuth, 8)
+                .push(record.elevation, 7)
+                .push(0, 1);
+            if record.mode == 1 {
+                match record.row {
+                    Some((mask, code)) => {
+                        w.push(1, 1).push(0, 1).push(mask, 8);
+                        for column in 0..8 {
+                            if mask & (1 << column) != 0 {
+                                w.push(code, 6);
+                            }
+                        }
+                    }
+                    None => {
+                        w.push(0, 1).push(0, 1);
+                    }
+                }
+            }
+        }
+        let any_aux = records.iter().any(|record| record.centre_height);
+        w.push(u32::from(any_aux), 1);
+        if any_aux {
+            for record in records {
+                w.push(u32::from(record.centre_height), 1);
+                if record.centre_height {
+                    w.push(0, 2)
+                        .push(8, 5)
+                        .push(CENTRE_HEIGHT_MASK, 8)
+                        .push(1, 1)
+                        .push(1, 1)
+                        .push(UNITY_CODE, 6);
+                }
+            }
+        }
+        w.align();
+        let type241 = w.bytes();
+
+        let mut w = BitWriter::new();
+        layout_header_bits(&mut w, 3, FULL_MASK, explicit_type3_mask);
+        w.push(2, 5)
+            .push(0, 6)
+            .push(1, 1)
+            .push(0, 1)
+            .push(TYPE3_CONTROL, 12);
+        for (mask, code) in height_rows {
+            w.push(mask, 12);
+            for column in 0..FULL_COLUMNS {
+                if mask & (1 << column) != 0 {
+                    let is_height = FULL_TO_HEIGHT[column].is_some();
+                    w.push(if is_height { UNITY_CODE } else { code }, 6);
+                }
+            }
+        }
+        w.align();
+        let type3 = w.bytes();
+
+        let mut prefix = type241;
+        prefix.extend_from_slice(&type3);
+        let mut payload = crc_appended(prefix);
+        payload.extend_from_slice(&XLL_X_ALT_OUTER_SUFFIX);
+        payload.extend_from_slice(&[0xb2, 0, 0, 0, 0, 0, 0, 0]);
+        payload
+    }
+
+    /// The corpus D3 form: heights folded at code 55 into L, R, Lsr, Rsr.
+    pub(crate) const HEIGHT_ROWS_55: [(u32, u32); 4] = [
+        (1 << 1 | 1 << 4, 55),
+        (1 << 2 | 1 << 5, 55),
+        (1 << 6 | 1 << 10, 55),
+        (1 << 7 | 1 << 11, 55),
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fixtures::*;
+    use super::*;
+
+    const Q55: f32 = 23170.0 / 32768.0;
+
+    #[test]
+    fn gain_codes_follow_the_downmix_table_at_the_verified_points() {
+        assert_eq!(gain_code_linear(61), Some(1.0));
+        assert_eq!(gain_code_linear(55), Some(Q55));
+        assert_eq!(gain_code_linear(58), Some(27571.0 / 32768.0));
+        assert_eq!(gain_code_linear(46), Some(13818.0 / 32768.0));
+        for code in [0, 62, 63, 64, 200] {
+            assert_eq!(gain_code_linear(code), None, "code {code}");
+        }
+    }
+
+    #[test]
+    fn spherical_calibration_and_cartesian_conversion() {
+        assert_eq!(
+            SphericalPosition::from_codes(193, 60, 0),
+            SphericalPosition {
+                azimuth_half_degrees: 220,
+                elevation_half_degrees: 0,
+                distance_64ths: 0
+            }
+        );
+        assert_eq!(
+            SphericalPosition::from_codes(120, 77, 63),
+            SphericalPosition {
+                azimuth_half_degrees: 0,
+                elevation_half_degrees: 51,
+                distance_64ths: 64
+            }
+        );
+        assert_eq!(
+            SphericalPosition::from_codes(23, 79, 63).azimuth_half_degrees,
+            -291
+        );
+        assert_eq!(
+            SphericalPosition::from_codes(47, 127, 1).azimuth_half_degrees,
+            -220
+        );
+        assert_eq!(
+            SphericalPosition::from_codes(255, 127, 1).elevation_half_degrees,
+            180
+        );
+
+        let left = SphericalPosition {
+            azimuth_half_degrees: -180,
+            elevation_half_degrees: 0,
+            distance_64ths: 64,
+        }
+        .to_adm_cartesian();
+        assert!((left[0] + 1.0).abs() < 1e-9 && left[1].abs() < 1e-9 && left[2].abs() < 1e-9);
+        let up = SphericalPosition {
+            azimuth_half_degrees: 0,
+            elevation_half_degrees: 180,
+            distance_64ths: 32,
+        }
+        .to_adm_cartesian();
+        assert!(up[0].abs() < 1e-9 && up[1].abs() < 1e-9 && (up[2] - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn standard_matrix_becomes_height_folds() {
+        let payload = standard_payload([(1 << 1, 55), (1 << 2, 55), (1 << 4, 55), (1 << 5, 55)]);
+        let metadata = XMetadata::parse(&payload, 4).expect("standard matrix");
+        assert_eq!(metadata.source_count(), 4);
+        let expected = [
+            (SpatialChannel::TopFrontLeft, 1),
+            (SpatialChannel::TopFrontRight, 2),
+            (SpatialChannel::TopBackLeft, 4),
+            (SpatialChannel::TopBackRight, 5),
+        ];
+        for (feed, (speaker, column)) in expected.into_iter().enumerate() {
+            let source = metadata.source(feed).unwrap();
+            assert_eq!(source.role, SourceRole::Height(speaker));
+            let BedFold::Known(columns) = source.fold else {
+                panic!("standard fold must be known");
+            };
+            for (index, gain) in columns.iter().enumerate() {
+                assert_eq!(*gain, if index == column { Q55 } else { 0.0 });
+            }
+        }
+        let plan = FoldPlan::from_metadata(&metadata);
+        // Reference column 1 is L (speaker 1), column 4 is Lsr (speaker 7).
+        let sources = vec![vec![0.5f32], vec![0.25], vec![0.125], vec![0.0625]];
+        assert_eq!(plan.clean(1, 1.0, 0, &sources), 1.0 - Q55 * 0.5);
+        assert_eq!(plan.clean(7, 1.0, 0, &sources), 1.0 - Q55 * 0.125);
+        assert_eq!(plan.clean(0, 1.0, 0, &sources), 1.0);
+        assert!((0..4).all(|feed| plan.source_is_known(feed)));
+
+        let changed = standard_payload([(1 << 0, 54), (1 << 2, 55), (1 << 4, 55), (1 << 5, 55)]);
+        let metadata = XMetadata::parse(&changed, 4).unwrap();
+        let BedFold::Known(columns) = metadata.source(0).unwrap().fold else {
+            panic!()
+        };
+        assert_eq!(columns[0], gain_code_linear(54).unwrap());
+        assert_eq!(columns[1], 0.0);
+    }
+
+    #[test]
+    fn standard_matrix_rejects_corruption_and_wrong_counts() {
+        let payload = standard_payload([(1 << 1, 55), (1 << 2, 55), (1 << 4, 55), (1 << 5, 55)]);
+        assert!(XMetadata::parse(&payload, 5).is_err());
+        for end in 0..21 {
+            assert!(XMetadata::parse(&payload[..end], 4).is_err(), "end {end}");
+        }
+        for bit in 0..21 * 8 {
+            let mut damaged = payload.clone();
+            damaged[bit / 8] ^= 1 << (bit % 8);
+            assert!(XMetadata::parse(&damaged, 4).is_err(), "bit {bit}");
+        }
+        assert!(XMetadata::parse(&[0xf1, 0x40, 0x00, 0xd9, 0, 0, 0, 0], 5).is_err());
+        assert!(XMetadata::parse(&[], 4).is_err());
+    }
+
+    fn d3_records() -> Vec<ObjectRecord> {
+        vec![
+            ObjectRecord {
+                mode: 1,
+                index: 0,
+                distance: 63,
+                azimuth: 23,
+                elevation: 79,
+                row: Some((1 << 4 | 1 << 5, 21)),
+                centre_height: false,
+            },
+            ObjectRecord {
+                mode: 1,
+                index: 1,
+                distance: 63,
+                azimuth: 217,
+                elevation: 78,
+                row: Some((1 << 5, 61)),
+                centre_height: false,
+            },
+            ObjectRecord {
+                mode: 1,
+                index: 2,
+                distance: 63,
+                azimuth: 20,
+                elevation: 60,
+                row: None,
+                centre_height: false,
+            },
+            ObjectRecord {
+                mode: 1,
+                index: 3,
+                distance: 63,
+                azimuth: 220,
+                elevation: 60,
+                row: Some((1 << 5, 61)),
+                centre_height: false,
+            },
+        ]
+    }
+
+    #[test]
+    fn alternate_objects_and_heights_are_read_from_fields() {
+        let payload = alternate_payload(&d3_records(), HEIGHT_ROWS_55);
+        let metadata = XMetadata::parse(&payload, 8).expect("alternate metadata");
+        assert_eq!(metadata.source_count(), 8);
+
+        let object = metadata.source(0).unwrap();
+        let SourceRole::Object {
+            position,
+            centre_height_alternative,
+        } = object.role
+        else {
+            panic!("source 0 is an object");
+        };
+        assert_eq!(position.azimuth_half_degrees, -291);
+        assert_eq!(position.elevation_half_degrees, 57);
+        assert_eq!(position.distance_64ths, 64);
+        assert!(!centre_height_alternative);
+        let BedFold::Known(columns) = object.fold else {
+            panic!()
+        };
+        let code21 = gain_code_linear(21).unwrap();
+        assert_eq!(columns, [0.0, 0.0, 0.0, 0.0, code21, code21, 0.0, 0.0]);
+
+        // An object without a reference row is not in the bed at all.
+        assert_eq!(metadata.source(2).unwrap().fold, BedFold::Known([0.0; 8]));
+
+        let heights = [
+            SpatialChannel::TopFrontLeft,
+            SpatialChannel::TopFrontRight,
+            SpatialChannel::TopBackLeft,
+            SpatialChannel::TopBackRight,
+        ];
+        for (feed, speaker) in (4..8).zip(heights) {
+            let source = metadata.source(feed).unwrap();
+            assert_eq!(source.role, SourceRole::Height(speaker));
+            let BedFold::Known(columns) = source.fold else {
+                panic!()
+            };
+            assert_eq!(columns.iter().filter(|&&g| g != 0.0).count(), 1);
+            assert_eq!(columns.iter().sum::<f32>(), Q55);
+        }
+
+        let plan = FoldPlan::from_metadata(&metadata);
+        let sources: Vec<Vec<f32>> = (0..8).map(|k| vec![0.01 * (k + 1) as f32]).collect();
+        // Lsr (speaker 7) receives object 0 at code 21 and height TBL (feed 6) at code 55.
+        let expected = 1.0 - code21 * 0.01 - Q55 * 0.07;
+        assert!((plan.clean(7, 1.0, 0, &sources) - expected).abs() < 1e-6);
+        // L (speaker 1) receives only height TFL (feed 4).
+        assert!((plan.clean(1, 1.0, 0, &sources) - (1.0 - Q55 * 0.05)).abs() < 1e-6);
+        assert!((0..8).all(|feed| plan.source_is_known(feed)));
+        assert!(plan.touches(7) && plan.touches(1) && !plan.touches(0));
+    }
+
+    #[test]
+    fn declaration_order_and_indices_come_from_fields() {
+        let mut records = d3_records();
+        records.swap(0, 3);
+        records.swap(1, 2);
+        let payload = alternate_payload(&records, HEIGHT_ROWS_55);
+        let metadata = XMetadata::parse(&payload, 8).unwrap();
+        let SourceRole::Object { position, .. } = metadata.source(0).unwrap().role else {
+            panic!()
+        };
+        assert_eq!(
+            position.azimuth_half_degrees, -291,
+            "index 0 keeps its record"
+        );
+        let SourceRole::Object { position, .. } = metadata.source(3).unwrap().role else {
+            panic!()
+        };
+        assert_eq!(position.azimuth_half_degrees, 300);
+
+        let mut duplicate = d3_records();
+        duplicate[1].index = 0;
+        assert!(XMetadata::parse(&alternate_payload(&duplicate, HEIGHT_ROWS_55), 8).is_err());
+        assert!(
+            XMetadata::parse(&payload, 7).is_err(),
+            "count must match the declarations"
+        );
+        assert!(XMetadata::parse(&payload, 4).is_err());
+    }
+
+    #[test]
+    fn mode0_objects_have_positions_but_no_usable_fold() {
+        let records = vec![
+            ObjectRecord {
+                mode: 0,
+                index: 0,
+                distance: 63,
+                azimuth: 97,
+                elevation: 68,
+                row: None,
+                centre_height: false,
+            },
+            ObjectRecord {
+                mode: 0,
+                index: 1,
+                distance: 63,
+                azimuth: 143,
+                elevation: 68,
+                row: None,
+                centre_height: false,
+            },
+        ];
+        let payload = alternate_payload(&records, HEIGHT_ROWS_55);
+        let metadata = XMetadata::parse(&payload, 6).unwrap();
+        for feed in 0..2 {
+            let source = metadata.source(feed).unwrap();
+            assert_eq!(source.fold, BedFold::Unknown);
+            let SourceRole::Object { position, .. } = source.role else {
+                panic!()
+            };
+            assert_eq!(
+                position.azimuth_half_degrees,
+                if feed == 0 { -69 } else { 69 }
+            );
+            assert_eq!(position.elevation_half_degrees, 24);
+        }
+        let plan = FoldPlan::from_metadata(&metadata);
+        assert!(!plan.source_is_known(0) && !plan.source_is_known(1));
+        assert!((2..6).all(|feed| plan.source_is_known(feed)));
+        assert!(!plan.source_is_known(6));
+        // Heights still unfold; the objects stay in the bed untouched.
+        let sources: Vec<Vec<f32>> = (0..6).map(|_| vec![0.1f32]).collect();
+        assert!((plan.clean(1, 1.0, 0, &sources) - (1.0 - Q55 * 0.1)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn d0_object_carries_its_centre_height_alternative_and_unity_heights() {
+        let records = vec![ObjectRecord {
+            mode: 1,
+            index: 0,
+            distance: 63,
+            azimuth: 120,
+            elevation: 77,
+            row: Some((1 << 0 | 1 << 1 | 1 << 2, 46)),
+            centre_height: true,
+        }];
+        let rows = [
+            (1 << 1 | 1 << 4, 61),
+            (1 << 2 | 1 << 5, 61),
+            (1 << 6 | 1 << 10, 61),
+            (1 << 7 | 1 << 11, 61),
+        ];
+        let payload = alternate_payload(&records, rows);
+        let metadata = XMetadata::parse(&payload, 5).unwrap();
+        let object = metadata.source(0).unwrap();
+        assert!(matches!(
+            object.role,
+            SourceRole::Object {
+                centre_height_alternative: true,
+                ..
+            }
+        ));
+        let plan = FoldPlan::from_metadata(&metadata);
+        let sources: Vec<Vec<f32>> = (0..5).map(|k| vec![0.1 * (k + 1) as f32]).collect();
+        let code46 = gain_code_linear(46).unwrap();
+        // C receives the object only; L receives the object and TFL at unity.
+        assert!((plan.clean(0, 1.0, 0, &sources) - (1.0 - code46 * 0.1)).abs() < 1e-6);
+        assert!((plan.clean(1, 1.0, 0, &sources) - (1.0 - code46 * 0.1 - 0.2)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn every_truncation_and_extension_of_an_alternate_prefix_is_rejected() {
+        let payload = alternate_payload(&d3_records(), HEIGHT_ROWS_55);
+        let prefix_len = alternate_prefix_len(&payload).unwrap();
+        for end in 0..prefix_len {
+            assert!(XMetadata::parse(&payload[..end], 8).is_err(), "end {end}");
+        }
+        for bit in 0..prefix_len * 8 {
+            let mut damaged = payload.clone();
+            damaged[bit / 8] ^= 1 << (bit % 8);
+            assert!(XMetadata::parse(&damaged, 8).is_err(), "bit {bit}");
+        }
+    }
+
+    #[test]
+    fn unfamiliar_forms_are_errors_not_guesses() {
+        let mut rows = HEIGHT_ROWS_55;
+        rows[0] = (1 << 1, 55); // a height row without its own speaker
+        assert!(XMetadata::parse(&alternate_payload(&d3_records(), rows), 8).is_err());
+        let mut rows = HEIGHT_ROWS_55;
+        rows[1] = (1 << 2 | 1 << 4 | 1 << 5, 55); // two height columns
+        assert!(XMetadata::parse(&alternate_payload(&d3_records(), rows), 8).is_err());
+        let mut records = d3_records();
+        records[0].row = Some((1 << 4, 62)); // escape code
+        assert!(XMetadata::parse(&alternate_payload(&records, HEIGHT_ROWS_55), 8).is_err());
+    }
+
+    #[test]
+    fn type3_accepts_an_explicit_reference_mask() {
+        let payload = alternate_payload_with(&d3_records(), HEIGHT_ROWS_55, true);
+        let metadata = XMetadata::parse(&payload, 8).expect("explicit type-3 mask");
+        assert_eq!(
+            metadata.source(4).unwrap().role,
+            SourceRole::Height(SpatialChannel::TopFrontLeft)
+        );
+    }
+
+    #[test]
+    fn fallback_plans_behave_as_documented() {
+        let unknown = FoldPlan::all_unknown(6);
+        assert!((0..6).all(|feed| !unknown.source_is_known(feed)));
+        let sources = vec![vec![0.5f32]; 6];
+        assert_eq!(unknown.clean(1, 0.3, 0, &sources), 0.3);
+
+        let standard = FoldPlan::standard_heights(Q55);
+        let sources = vec![vec![0.1f32], vec![0.2], vec![0.3], vec![0.4]];
+        assert!((standard.clean(1, 1.0, 0, &sources) - (1.0 - Q55 * 0.1)).abs() < 1e-6);
+        assert!((standard.clean(8, 1.0, 0, &sources) - (1.0 - Q55 * 0.4)).abs() < 1e-6);
+        assert_eq!(standard.clean(3, 1.0, 0, &sources), 1.0);
+        assert!((0..4).all(|feed| standard.source_is_known(feed)));
+
+        let short: Vec<Vec<f32>> = vec![Vec::new(); 4];
+        assert_eq!(
+            standard.clean(1, 1.0, 0, &short),
+            1.0,
+            "missing samples contribute nothing"
+        );
+        assert_eq!(standard.clean(FOLD_SPEAKERS + 3, 1.0, 0, &sources), 1.0);
+    }
+}

--- a/dca/src/lib.rs
+++ b/dca/src/lib.rs
@@ -27,4 +27,8 @@ pub use parser::{
 pub use hd::{exss_has_xll, exss_substream_size, HdDecoder, HdError, HdFrame};
 pub use pcm::{CorePcmFrame, DecodeError, PcmDecoder, PcmPushResult, bed_layout};
 pub use spatial::{SpatialChannel, XPresentation};
+pub use dcadec::xmeta::{
+    BedFold, FoldPlan, MAX_SOURCES, REFERENCE_CHANNELS, REFERENCE_SPEAKERS, SourceMetadata,
+    SourceRole, SphericalPosition, XMetadata, XMetadataError, gain_code_linear,
+};
 pub use types::BedChannel;

--- a/dca/src/spatial.rs
+++ b/dca/src/spatial.rs
@@ -1,25 +1,31 @@
 //! Spatial-extension presentations: what the DTS:X extension waveforms in an
-//! [`HdFrame`] mean.
+//! [`HdFrame`] are.
 //!
 //! The lossless decoder recovers the extension channel set as a bag of
-//! waveforms with no one-to-one speaker mask. Deciding that "waveform 2 of a
-//! five-feed alternate profile is top-front-right" is *codec* knowledge, so it
+//! waveforms with no one-to-one speaker mask. Deciding that "waveform 5 of an
+//! eight-feed alternate profile is top-front-right" is *codec* knowledge, so it
 //! lives here rather than in a consumer — the realtime bridge and the offline
 //! ADM/DAMF exporter both need it and must not disagree about it.
 //!
-//! What deliberately does NOT live here: fold/unfold gains and the per-sample
-//! recombination. Those are presentation choices a renderer makes, and the
-//! bridge owns them.
+//! A presentation splits the feeds into **objects**, whose positions and bed
+//! folds come from the frame's private metadata ([`crate::XMetadata`]), and
+//! **fixed channels** at the positions listed here. What deliberately does NOT
+//! live here: the per-sample bed recombination. That is [`crate::FoldPlan`],
+//! built from the metadata and applied by each host.
 //!
 //! Everything below is expressed as plain data. This module has no notion of
 //! any consumer's channel-label ABI.
 //!
 //! # Status
 //!
-//! Only [`XPresentation::Height`] is established. The alternate profiles are
-//! research results from a finite corpus; each carries its provenance in the
-//! docs below. They are exposed so consumers can render *something* coherent,
-//! not because the mapping is confirmed normative.
+//! [`XPresentation::Height`] is established. The alternate profiles' feed
+//! identities were established against a finite corpus by comparing the
+//! decoded audio with the private metadata (see the repository's
+//! `docs/private-metadata-probe.md`): the last four feeds are the fixed
+//! heights named by the type-3 rows, the first feeds are the declared objects,
+//! and D0's single object also declares the centre-height speaker as its
+//! fixed alternative. They are exposed as presentations rather than as
+//! research defaults, but no listening sign-off exists yet.
 
 use crate::hd::HdFrame;
 
@@ -46,16 +52,14 @@ pub enum XPresentation {
     /// Standard DTS:X: four full-coded height waveforms folded into the 7.1
     /// bed. The stable stereo pairs are front-height L/R then rear-height L/R.
     Height,
-    /// Experimental five-feed alternate profile. Inferred from two complete
-    /// programmes: the first feed has a stable front-centre signature and the
-    /// remaining four form the established top quartet.
+    /// Five-feed alternate profile: one object whose record declares the
+    /// centre-height speaker as its fixed alternative, presented as that fixed
+    /// channel, then the four fixed heights.
     FixedD0,
-    /// Experimental six-feed alternate profile. Inferred from a single complete
-    /// programme. The wide fold is strongly measurable, but all six channel
-    /// identities remain experimental pending an independent source.
-    FixedD1,
-    /// Experimental eight-feed alternate profile, presented as named objects at
-    /// static inferred positions. See [`XPresentation::object_positions`].
+    /// Six-feed alternate profile: two objects, then the four fixed heights.
+    ObjectsD1,
+    /// Eight-feed alternate profile: four objects, then the four fixed
+    /// heights.
     ObjectsD3,
 }
 
@@ -70,49 +74,6 @@ const D0_CHANNELS: [SpatialChannel; 5] = [
     SpatialChannel::TopFrontCenter,
     SpatialChannel::TopFrontLeft,
     SpatialChannel::TopFrontRight,
-    SpatialChannel::TopBackLeft,
-    SpatialChannel::TopBackRight,
-];
-
-const D1_CHANNELS: [SpatialChannel; 6] = [
-    SpatialChannel::TopFrontLeft,
-    SpatialChannel::TopFrontRight,
-    SpatialChannel::WideLeft,
-    SpatialChannel::WideRight,
-    SpatialChannel::TopBackLeft,
-    SpatialChannel::TopBackRight,
-];
-
-/// Research-only D3 default positions, as `[x, y, z]` with x left-to-right,
-/// y back-to-front and z floor-to-ceiling, each in `-1.0..=1.0`.
-///
-/// The corpus supports stable left/right pairing and a recurring rear
-/// association for feeds 6/7. Feeds 2/3 also match the front-elevation group in
-/// the paired fixed-layout control, while 4/5 remain the broad side pair.
-/// Feeds 0/1 are the least stable pair and are placed at the front-wide
-/// positions by elimination. These are presentation defaults, not decoded
-/// coordinates and not a claimed normative speaker map.
-const D3_OBJECT_POSITIONS: [[f64; 3]; 8] = [
-    [-1.0, 0.5, 0.0],  // 0: wide left
-    [1.0, 0.5, 0.0],   // 1: wide right
-    [-1.0, 1.0, 1.0],  // 2: top front left
-    [1.0, 1.0, 1.0],   // 3: top front right
-    [-1.0, 0.0, 1.0],  // 4: top side left
-    [1.0, 0.0, 1.0],   // 5: top side right
-    [-1.0, -1.0, 1.0], // 6: top back left
-    [1.0, -1.0, 1.0],  // 7: top back right
-];
-
-/// The position each D3 feed is nominally associated with, parallel to
-/// [`D3_OBJECT_POSITIONS`]. Advisory only — a consumer that renders D3 as
-/// objects should use the positions, not these labels.
-const D3_CHANNEL_HINTS: [SpatialChannel; 8] = [
-    SpatialChannel::WideLeft,
-    SpatialChannel::WideRight,
-    SpatialChannel::TopFrontLeft,
-    SpatialChannel::TopFrontRight,
-    SpatialChannel::TopSideLeft,
-    SpatialChannel::TopSideRight,
     SpatialChannel::TopBackLeft,
     SpatialChannel::TopBackRight,
 ];
@@ -145,45 +106,42 @@ impl XPresentation {
         if !frame.x_imax {
             return None;
         }
-        match frame.x_samples.len() {
-            n if n == D0_CHANNELS.len() && feeds_are(n) => Some(Self::FixedD0),
-            n if n == D1_CHANNELS.len() && feeds_are(n) => Some(Self::FixedD1),
-            n if n == D3_OBJECT_POSITIONS.len() && feeds_are(n) => Some(Self::ObjectsD3),
-            _ => None,
-        }
+        [Self::FixedD0, Self::ObjectsD1, Self::ObjectsD3]
+            .into_iter()
+            .find(|presentation| feeds_are(presentation.feed_count()))
     }
 
     /// Number of extension waveforms this presentation carries.
     pub fn feed_count(self) -> usize {
-        self.channels().len()
+        match self {
+            Self::Height => 4,
+            Self::FixedD0 => 5,
+            Self::ObjectsD1 => 6,
+            Self::ObjectsD3 => 8,
+        }
     }
 
-    /// Speaker position of each extension waveform, in feed order.
-    ///
-    /// For [`XPresentation::ObjectsD3`] these are advisory hints; that
-    /// presentation is meant to be rendered as objects via
-    /// [`XPresentation::object_positions`].
-    pub fn channels(self) -> &'static [SpatialChannel] {
+    /// Feeds presented as objects, positioned by the frame's metadata.
+    pub fn object_feeds(self) -> std::ops::Range<usize> {
+        0..self.feed_count() - self.fixed_channels().len()
+    }
+
+    /// Feeds presented as fixed channels, parallel to [`Self::fixed_channels`].
+    pub fn fixed_feeds(self) -> std::ops::Range<usize> {
+        self.object_feeds().end..self.feed_count()
+    }
+
+    /// Speaker position of each fixed feed, in feed order.
+    pub fn fixed_channels(self) -> &'static [SpatialChannel] {
         match self {
-            Self::Height => &HEIGHT_CHANNELS,
+            Self::Height | Self::ObjectsD1 | Self::ObjectsD3 => &HEIGHT_CHANNELS,
             Self::FixedD0 => &D0_CHANNELS,
-            Self::FixedD1 => &D1_CHANNELS,
-            Self::ObjectsD3 => &D3_CHANNEL_HINTS,
         }
     }
 
-    /// Static positions for a presentation whose feeds are objects rather than
-    /// fixed channels, or `None` for the fixed presentations.
-    pub fn object_positions(self) -> Option<&'static [[f64; 3]]> {
-        match self {
-            Self::ObjectsD3 => Some(&D3_OBJECT_POSITIONS),
-            _ => None,
-        }
-    }
-
-    /// Whether this presentation's channel identities are inferred research
-    /// results rather than an established mapping. Consumers should say so
-    /// when they surface it to a user.
+    /// Whether this presentation's feed identities rest on corpus evidence
+    /// rather than on the standard profile's established layout. Consumers
+    /// should say so when they surface it to a user.
     pub fn is_experimental(self) -> bool {
         !matches!(self, Self::Height)
     }
@@ -207,6 +165,8 @@ mod tests {
         let f = frame_with(vec![vec![0.0; 512]; 4], false, 512);
         assert_eq!(XPresentation::detect(&f), Some(XPresentation::Height));
         assert!(!XPresentation::Height.is_experimental());
+        assert_eq!(XPresentation::Height.object_feeds(), 0..0);
+        assert_eq!(XPresentation::Height.fixed_feeds(), 0..4);
     }
 
     #[test]
@@ -221,7 +181,7 @@ mod tests {
     fn detects_each_alternate_profile() {
         for (n, expected) in [
             (5usize, XPresentation::FixedD0),
-            (6, XPresentation::FixedD1),
+            (6, XPresentation::ObjectsD1),
             (8, XPresentation::ObjectsD3),
         ] {
             let f = frame_with(vec![vec![0.0; 512]; n], true, 512);
@@ -263,30 +223,35 @@ mod tests {
         assert_eq!(XPresentation::detect(&f), None);
     }
 
+    /// Objects come first, the fixed heights last, and together they cover
+    /// every feed exactly once.
     #[test]
-    fn only_d3_carries_object_positions() {
-        assert_eq!(XPresentation::Height.object_positions(), None);
-        assert_eq!(XPresentation::FixedD0.object_positions(), None);
-        assert_eq!(XPresentation::FixedD1.object_positions(), None);
-        let d3 = XPresentation::ObjectsD3.object_positions().unwrap();
-        assert_eq!(d3.len(), XPresentation::ObjectsD3.feed_count());
-        // Left feeds sit left of centre, right feeds right of it.
-        for (i, pos) in d3.iter().enumerate() {
-            let expected_sign = if i % 2 == 0 { -1.0 } else { 1.0 };
-            assert_eq!(pos[0].signum(), expected_sign, "feed {i} laterality");
-            assert!(pos.iter().all(|c| (-1.0..=1.0).contains(c)), "feed {i} range");
-        }
-    }
-
-    #[test]
-    fn channel_tables_match_their_feed_counts() {
-        for p in [
-            XPresentation::Height,
-            XPresentation::FixedD0,
-            XPresentation::FixedD1,
-            XPresentation::ObjectsD3,
+    fn feeds_split_into_objects_then_fixed_channels() {
+        for (presentation, objects, fixed) in [
+            (XPresentation::Height, 0..0, 0..4),
+            (XPresentation::FixedD0, 0..0, 0..5),
+            (XPresentation::ObjectsD1, 0..2, 2..6),
+            (XPresentation::ObjectsD3, 0..4, 4..8),
         ] {
-            assert_eq!(p.channels().len(), p.feed_count());
+            assert_eq!(presentation.object_feeds(), objects, "{presentation:?}");
+            assert_eq!(presentation.fixed_feeds(), fixed, "{presentation:?}");
+            assert_eq!(
+                presentation.fixed_channels().len(),
+                presentation.fixed_feeds().len()
+            );
+            assert_eq!(
+                presentation.object_feeds().len() + presentation.fixed_feeds().len(),
+                presentation.feed_count()
+            );
         }
+        assert_eq!(
+            XPresentation::ObjectsD3.fixed_channels(),
+            &HEIGHT_CHANNELS,
+            "alternate heights are the standard quartet"
+        );
+        assert_eq!(
+            XPresentation::FixedD0.fixed_channels()[0],
+            SpatialChannel::TopFrontCenter
+        );
     }
 }

--- a/dca/tests/xmeta_corpus.rs
+++ b/dca/tests/xmeta_corpus.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Corpus-gated checks of the private-metadata reader against real streams.
+//!
+//! Inputs come from the `HARLETTY_DTSX_STANDARD_CORPUS`, `HARLETTY_D0_CORPUS`,
+//! `HARLETTY_D1_CORPUS` and `HARLETTY_D3_CORPUS` environment variables; each
+//! test self-skips, loudly, when its input is absent. A green run without the
+//! corpus therefore proves nothing about the reader; run these locally.
+
+use std::io::Read;
+
+use dca::{
+    BedFold, FoldPlan, HdDecoder, HdError, SourceRole, SpatialChannel, XMetadata, XPresentation,
+    exss_substream_size, parse_header,
+};
+
+const PREFIX_BYTES: usize = 4 * 1024 * 1024;
+const Q55: f32 = 23170.0 / 32768.0;
+
+fn corpus(var: &str) -> Option<Vec<u8>> {
+    let path = std::env::var(var).ok()?;
+    let mut file = match std::fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) => {
+            eprintln!("skipping: {var}={path} is not readable ({error})");
+            return None;
+        }
+    };
+    let mut bytes = vec![0u8; PREFIX_BYTES];
+    let mut read = 0;
+    while read < bytes.len() {
+        match file.read(&mut bytes[read..]) {
+            Ok(0) => break,
+            Ok(n) => read += n,
+            Err(error) => {
+                eprintln!("skipping: {var} could not be read ({error})");
+                return None;
+            }
+        }
+    }
+    bytes.truncate(read);
+    Some(bytes)
+}
+
+struct Survey {
+    frames: usize,
+    presentation: XPresentation,
+    metadata: XMetadata,
+}
+
+/// Decode every complete DTS-HD frame of `bytes` and parse its metadata,
+/// requiring one presentation throughout and a successful parse on every
+/// frame that carries extension waveforms. Returns the last metadata read.
+fn survey(bytes: &[u8]) -> Survey {
+    let mut decoder = HdDecoder::new();
+    let mut offset = 0;
+    let mut frames = 0;
+    let mut presentation = None;
+    let mut metadata = None;
+    while offset + 18 <= bytes.len() {
+        let info = parse_header(&bytes[offset..]).expect("core header");
+        let core_end = offset + info.frame_size;
+        if core_end + 16 > bytes.len() {
+            break;
+        }
+        let Some(exss_size) = exss_substream_size(&bytes[core_end..]) else {
+            // The prefix ends inside this substream; anything else is a
+            // stream the decoder would not play either.
+            assert!(
+                bytes.len() - core_end < 65_536,
+                "EXSS header at byte {core_end} (frame {frames})"
+            );
+            break;
+        };
+        let exss_end = core_end + exss_size;
+        if exss_end > bytes.len() {
+            break;
+        }
+        match decoder.decode(&bytes[offset..core_end], &bytes[core_end..exss_end]) {
+            Ok(frame) => {
+                frames += 1;
+                let detected = XPresentation::detect(&frame).expect("extension presentation");
+                if let Some(previous) = presentation.replace(detected) {
+                    assert_eq!(previous, detected, "presentation changed at frame {frames}");
+                }
+                let parsed = XMetadata::parse(&frame.x_payload, frame.x_samples.len())
+                    .unwrap_or_else(|error| panic!("frame {frames}: {error:?}"));
+                assert_eq!(parsed.source_count(), detected.feed_count());
+                // The last four feeds of every profile are the fixed heights
+                // (D0's first fixed feed is its centre-height object).
+                for feed in detected.feed_count() - 4..detected.feed_count() {
+                    assert!(
+                        matches!(parsed.source(feed).unwrap().role, SourceRole::Height(_)),
+                        "frame {frames}: feed {feed} is a fixed height"
+                    );
+                }
+                metadata = Some(parsed);
+            }
+            Err(HdError::Pending) => {}
+            Err(error) => panic!("decode error at byte {offset}: {error:?}"),
+        }
+        offset = exss_end;
+    }
+    assert!(frames > 100, "corpus was not exercised ({frames} frames)");
+    Survey {
+        frames,
+        presentation: presentation.unwrap(),
+        metadata: metadata.unwrap(),
+    }
+}
+
+/// The reference column that each fixed height (the last four feeds) folds
+/// into, in row order.
+fn height_fold_columns(metadata: &XMetadata, presentation: XPresentation) -> Vec<(usize, f32)> {
+    (presentation.feed_count() - 4..presentation.feed_count())
+        .map(|feed| match metadata.source(feed).unwrap().fold {
+            BedFold::Known(columns) => {
+                let set: Vec<_> = columns
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, gain)| **gain != 0.0)
+                    .map(|(column, gain)| (column, *gain))
+                    .collect();
+                assert_eq!(set.len(), 1, "one bed column per height");
+                set[0]
+            }
+            BedFold::Unknown => panic!("height fold must be known"),
+        })
+        .collect()
+}
+
+#[test]
+fn standard_matrix_parses_on_every_frame() {
+    let Some(bytes) = corpus("HARLETTY_DTSX_STANDARD_CORPUS") else {
+        eprintln!("skipping: HARLETTY_DTSX_STANDARD_CORPUS is not set");
+        return;
+    };
+    let survey = survey(&bytes);
+    assert_eq!(survey.presentation, XPresentation::Height);
+    assert_eq!(
+        height_fold_columns(&survey.metadata, survey.presentation),
+        vec![(1, Q55), (2, Q55), (4, Q55), (5, Q55)]
+    );
+    eprintln!(
+        "standard: {} frames, fold code 55 on every height",
+        survey.frames
+    );
+}
+
+#[test]
+fn d0_folds_heights_at_unity_and_declares_a_centre_height_object() {
+    let Some(bytes) = corpus("HARLETTY_D0_CORPUS") else {
+        eprintln!("skipping: HARLETTY_D0_CORPUS is not set");
+        return;
+    };
+    let survey = survey(&bytes);
+    assert_eq!(survey.presentation, XPresentation::FixedD0);
+    assert_eq!(
+        height_fold_columns(&survey.metadata, survey.presentation),
+        vec![(1, 1.0), (2, 1.0), (4, 1.0), (5, 1.0)]
+    );
+    let object = survey.metadata.source(0).unwrap();
+    assert!(matches!(
+        object.role,
+        SourceRole::Object {
+            centre_height_alternative: true,
+            ..
+        }
+    ));
+    assert!(matches!(object.fold, BedFold::Known(_)));
+    let plan = FoldPlan::from_metadata(&survey.metadata);
+    assert!((0..5).all(|feed| plan.source_is_known(feed)));
+    eprintln!("D0: {} frames", survey.frames);
+}
+
+#[test]
+fn d1_folds_heights_at_minus_3_db_and_reads_two_object_positions() {
+    let Some(bytes) = corpus("HARLETTY_D1_CORPUS") else {
+        eprintln!("skipping: HARLETTY_D1_CORPUS is not set");
+        return;
+    };
+    let survey = survey(&bytes);
+    assert_eq!(survey.presentation, XPresentation::ObjectsD1);
+    assert_eq!(
+        height_fold_columns(&survey.metadata, survey.presentation),
+        vec![(1, Q55), (2, Q55), (4, Q55), (5, Q55)]
+    );
+    for feed in 0..2 {
+        let SourceRole::Object { position, .. } = survey.metadata.source(feed).unwrap().role else {
+            panic!("feed {feed} is an object");
+        };
+        assert_eq!(position.distance_64ths, 64);
+        assert_eq!(
+            position.azimuth_half_degrees.signum(),
+            if feed == 0 { -1 } else { 1 },
+            "objects are a left/right pair"
+        );
+    }
+    eprintln!(
+        "D1: {} frames, object folds {:?}",
+        survey.frames,
+        (0..2)
+            .map(|feed| matches!(
+                survey.metadata.source(feed).unwrap().fold,
+                BedFold::Known(_)
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn d3_folds_heights_at_minus_3_db_and_reads_four_object_folds() {
+    let Some(bytes) = corpus("HARLETTY_D3_CORPUS") else {
+        eprintln!("skipping: HARLETTY_D3_CORPUS is not set");
+        return;
+    };
+    let survey = survey(&bytes);
+    assert_eq!(survey.presentation, XPresentation::ObjectsD3);
+    let folds = height_fold_columns(&survey.metadata, survey.presentation);
+    assert_eq!(folds, vec![(1, Q55), (2, Q55), (4, Q55), (5, Q55)]);
+    assert_eq!(
+        survey.metadata.source(4).unwrap().role,
+        SourceRole::Height(SpatialChannel::TopFrontLeft)
+    );
+    for feed in 0..4 {
+        let source = survey.metadata.source(feed).unwrap();
+        assert!(matches!(source.role, SourceRole::Object { .. }));
+        assert!(
+            matches!(source.fold, BedFold::Known(_)),
+            "D3 objects carry rows"
+        );
+    }
+    let plan = FoldPlan::from_metadata(&survey.metadata);
+    assert!((0..8).all(|feed| plan.source_is_known(feed)));
+    assert!(
+        plan.touches(7) && plan.touches(8),
+        "rear pair receives objects and heights"
+    );
+    eprintln!("D3: {} frames", survey.frames);
+}

--- a/docs/dtsx-d1-wide-audition.md
+++ b/docs/dtsx-d1-wide-audition.md
@@ -1,5 +1,16 @@
 # Alternate-profile experimental presentations
 
+> **Superseded (2026-09).** The D0/D1 presentations and folds described
+> below were inferred from the audio alone. The stream's private metadata,
+> read since `dca::XMetadata`, states the feed identities and fold gains
+> directly, and the audio confirms them: the last four feeds of every
+> alternate profile are the fixed heights (folded at unity in D0, at
+> -3.01 dB in D1/D3), D1's first two feeds are objects rather than wide
+> channels, and D0's first feed is an object that also declares the
+> centre-height speaker. Both hosts now build their presentation from that
+> metadata; see `private-metadata-probe.md`. This note is kept as the record
+> of the earlier inference and its measurements.
+
 This note records the evidence and reproduction steps for the experimental D0
 height and D1 wide-channel presentations. They are research, not normative
 format claims. Harletty now selects the standard four-source or inferred

--- a/docs/private-metadata-probe.md
+++ b/docs/private-metadata-probe.md
@@ -1,8 +1,11 @@
 # Private metadata: standard matrix and alternate-profile candidates
 
-Status: offline research only. The decoder, ABI, fold configuration and output
-presentations are unchanged. `dca/examples/xll_private_metadata.rs` is an
-independent diagnostic; it is not a general DTS:X navigation parser.
+Status: the reading established here is now applied in playback. The
+realtime reader is `dca::XMetadata` (positions, bed folds) with the
+subtraction table `dca::FoldPlan`; the bridge and the offline exporter both
+present the extension waveforms from it. `dca/examples/xll_private_metadata.rs`
+remains the independent offline diagnostic that produced the evidence below;
+it is not a general DTS:X navigation parser.
 
 ## Confirmed standard result
 
@@ -396,25 +399,23 @@ that would cross the selected limit.
 
 The reading questions that gated playback work are now answered by the
 audio itself: which sources the type-3 rows describe, in which direction,
-at which gains, and what the mode-1 rows are. What remains is
-implementation-side:
+at which gains, and what the mode-1 rows are. The realtime reader lives in
+`dca::XMetadata` with the subtraction table in `dca::FoldPlan`; the bridge
+and the offline exporter both build their presentation from it (fixed
+heights as labeled channels, objects with transmitted positions, every
+stated fold removed from the bed, an unstated fold left in the bed with the
+feed muted). What remains:
 
-1. Subtract the embedded folds from the compatible bed using the decoded
-   metadata: the type-3 first entries for the four fixed heights and the
-   mode-1 reference rows for objects, with gain codes limited to the four
-   verified calibration points until the table relation is confirmed on
-   more codes.
-2. Recover the mode-0 panning law, which needs more mode-0 inputs than the
-   single one at hand; until then a mode-0 object cannot be removed from the
-   bed and must not be rendered a second time.
-3. Read positions per frame in playback and decide, with the renderer, how
-   transmitted positions replace the static D3 defaults, including the
-   auxiliary centre-height declaration.
-4. Explain the type-3 control word and the general association navigation,
+1. Recover the mode-0 panning law, which needs more mode-0 inputs than the
+   single one at hand; until then a mode-0 object stays in the bed and its
+   object channel is silent.
+2. Confirm the gain-code table relation on codes other than the four
+   verified points; the reader applies it to every code in 1..=61.
+3. Explain the type-3 control word and the general association navigation,
    which the corpus cannot distinguish from constants.
-5. A/B listen before any of this changes a presentation.
+4. A/B listen before merging any of this into a release.
 
-Until then no alternate presentation or `has_objects` behavior changes.
+
 
 ## Research provenance
 

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -11,7 +11,7 @@ use crate::cli::command::{AudioFormat, WarpMode};
 use crate::dts_to_oamd::{BedSource, DtsLayout, convert_dts};
 use anyhow::Result;
 use damf::{Configuration, Event, SourceCodec};
-use dca::{CorePcmFrame, HdFrame, PcmPushResult, XPresentation};
+use dca::{CorePcmFrame, FoldPlan, HdFrame, PcmPushResult, XMetadata, XPresentation};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
@@ -21,6 +21,9 @@ pub enum DtsFrameMessage {
     Hd {
         frame: Box<HdFrame>,
         presentation: Option<XPresentation>,
+        /// The frame's private metadata (object positions and bed folds),
+        /// or `None` when it did not parse.
+        metadata: Option<XMetadata>,
     },
     /// A plain DTS core frame (5.1 lossy bed, no extension).
     Core(Box<PcmPushResult>),
@@ -52,6 +55,8 @@ pub struct DtsDecodeHandler {
     metadata_header_written: bool,
     /// Whether the dropped-channel warning has already been emitted.
     warned_dropped_channels: bool,
+    /// Whether the unreadable-metadata warning has already been emitted.
+    warned_unreadable_metadata: bool,
     /// Label for the master set, chosen from the presentation of the first
     /// spatial frame.
     source_codec: SourceCodec,
@@ -65,7 +70,7 @@ fn source_codec_for(presentation: XPresentation) -> SourceCodec {
     match presentation {
         XPresentation::Height => SourceCodec::DtsX714,
         XPresentation::FixedD0 => SourceCodec::DtsX715,
-        XPresentation::FixedD1 => SourceCodec::DtsX914,
+        XPresentation::ObjectsD1 => SourceCodec::DtsX914,
         XPresentation::ObjectsD3 => SourceCodec::DtsX71Plus8,
     }
 }
@@ -86,6 +91,7 @@ impl Default for DtsDecodeHandler {
             last_layout: None,
             metadata_header_written: false,
             warned_dropped_channels: false,
+            warned_unreadable_metadata: false,
             source_codec: SourceCodec::DtsX714,
         }
     }
@@ -103,7 +109,8 @@ impl DtsDecodeHandler {
             DtsFrameMessage::Hd {
                 frame,
                 presentation,
-            } => self.handle_hd_frame(&frame, presentation, base_path, format, no_audio),
+                metadata,
+            } => self.handle_hd_frame(&frame, presentation, metadata, base_path, format, no_audio),
             DtsFrameMessage::Core(push) => {
                 self.handle_core_frame(&push.pcm, base_path, format, no_audio)
             }
@@ -114,6 +121,7 @@ impl DtsDecodeHandler {
         &mut self,
         frame: &HdFrame,
         presentation: Option<XPresentation>,
+        metadata: Option<XMetadata>,
         base_path: &Option<PathBuf>,
         format: AudioFormat,
         no_audio: bool,
@@ -128,7 +136,8 @@ impl DtsDecodeHandler {
             .filter(|&s| frame.samples[s].is_some())
             .collect();
 
-        let layout = DtsLayout::from_hd(&active, presentation);
+        let layout = DtsLayout::from_hd(&active, presentation, metadata.as_ref());
+        let plan = self.fold_plan(presentation, metadata.as_ref());
         // The output carries exactly what the master set declares: the bed the
         // layout resolved (speakers with no OAMD name, i.e. rear centre, are
         // dropped from both) plus one channel per object.
@@ -165,7 +174,7 @@ impl DtsDecodeHandler {
                 format
             };
             self.ensure_audio_writer(base_path, audio_format, frame.sample_rate, total_channels)?;
-            self.write_hd_pcm(frame, &active, &layout, sample_count, total_channels)?;
+            self.write_hd_pcm(frame, &active, &layout, &plan, sample_count, total_channels)?;
         }
 
         self.decoded_samples += sample_count as u64;
@@ -223,19 +232,18 @@ impl DtsDecodeHandler {
             self.has_spatial = true;
             if let Some(base_path) = base_path {
                 let oamd = convert_dts(layout);
-                if let Err(e) = create_damf_header_file(
-                    base_path,
-                    &oamd,
-                    self.warp_mode,
-                    self.source_codec,
-                ) {
+                if let Err(e) =
+                    create_damf_header_file(base_path, &oamd, self.warp_mode, self.source_codec)
+                {
                     log::error!("failed to write .atmos header: {e}");
                 }
             }
         }
 
         match &self.last_layout {
-            Some(previous) if previous != layout => {
+            Some(previous)
+                if previous.bed != layout.bed || previous.objects.len() != layout.objects.len() =>
+            {
                 log::warn!(
                     "DTS layout changed mid-stream ({} bed / {} objects -> {} bed / {} objects); \
                      the master set describes the first layout",
@@ -262,16 +270,50 @@ impl DtsDecodeHandler {
         log::info!(
             "DTS:X spatial presentation: {presentation:?} ({} extension feeds, {})",
             presentation.feed_count(),
-            match presentation.object_positions() {
-                Some(positions) => format!("{} objects", positions.len()),
-                None => "fixed channels".to_string(),
+            match presentation.object_feeds().len() {
+                0 => "fixed channels".to_string(),
+                objects => format!("{objects} objects"),
             }
         );
         if presentation.is_experimental() {
             log::warn!(
-                "DTS:X {presentation:?} is an experimental presentation: its channel identities \
-                 are inferred from a research corpus, not decoded metadata"
+                "DTS:X {presentation:?} is an experimental presentation: its feed identities rest \
+                 on corpus evidence; positions and bed folds come from the stream's metadata"
             );
+        }
+    }
+
+    /// The bed-fold plan for this frame, mirroring the realtime bridge: the
+    /// frame's metadata when readable, the standard -3 dB height fold when a
+    /// standard frame's matrix is unreadable, otherwise nothing is removed
+    /// and every extension feed is muted so nothing plays twice.
+    fn fold_plan(
+        &mut self,
+        presentation: Option<XPresentation>,
+        metadata: Option<&XMetadata>,
+    ) -> FoldPlan {
+        const STANDARD_HEIGHT_GAIN: f32 = 23_170.0 / 32_768.0;
+        match (presentation, metadata) {
+            (Some(_), Some(metadata)) => FoldPlan::from_metadata(metadata),
+            (Some(presentation), None) => {
+                if !self.warned_unreadable_metadata {
+                    self.warned_unreadable_metadata = true;
+                    log::warn!(
+                        "DTS:X {presentation:?} metadata unreadable: {}",
+                        if presentation == XPresentation::Height {
+                            "assuming the standard -3 dB height fold"
+                        } else {
+                            "keeping the bed as authored and muting the extension feeds"
+                        }
+                    );
+                }
+                if presentation == XPresentation::Height {
+                    FoldPlan::standard_heights(STANDARD_HEIGHT_GAIN)
+                } else {
+                    FoldPlan::all_unknown(presentation.feed_count())
+                }
+            }
+            (None, _) => FoldPlan::all_unknown(0),
         }
     }
 
@@ -311,24 +353,37 @@ impl DtsDecodeHandler {
         frame: &HdFrame,
         active: &[usize],
         layout: &DtsLayout,
+        plan: &FoldPlan,
         sample_count: usize,
         total_channels: usize,
     ) -> Result<()> {
         let Some(ref mut writer) = self.audio_writer else {
             return Ok(());
         };
+        // A feed whose bed fold is not stated stays in the bed and is muted
+        // on its own channel, exactly as the realtime bridge does.
+        let feed_at = |feed: usize, idx: usize| -> f32 {
+            if !plan.source_is_known(feed) {
+                return 0.0;
+            }
+            frame
+                .x_samples
+                .get(feed)
+                .and_then(|channel| channel.get(idx).copied())
+                .unwrap_or(0.0)
+        };
         let sample_at = |source: BedSource, idx: usize| -> f32 {
             match source {
                 BedSource::Speaker(position) => active
                     .get(position)
-                    .and_then(|&speaker| frame.samples[speaker].as_ref())
-                    .and_then(|channel| channel.get(idx).copied())
+                    .and_then(|&speaker| {
+                        frame.samples[speaker]
+                            .as_ref()
+                            .and_then(|channel| channel.get(idx).copied())
+                            .map(|value| plan.clean(speaker, value, idx, &frame.x_samples))
+                    })
                     .unwrap_or(0.0),
-                BedSource::Feed(feed) => frame
-                    .x_samples
-                    .get(feed)
-                    .and_then(|channel| channel.get(idx).copied())
-                    .unwrap_or(0.0),
+                BedSource::Feed(feed) => feed_at(feed, idx),
             }
         };
 
@@ -338,13 +393,7 @@ impl DtsDecodeHandler {
                 interleaved.push(float_to_i24(sample_at(source, sample_idx)));
             }
             for &feed in &layout.object_sources {
-                interleaved.push(float_to_i24(
-                    frame
-                        .x_samples
-                        .get(feed)
-                        .and_then(|channel| channel.get(sample_idx).copied())
-                        .unwrap_or(0.0),
-                ));
+                interleaved.push(float_to_i24(feed_at(feed, sample_idx)));
             }
         }
         writer.write_pcm_samples(&interleaved, total_channels)?;

--- a/harletty/src/cli/decode/dts_thread.rs
+++ b/harletty/src/cli/decode/dts_thread.rs
@@ -13,8 +13,10 @@
 use super::dts_handler::DtsFrameMessage;
 use crate::input::InputReader;
 use anyhow::Result;
-use dca::{HdDecoder, HdError, PcmDecoder, XPresentation, exss_has_xll, exss_substream_size,
-    parse_header};
+use dca::{
+    HdDecoder, HdError, PcmDecoder, XMetadata, XPresentation, exss_has_xll, exss_substream_size,
+    parse_header,
+};
 use indicatif::ProgressBar;
 use std::path::PathBuf;
 use std::sync::mpsc;
@@ -180,11 +182,16 @@ fn decode_one(
         match hd_decoder.decode(core, exss) {
             Ok(frame) => {
                 let presentation = XPresentation::detect(&frame);
+                // Unreadable metadata is reported by the handler once; the
+                // frame still plays with its bed as authored.
+                let metadata = presentation
+                    .and_then(|p| XMetadata::parse(&frame.x_payload, p.feed_count()).ok());
                 *frame_count += 1;
                 tick(pb);
                 let _ = tx.send(Ok(DtsFrameMessage::Hd {
                     frame: Box::new(frame),
                     presentation,
+                    metadata,
                 }));
                 return Ok(());
             }

--- a/harletty/src/dts_to_oamd.rs
+++ b/harletty/src/dts_to_oamd.rs
@@ -5,13 +5,12 @@
 //! and each consumer owns its own mapping. `dca::spatial` says which extension
 //! waveform sits where; this decides how that becomes a DAMF bed and objects.
 //!
-//! Only the DTS:X D3 presentation produces objects, and their positions are
-//! static (see [`dca::XPresentation::object_positions`]). Every other
-//! presentation is a fixed bed. When per-frame object coordinates are decoded
-//! from the extension blob, they slot into [`DtsLayout::objects`] without any
-//! change to this module's shape.
+//! The D1 and D3 presentations carry objects whose positions come from each
+//! frame's private metadata ([`dca::XMetadata`]); every other feed is a fixed
+//! channel that joins the bed. Which feeds are which is the presentation's
+//! call ([`dca::XPresentation`]), so both hosts agree.
 
-use dca::{BedChannel, SpatialChannel, XPresentation};
+use dca::{BedChannel, SourceRole, SpatialChannel, XMetadata, XPresentation};
 use truehd::structs::oamd::{
     BedAssignment, BlockUpdateInfo, MDUpdateInfo, ObjectAudioMetadataPayload, ObjectBasicInfo,
     ObjectData, ObjectElement, ObjectInfoBlock, ObjectRenderInfo, ProgramAssignment, SpeakerLabels,
@@ -43,8 +42,9 @@ pub struct DtsLayout {
     pub bed: Vec<SpeakerLabels>,
     /// Source of each entry in `bed`, same length and order.
     pub bed_sources: Vec<BedSource>,
-    /// Static object positions in DAMF space: `[x, y, z]`, each `-1.0..=1.0`,
-    /// x left-to-right, y back-to-front, z floor-to-ceiling.
+    /// This frame's object positions in DAMF space: `[x, y, z]`, each
+    /// `-1.0..=1.0`, x left-to-right, y back-to-front, z floor-to-ceiling.
+    /// An object whose position is unavailable sits at the origin.
     pub objects: Vec<[f64; 3]>,
     /// Extension feed index backing each entry in `objects`.
     pub object_sources: Vec<usize>,
@@ -52,7 +52,9 @@ pub struct DtsLayout {
 
 impl DtsLayout {
     /// Sort a `(speaker, source)` set into DAMF bed order and split it.
-    fn from_pairs(mut pairs: Vec<(SpeakerLabels, BedSource)>) -> (Vec<SpeakerLabels>, Vec<BedSource>) {
+    fn from_pairs(
+        mut pairs: Vec<(SpeakerLabels, BedSource)>,
+    ) -> (Vec<SpeakerLabels>, Vec<BedSource>) {
         pairs.sort_by_key(|(speaker, _)| *speaker as u8);
         pairs.into_iter().unzip()
     }
@@ -140,12 +142,16 @@ impl DtsLayout {
     }
 
     /// Layout of a DTS-HD frame: the lossless bed, extended by whatever spatial
-    /// presentation the frame carries.
+    /// presentation the frame carries, with object positions from `metadata`.
     ///
     /// `active_speakers` are the DCA speaker indices present in the frame, in
     /// ascending order — the same order the realtime pipeline emits channels
     /// in, so the ADM channel order matches the audio it describes.
-    pub fn from_hd(active_speakers: &[usize], presentation: Option<XPresentation>) -> Self {
+    pub fn from_hd(
+        active_speakers: &[usize],
+        presentation: Option<XPresentation>,
+        metadata: Option<&XMetadata>,
+    ) -> Self {
         let mut pairs: Vec<(SpeakerLabels, BedSource)> = active_speakers
             .iter()
             .enumerate()
@@ -157,18 +163,24 @@ impl DtsLayout {
         let mut object_sources = Vec::new();
 
         if let Some(p) = presentation {
-            match p.object_positions() {
-                // Object presentation: the feeds are objects, not bed channels.
-                Some(positions) => {
-                    objects.extend_from_slice(positions);
-                    object_sources.extend(0..positions.len());
-                }
-                // Fixed presentation: the feeds extend the bed.
-                None => pairs.extend(p.channels().iter().enumerate().filter_map(
-                    |(feed, channel)| {
+            // Fixed feeds extend the bed; object feeds become objects.
+            pairs.extend(
+                p.fixed_feeds()
+                    .zip(p.fixed_channels())
+                    .filter_map(|(feed, channel)| {
                         spatial_channel_to_speaker(*channel).map(|s| (s, BedSource::Feed(feed)))
-                    },
-                )),
+                    }),
+            );
+            for feed in p.object_feeds() {
+                let position = metadata
+                    .and_then(|metadata| metadata.source(feed))
+                    .and_then(|source| match source.role {
+                        SourceRole::Object { position, .. } => Some(position.to_adm_cartesian()),
+                        SourceRole::Height(_) => None,
+                    })
+                    .unwrap_or([0.0; 3]);
+                objects.push(position);
+                object_sources.push(feed);
             }
         }
 
@@ -274,11 +286,8 @@ mod tests {
         let layout = DtsLayout {
             bed: vec![SpeakerLabels::L, SpeakerLabels::R],
             bed_sources: vec![BedSource::Speaker(0), BedSource::Speaker(1)],
-            objects: XPresentation::ObjectsD3
-                .object_positions()
-                .unwrap()
-                .to_vec(),
-            object_sources: (0..8).collect(),
+            objects: vec![[-0.5, 0.75, 0.25], [0.5, -0.75, 0.0], [0.0, 0.0, 1.0]],
+            object_sources: (0..3).collect(),
         };
         let oamd = convert_dts(&layout);
         let read_back = oamd.get_damf_pos();
@@ -351,17 +360,15 @@ mod tests {
     fn rear_centre_is_dropped_from_the_bed() {
         assert_eq!(bed_channel_to_speaker(BedChannel::RearCenter), None);
         assert_eq!(hd_speaker_to_speaker(6), None);
-        let layout = DtsLayout::from_core(
-            &[BedChannel::FrontLeft, BedChannel::RearCenter],
-            false,
-        );
+        let layout = DtsLayout::from_core(&[BedChannel::FrontLeft, BedChannel::RearCenter], false);
         assert_eq!(layout.bed, vec![SpeakerLabels::L]);
     }
 
     #[test]
     fn standard_height_extends_the_bed_to_7_1_4() {
         // A full 7.1 lossless bed: every DCA speaker except rear centre.
-        let layout = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::Height));
+        let layout =
+            DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::Height), None);
         assert_eq!(
             layout.bed,
             vec![
@@ -380,15 +387,26 @@ mod tests {
             ],
             "7.1 bed plus the four height feeds, in DAMF order"
         );
-        assert!(layout.objects.is_empty(), "heights are channels, not objects");
+        assert!(
+            layout.objects.is_empty(),
+            "heights are channels, not objects"
+        );
     }
 
     /// D0 carries a top-front-centre feed that OAMD cannot name, so the bed
     /// comes out as 7.1.4 rather than 7.1.5.
     #[test]
     fn d0_drops_top_front_centre() {
-        let layout = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::FixedD0));
-        assert_eq!(XPresentation::FixedD0.feed_count(), 5, "D0 carries five feeds");
+        let layout = DtsLayout::from_hd(
+            &[0, 1, 2, 3, 4, 5, 7, 8],
+            Some(XPresentation::FixedD0),
+            None,
+        );
+        assert_eq!(
+            XPresentation::FixedD0.feed_count(),
+            5,
+            "D0 carries five feeds"
+        );
         assert_eq!(
             layout.bed.len(),
             8 + 4,
@@ -399,25 +417,105 @@ mod tests {
     }
 
     #[test]
-    fn d1_maps_its_wides_into_the_bed() {
-        let layout = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::FixedD1));
-        assert!(layout.bed.contains(&SpeakerLabels::Lw));
-        assert!(layout.bed.contains(&SpeakerLabels::Rw));
-        assert!(layout.objects.is_empty());
+    fn d1_is_two_objects_and_four_heights() {
+        let bed_only = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], None, None);
+        let layout = DtsLayout::from_hd(
+            &[0, 1, 2, 3, 4, 5, 7, 8],
+            Some(XPresentation::ObjectsD1),
+            None,
+        );
+        assert_eq!(
+            layout.bed.len(),
+            bed_only.bed.len() + 4,
+            "the four heights join the bed"
+        );
+        assert!(
+            layout.bed.contains(&SpeakerLabels::Lfh) && layout.bed.contains(&SpeakerLabels::Rrh)
+        );
+        assert!(
+            !layout.bed.contains(&SpeakerLabels::Lw),
+            "D1 has no wide channels"
+        );
+        assert_eq!(
+            layout.object_sources,
+            vec![0, 1],
+            "the first two feeds are the objects"
+        );
+        assert_eq!(
+            layout.objects,
+            vec![[0.0; 3]; 2],
+            "no metadata: objects sit at the origin"
+        );
+        let feeds: Vec<_> = layout
+            .bed_sources
+            .iter()
+            .filter_map(|s| match s {
+                BedSource::Feed(feed) => Some(*feed),
+                BedSource::Speaker(_) => None,
+            })
+            .collect();
+        assert_eq!(
+            feeds,
+            vec![2, 3, 4, 5],
+            "heights are feeds 2..6, in bed order"
+        );
     }
 
     #[test]
-    fn d3_becomes_objects_and_leaves_the_bed_alone() {
-        let bed_only = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], None);
-        let layout = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::ObjectsD3));
-        assert_eq!(layout.bed, bed_only.bed, "D3 feeds must not join the bed");
-        assert_eq!(layout.objects.len(), 8);
+    fn d3_is_four_objects_and_four_heights_positioned_by_metadata() {
+        use dca::{BedFold, SourceMetadata, SphericalPosition};
+
+        let object = |azimuth: i16, elevation: i16| SourceMetadata {
+            role: SourceRole::Object {
+                position: SphericalPosition {
+                    azimuth_half_degrees: azimuth,
+                    elevation_half_degrees: elevation,
+                    distance_64ths: 64,
+                },
+                centre_height_alternative: false,
+            },
+            fold: BedFold::Known([0.0; 8]),
+        };
+        let height = |channel: SpatialChannel| SourceMetadata {
+            role: SourceRole::Height(channel),
+            fold: BedFold::Known([0.0; 8]),
+        };
+        let metadata = XMetadata::from_sources(&[
+            object(-291, 57),
+            object(291, 54),
+            object(-300, 0),
+            object(300, 0),
+            height(SpatialChannel::TopFrontLeft),
+            height(SpatialChannel::TopFrontRight),
+            height(SpatialChannel::TopBackLeft),
+            height(SpatialChannel::TopBackRight),
+        ])
+        .unwrap();
+
+        let bed_only = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], None, None);
+        let layout = DtsLayout::from_hd(
+            &[0, 1, 2, 3, 4, 5, 7, 8],
+            Some(XPresentation::ObjectsD3),
+            Some(&metadata),
+        );
+        assert_eq!(layout.bed.len(), bed_only.bed.len() + 4);
+        assert_eq!(layout.object_sources, vec![0, 1, 2, 3]);
+        assert_eq!(layout.objects.len(), 4);
+        // Object 0 is rear-left and raised; object 3 is rear-right at ear level.
+        assert!(
+            layout.objects[0][0] < 0.0 && layout.objects[0][1] < 0.0 && layout.objects[0][2] > 0.0
+        );
+        assert!(layout.objects[3][0] > 0.0 && layout.objects[3][1] < 0.0);
+        assert!(layout.objects[3][2].abs() < 1e-9);
 
         let oamd = convert_dts(&layout);
-        assert_eq!(oamd.program_assignment.num_dynamic_objects, 8);
-        assert_eq!(oamd.object_count, 8);
-        let element = oamd.object_element.expect("D3 must emit an object element");
-        assert_eq!(element.object_data.len(), 8);
+        assert_eq!(oamd.program_assignment.num_dynamic_objects, 4);
+        assert_eq!(oamd.object_count, 4);
+        let element = oamd
+            .object_element
+            .as_ref()
+            .expect("D3 must emit an object element");
+        assert_eq!(element.object_data.len(), 4);
         assert!(
             element
                 .object_data
@@ -425,11 +523,17 @@ mod tests {
                 .all(|blocks| blocks.len() == 1 && !blocks[0].b_object_in_bed_or_isf),
             "each object gets one block and none of them are bed channels"
         );
+        let read_back = oamd.get_damf_pos();
+        for (index, expected) in layout.objects.iter().enumerate() {
+            for axis in 0..3 {
+                assert!((read_back[index][0][axis] - expected[axis]).abs() < 1e-9);
+            }
+        }
     }
 
     #[test]
     fn a_frame_with_no_presentation_is_just_its_bed() {
-        let layout = DtsLayout::from_hd(&[1, 2], None);
+        let layout = DtsLayout::from_hd(&[1, 2], None, None);
         assert_eq!(layout.bed, vec![SpeakerLabels::L, SpeakerLabels::R]);
         assert!(layout.objects.is_empty());
     }
@@ -486,7 +590,8 @@ mod tests {
     /// sorted in among the speakers, not appended.
     #[test]
     fn height_feeds_sort_into_the_bed_rather_than_trailing_it() {
-        let layout = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::Height));
+        let layout =
+            DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::Height), None);
         assert_eq!(layout.bed.len(), layout.bed_sources.len());
 
         let mut sorted = layout.bed.clone();


### PR DESCRIPTION
Stacked on #51 (research checkpoint); the diff against `feat/private-navigation` is this change alone.

Every DTS:X extension waveform was mixed into the backward-compatible 7.1 bed by the encoder, at gains the stream's private metadata states. Until now the bridge removed a fixed −3 dB for the standard heights, applied guessed folds to D0/D1 (measured on audio, and wrong: D0 folds its heights at unity), and none at all to D3, whose eight feeds were rendered on top of a bed that still contained them. This PR reads the fold from the stream and removes it, in both hosts.

What changes:
- `dca::XMetadata` (new, `dca/src/dcadec/xmeta.rs`): a realtime reader of the private prefix — the standard type-2 matrix, the alternate type-241 object records (positions, sparse reference rows, the D0 centre-height alternative) and the type-3 height rows. Bounded bit reader, no allocation, no panic, every unfamiliar form is an error. Gain codes map through the decoder's downmix table at index `4·code − 3` (verified at 46, 55, 58, 61; applied to 1..=61).
- `dca::FoldPlan`: the per-frame subtraction table built from that metadata, applied per sample by the hosts. A waveform whose fold is not stated (mode-0 object) is `Unknown`: it stays in the bed and its own channel is muted, so nothing plays twice.
- `dca::XPresentation`: feeds split into objects and fixed channels as the audio established (last four feeds = TFL/TFR/TBL/TBR in every alternate profile; D1 = 2 objects + 4 heights, D3 = 4 objects + 4 heights, D0 = centre-height object as fixed TFC + 4 heights). The static D3 positions and the D1 "wide" identities are gone; positions come from the stream per frame.
- Bridge (`dts_pipeline.rs`): bed = decoded bed minus every stated contribution; fixed heights as labeled channels; D1/D3 objects as object channels (ids 10+feed, names `X<feed>`) with transmitted positions converted to ADM Cartesian exactly as the renderer converts polar events. Shape is latched per stream (composite bed + silent feeds on a dropout, no renegotiation); a frame whose metadata does not parse reuses the last readable one, and a standard frame without any falls back to the bundled −3 dB (`dts-fold.yaml`, now standard-only). `has_objects` is true for D1 and D3.
- CLI (`harletty decode`): same plan applied to the exported bed, same feed split, per-frame object positions in the DAMF payload; the mid-stream layout warning compares shape, not positions.

Evidence for the reading is in `docs/private-metadata-probe.md` (#51). `docs/dtsx-d1-wide-audition.md` is marked superseded.

Local validation (corpus present, every gated test ran):
- `cargo build --all-targets` with `-D warnings`; full suite green (count in the last commit message). New: 12 reader unit tests with synthetic payloads (field changes, every truncation and single-bit corruption rejected), 4 corpus-gated reader checks (`dca/tests/xmeta_corpus.rs`: standard 559 frames at code 55; D0 955 frames at unity with the centre-height object; D1 599 mode-0 frames; D3 724 frames with four object rows), 9 bridge presentation tests (standard/D0/D1/D3, fallback, dropout, unreadable metadata), CLI layout tests.
- Bridge corpus test: D0 → 13 fixed channels, D1 → 8 + 4 heights + 2 objects, D3 → 8 + 4 heights + 4 objects with positions on every object.
- Lossless bed decode unchanged (bit-exact tests untouched and green).

Not done, deliberately:
- No A/B listen yet. This is a presentation change on every DTS:X profile; per the working agreement it must not be merged without one.
- Mode-0 objects (the shorter D1 form, one input in the corpus) are folded by a panning law the stream does not state; they are left in the bed and muted on their object channel until that law is recovered.
- The gain-code table relation is applied beyond the four verified points; codes seen in the corpus rows go down to 11 (−25 dB), where an error would be inaudible, but it is an extrapolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
