### PR TITLE
feat(dts): decode the object-only alternate variant on a 5.1 bed

### DIFF
--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -1167,6 +1167,55 @@ mod raw_transport_tests {
 }
 
 #[cfg(test)]
+mod dts_object_only_tests {
+    use super::*;
+    use abi_stable::std_types::RSlice;
+    use bridge_api::RInputTransport;
+
+    /// The object-only variant on a 5.1 bed presents six labeled bed channels
+    /// plus one object channel, with a position on the object.
+    #[test]
+    fn object_only_stream_presents_5_1_plus_one_object() {
+        let Some(path) = std::env::var("HARLETTY_ALT_51_CORPUS")
+            .ok()
+            .filter(|p| std::path::Path::new(p).is_file())
+        else {
+            eprintln!("skipping: HARLETTY_ALT_51_CORPUS is not set to a readable file");
+            return;
+        };
+        let bytes = std::fs::read(&path).expect("read corpus");
+        let bytes = &bytes[..bytes.len().min(4_000_000)];
+        let mut bridge = AtmosBridge::new(false);
+        assert!(bridge.configure("input_codec".into(), "dts".into()));
+        let result = bridge.push_packet(RSlice::from_slice(bytes), RInputTransport::Raw, 0);
+        assert!(result.error_message.is_empty(), "{}", result.error_message);
+        assert!(
+            bridge.has_objects(),
+            "the object-only variant declares its object"
+        );
+        use bridge_api::RChannelLabel::*;
+        let frame = result
+            .frames
+            .iter()
+            .find(|frame| frame.metadata.iter().any(|m| m.name_updates.len() == 1))
+            .expect("no object declaration");
+        assert_eq!(frame.channel_count, 7);
+        assert_eq!(
+            frame.channel_labels.as_slice(),
+            &[C, L, R, Ls, Rs, LFE, Object]
+        );
+        let metadata = frame
+            .metadata
+            .iter()
+            .find(|m| m.name_updates.len() == 1)
+            .unwrap();
+        assert_eq!(metadata.events.len(), 1);
+        assert!(metadata.events[0].has_pos && metadata.events[0].pos[2] > 0.0);
+        assert!(result.frames.len() > 100, "corpus was not exercised");
+    }
+}
+
+#[cfg(test)]
 mod dts_object_motion_tests {
     use super::*;
     use abi_stable::std_types::RSlice;

--- a/bridge/src/dts_pipeline.rs
+++ b/bridge/src/dts_pipeline.rs
@@ -1116,6 +1116,65 @@ mod tests {
     }
 
     #[test]
+    fn object_only_variant_presents_a_5_1_bed_plus_one_object() {
+        let object_pcm = vec![0.20, -0.10];
+        let dry_c = vec![0.05, -0.05];
+        let dry_l = vec![0.07, -0.02];
+        let code58 = gain_code_linear(58).unwrap();
+        let code46 = gain_code_linear(46).unwrap();
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        samples[0] = Some(folded(&dry_c, &[(&object_pcm, code58)]));
+        samples[1] = Some(folded(&dry_l, &[(&object_pcm, code46)]));
+        samples[2] = Some(vec![0.03, -0.03]);
+        samples[3] = Some(vec![0.04, -0.04]);
+        samples[4] = Some(vec![0.06, -0.06]);
+        samples[5] = Some(vec![0.08, -0.08]);
+        let mut hd = hd_frame(samples, vec![object_pcm.clone()]);
+        hd.x_present = false;
+        hd.x_imax = true;
+
+        let mut columns = [0.0; 8];
+        columns[0] = code58;
+        columns[1] = code46;
+        columns[2] = code46;
+        let source = object(0, 51, BedFold::Known(columns));
+        let mut state = state_with(XMetadata::from_sources_on(
+            &[source],
+            dca::REFERENCE_MASK_5_1,
+        ));
+        let (frame, emitted) = build(&hd, &mut state);
+
+        assert!(emitted, "the object is an object channel");
+        assert_eq!(state.locked, Some(XPresentation::ObjectOnly));
+        assert_eq!(frame.channel_count, 7);
+        assert_eq!(
+            frame.channel_labels.as_slice(),
+            &[
+                RChannelLabel::C,
+                RChannelLabel::L,
+                RChannelLabel::R,
+                RChannelLabel::Ls,
+                RChannelLabel::Rs,
+                RChannelLabel::LFE,
+                RChannelLabel::Object,
+            ]
+        );
+        for sample in 0..SAMPLE_COUNT {
+            let row = &frame.pcm[sample * 7..(sample + 1) * 7];
+            assert_pcm_close(row[0], dry_c[sample]);
+            assert_pcm_close(row[1], dry_l[sample]);
+            assert_pcm_close(row[3], hd.samples[3].as_ref().unwrap()[sample]);
+            assert_pcm_close(row[6], object_pcm[sample]);
+        }
+        assert_eq!(frame.metadata.len(), 1);
+        let metadata = &frame.metadata[0];
+        assert_eq!(metadata.object_channels.len(), 1);
+        assert_eq!(metadata.object_channels[0].channel, 6);
+        assert_eq!(metadata.events.len(), 1);
+        assert!(metadata.events[0].pos[2] > 0.0, "the object is raised");
+    }
+
+    #[test]
     fn alternate_frame_without_any_readable_metadata_mutes_its_feeds() {
         let extension: Vec<Vec<f32>> = (0..8).map(|_| vec![0.1; SAMPLE_COUNT]).collect();
         let composite_left = vec![0.25, -0.25];

--- a/damf/src/damf.rs
+++ b/damf/src/damf.rs
@@ -134,6 +134,10 @@ pub enum SourceCodec {
     /// Experimental eight-feed object presentation (D3).
     #[serde(rename = "DTS:X-7.1+8")]
     DtsX71Plus8,
+    /// Object-only presentation on a 5.1 bed: one object waveform, no height
+    /// quartet (the D0 marker with a 5.1 reference layout).
+    #[serde(rename = "DTS:X-5.1+1")]
+    DtsX51Plus1,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/dca/src/dcadec/xll.rs
+++ b/dca/src/dcadec/xll.rs
@@ -27,8 +27,20 @@ const DCA_SYNCWORD_XLL: u32 = 0x41A2_9547;
 const XLL_X_ALT_FRAME_SAMPLES: usize = 512;
 const XLL_X_ALT_MAX_SEGMENTS: usize = 8;
 const XLL_X_ALT_MAX_INTERSTITIAL: usize = 20;
+/// Tail of the marker that ends the CRC-protected prefix (outer) and the
+/// first channel set (inner). The byte before it is a mask of the channel
+/// sets that follow: `0x03` when the object set and the height quartet both
+/// follow the outer marker, `0x01` when only the object set does (the
+/// object-only variant on a 5.1 bed), `0x02` before the quartet.
+pub(crate) const XLL_X_ALT_MARKER_TAIL: [u8; 5] = [0x34, 0x38, 0x8c, 0x4f, 0x00];
+pub(crate) const XLL_X_ALT_SET_FIRST: u8 = 0x01;
+pub(crate) const XLL_X_ALT_SET_SECOND: u8 = 0x02;
+/// Outer marker of a payload carrying both channel sets (test fixtures).
+#[cfg(test)]
 pub(crate) const XLL_X_ALT_OUTER_SUFFIX: [u8; 6] = [0x03, 0x34, 0x38, 0x8c, 0x4f, 0x00];
 const XLL_X_ALT_INNER_SUFFIX: [u8; 6] = [0x02, 0x34, 0x38, 0x8c, 0x4f, 0x00];
+/// Shortest CRC-protected prefix seen: the object-only variant's 20 bytes.
+pub(crate) const XLL_X_ALT_MIN_PREFIX: usize = 16;
 const FF_DCA_DMIXTABLE_OFFSET: usize = 242 - 201; // SIZE - INV_SIZE
 const FF_DCA_DMIXTABLE_SIZE: usize = 242;
 const FF_DCA_INV_DMIXTABLE_SIZE: usize = 201;
@@ -62,9 +74,11 @@ enum AlternateProfile {
     D3,
 }
 
+#[derive(Clone, Copy)]
 struct AlternateLayout {
-    headers: [AlternateHeader; 2],
-    geometries: [AlternateGeometry; 2],
+    first: (AlternateHeader, AlternateGeometry),
+    /// The height quartet, absent from the object-only variant.
+    second: Option<(AlternateHeader, AlternateGeometry)>,
 }
 
 /// Allocation-free kind string for a failed XLL-X decode (the audio path
@@ -229,34 +243,45 @@ fn alternate_inner_control(payload: &[u8], second_header_offset: usize) -> R<&[u
     Ok(control)
 }
 
-fn alternate_outer_layout(payload: &[u8], profile: AlternateProfile) -> R<(usize, usize, usize)> {
+/// The CRC-protected prefix of an alternate payload: the bytes before an
+/// outer marker whose CRC16 is zero. Returns its length and the mask of the
+/// channel sets that follow. Shared with the metadata reader so both agree
+/// on the boundary.
+pub(crate) fn alternate_protected_prefix(payload: &[u8]) -> R<(usize, u8)> {
     const MAX_PREFIX_BYTES: usize = 96;
-
-    let minimum_prefix = match profile {
-        AlternateProfile::D0 => 48,
-        AlternateProfile::D1 | AlternateProfile::D3 => 49,
-    };
     let search_end = payload.len().min(MAX_PREFIX_BYTES);
-    let mut prefix_end = None;
-    for candidate in minimum_prefix..search_end {
-        let Some(suffix_end) = candidate.checked_add(XLL_X_ALT_OUTER_SUFFIX.len()) else {
+    let mut found = None;
+    for candidate in XLL_X_ALT_MIN_PREFIX..search_end {
+        let Some(tail_end) = candidate.checked_add(1 + XLL_X_ALT_MARKER_TAIL.len()) else {
             break;
         };
-        if suffix_end > payload.len() {
+        if tail_end > payload.len() {
             break;
         }
-        if payload.get(candidate..suffix_end) != Some(&XLL_X_ALT_OUTER_SUFFIX)
+        let set_mask = payload[candidate];
+        if payload[candidate + 1..tail_end] != XLL_X_ALT_MARKER_TAIL
+            || set_mask & !(XLL_X_ALT_SET_FIRST | XLL_X_ALT_SET_SECOND) != 0
+            || set_mask & XLL_X_ALT_SET_FIRST == 0
             || crc16_ccitt(&payload[..candidate]) != 0
         {
             continue;
         }
-        if prefix_end.replace(candidate).is_some() {
+        if found.replace((candidate, set_mask)).is_some() {
             return Err(XllError::Invalid("ambiguous alternate XLL prefix"));
         }
     }
-    let prefix_end = prefix_end.ok_or(XllError::Invalid("alternate XLL prefix CRC"))?;
+    found.ok_or(XllError::Invalid("alternate XLL prefix CRC"))
+}
+
+/// Control start, control size, second-header offset bias and channel-set
+/// mask of an alternate payload.
+fn alternate_outer_layout(
+    payload: &[u8],
+    profile: AlternateProfile,
+) -> R<(usize, usize, usize, u8)> {
+    let (prefix_end, set_mask) = alternate_protected_prefix(payload)?;
     let control_start = prefix_end
-        .checked_add(XLL_X_ALT_OUTER_SUFFIX.len())
+        .checked_add(1 + XLL_X_ALT_MARKER_TAIL.len())
         .ok_or(XllError::Invalid("alternate XLL control offset overflow"))?;
     let control_size = match payload.get(control_start) {
         Some(0xb2) => 7,
@@ -269,7 +294,7 @@ fn alternate_outer_layout(payload: &[u8], profile: AlternateProfile) -> R<(usize
             });
         }
     };
-    Ok((control_start, control_size, control_start + 12))
+    Ok((control_start, control_size, control_start + 12, set_mask))
 }
 
 fn alternate_layout(payload: &[u8]) -> R<AlternateLayout> {
@@ -284,7 +309,8 @@ fn alternate_layout(payload: &[u8]) -> R<AlternateLayout> {
         DCA_SYNCWORD_XLL_X_ALT_D3 => AlternateProfile::D3,
         _ => return Err(XllError::Invalid("unknown alternate XLL profile")),
     };
-    let (control_start, control_size, offset_bias) = alternate_outer_layout(payload, profile)?;
+    let (control_start, control_size, offset_bias, set_mask) =
+        alternate_outer_layout(payload, profile)?;
     let first_header_offset = control_start
         .checked_add(control_size)
         .ok_or(XllError::Invalid("alternate XLL header offset overflow"))?;
@@ -309,16 +335,23 @@ fn alternate_layout(payload: &[u8]) -> R<AlternateLayout> {
             "unexpected alternate XLL first channel count",
         ));
     }
-    let second_header = alternate_second_header(payload, outer_control, common_bit, offset_bias)?;
-    let inner_control = alternate_inner_control(payload, second_header.offset)?;
-    let second_geometry_start = match profile {
-        AlternateProfile::D0 => 18,
-        AlternateProfile::D1 | AlternateProfile::D3 => 19,
+    let second = if set_mask & XLL_X_ALT_SET_SECOND != 0 {
+        let second_header =
+            alternate_second_header(payload, outer_control, common_bit, offset_bias)?;
+        let inner_control = alternate_inner_control(payload, second_header.offset)?;
+        let second_geometry_start = match profile {
+            AlternateProfile::D0 => 18,
+            AlternateProfile::D1 | AlternateProfile::D3 => 19,
+        };
+        let (_, second_geometry) =
+            alternate_unique_geometry(inner_control, second_geometry_start, 26)?;
+        Some((second_header, second_geometry))
+    } else {
+        None
     };
-    let (_, second_geometry) = alternate_unique_geometry(inner_control, second_geometry_start, 26)?;
     Ok(AlternateLayout {
-        headers: [first_header, second_header],
-        geometries: [first_geometry, second_geometry],
+        first: (first_header, first_geometry),
+        second,
     })
 }
 
@@ -839,19 +872,25 @@ impl XllDecoder {
     /// set inherits the lossless bed's common XLL geometry.
     fn try_decode_alternate_x_extension_audio(&mut self, payload: &[u8]) -> R<()> {
         let layout = alternate_layout(payload)?;
+        let first_boundary = layout
+            .second
+            .map_or(payload.len(), |(header, _)| header.offset);
         let first = self.decode_alternate_channel_set(
             payload,
-            layout.headers[0],
-            layout.geometries[0],
-            layout.headers[1].offset,
+            layout.first.0,
+            layout.first.1,
+            first_boundary,
         )?;
-        let second = self.decode_alternate_channel_set(
-            payload,
-            layout.headers[1],
-            layout.geometries[1],
-            payload.len(),
-        )?;
-        if first.0.pcm_bit_res != second.0.pcm_bit_res {
+        let second = match layout.second {
+            Some((header, geometry)) => {
+                Some(self.decode_alternate_channel_set(payload, header, geometry, payload.len())?)
+            }
+            None => None,
+        };
+        if second
+            .as_ref()
+            .is_some_and(|second| first.0.pcm_bit_res != second.0.pcm_bit_res)
+        {
             return Err(XllError::Unsupported("mixed alternate XLL PCM resolutions"));
         }
         let pcm_bit_res = first.0.pcm_bit_res;
@@ -861,18 +900,20 @@ impl XllDecoder {
         let scale = 1i32
             .checked_shl(shift as u32)
             .ok_or(XllError::Invalid("alternate XLL PCM scale"))?;
+        let bits_consumed = second.as_ref().map_or(first.1, |second| second.1);
+        let second_channels = second.as_ref().map_or(0, |second| second.0.nchannels);
 
         self.x_output.clear();
-        self.x_output
-            .reserve(first.0.nchannels + second.0.nchannels);
-        for mut samples in first.0.band.msb.into_iter().chain(second.0.band.msb) {
+        self.x_output.reserve(first.0.nchannels + second_channels);
+        let second_samples = second.map(|second| second.0.band.msb).unwrap_or_default();
+        for mut samples in first.0.band.msb.into_iter().chain(second_samples) {
             for sample in &mut samples {
                 *sample = clip23(sample.wrapping_mul(scale));
             }
             self.x_output.push(samples);
         }
         self.x_pcm_bit_res = pcm_bit_res;
-        self.x_bits_consumed = second.1;
+        self.x_bits_consumed = bits_consumed;
         // This legacy diagnostic describes the single standard-profile header;
         // do not overload it with one of the alternate profile's two headers.
         self.x_header_tail_bits = 0;
@@ -1966,8 +2007,7 @@ mod alt_extension_tests {
         }
         let layout = alternate_layout(payload).ok()?;
         Some(
-            layout
-                .headers
+            [layout.first.0, layout.second?.0]
                 .map(|header| (header.offset, header.size, header.channels)),
         )
     }
@@ -1978,8 +2018,7 @@ mod alt_extension_tests {
         }
         let layout = alternate_layout(payload).ok()?;
         Some(
-            layout
-                .headers
+            [layout.first.0, layout.second?.0]
                 .map(|header| (header.offset, header.size, header.channels)),
         )
     }
@@ -2071,7 +2110,8 @@ mod alt_extension_tests {
                 Ok((
                     prefix.len() + XLL_X_ALT_OUTER_SUFFIX.len(),
                     7,
-                    prefix.len() + 18
+                    prefix.len() + 18,
+                    0x03
                 ))
             );
         }
@@ -2094,7 +2134,7 @@ mod alt_extension_tests {
         payload.push(0xc6);
         assert_eq!(
             alternate_outer_layout(&payload, AlternateProfile::D3),
-            Ok((79, 8, 91))
+            Ok((79, 8, 91, 0x03))
         );
     }
 
@@ -2149,10 +2189,11 @@ mod alt_extension_tests {
 
         for byte_offset in [
             48,
-            layout.headers[0].offset,
-            layout.headers[0].offset + layout.headers[0].size,
-            layout.headers[1].offset,
-            layout.headers[1].offset + layout.headers[1].size,
+            layout.first.0.offset,
+            layout.first.0.offset + layout.first.0.size,
+            layout.second.expect("height quartet").0.offset,
+            layout.second.expect("height quartet").0.offset
+                + layout.second.expect("height quartet").0.size,
         ] {
             let mut corrupt = payload.clone();
             corrupt[byte_offset] ^= 1;
@@ -2517,18 +2558,10 @@ mod alt_extension_tests {
             extension_payload_from_env(D1_CORPUS_PATH_ENV, 192).expect("adjacent corpus frame");
 
         let d1_candidates = immediate_navi_candidates(&d1, 764, 16, d1.len(), 16, None);
-        let d1_active_candidates = immediate_navi_candidates(
-            &d1_active,
-            1300,
-            18,
-            d1_active.len(),
-            16,
-            None,
-        );
+        let d1_active_candidates =
+            immediate_navi_candidates(&d1_active, 1300, 18, d1_active.len(), 16, None);
         eprintln!("D1 corpus terminal-quartet NAVI: {d1_candidates:?}");
-        eprintln!(
-            "D1 corpus active terminal-quartet NAVI: {d1_active_candidates:?}"
-        );
+        eprintln!("D1 corpus active terminal-quartet NAVI: {d1_active_candidates:?}");
         assert!(!d1_candidates.is_empty());
         assert!(!d1_active_candidates.is_empty());
     }
@@ -2573,11 +2606,8 @@ mod alt_extension_tests {
 
     #[test]
     fn alternate_d1_prefix_mode_decodes_active_channel_set_run() {
-        let Some((payloads, runtime_results)) = extension_payloads_from_env(
-            D1_CORPUS_PATH_ENV,
-            9_000,
-            64 * 1024 * 1024,
-        )
+        let Some((payloads, runtime_results)) =
+            extension_payloads_from_env(D1_CORPUS_PATH_ENV, 9_000, 64 * 1024 * 1024)
         else {
             eprintln!("skipping: alternate-extension corpus not present");
             return;
@@ -2731,7 +2761,13 @@ mod alt_extension_tests {
         };
         assert_eq!(payload.get(55), Some(&0xc3));
         let layout = alternate_layout(&payload).expect("valid D1 c3 layout");
-        assert_eq!(layout.headers.map(|header| header.channels), [2, 4]);
+        assert_eq!(
+            [
+                layout.first.0.channels,
+                layout.second.expect("height quartet").0.channels
+            ],
+            [2, 4]
+        );
 
         let mut decoder = XllDecoder::new();
         decoder
@@ -2748,11 +2784,8 @@ mod alt_extension_tests {
 
     #[test]
     fn alternate_d0_prefix_mode_decodes_active_channel_set_run() {
-        let Some((payloads, runtime_results)) = extension_payloads_from_env(
-            D0_CORPUS_PATH_ENV,
-            9_000,
-            64 * 1024 * 1024,
-        )
+        let Some((payloads, runtime_results)) =
+            extension_payloads_from_env(D0_CORPUS_PATH_ENV, 9_000, 64 * 1024 * 1024)
         else {
             eprintln!("skipping: alternate-extension corpus not present");
             return;

--- a/dca/src/dcadec/xmeta.rs
+++ b/dca/src/dcadec/xmeta.rs
@@ -28,7 +28,7 @@
 use crate::dcadec::tables::DMIXTABLE;
 use crate::dcadec::xll::{
     DCA_SYNCWORD_XLL_X, DCA_SYNCWORD_XLL_X_ALT_D0, DCA_SYNCWORD_XLL_X_ALT_D1,
-    DCA_SYNCWORD_XLL_X_ALT_D3, XLL_X_ALT_OUTER_SUFFIX, crc16_ccitt,
+    DCA_SYNCWORD_XLL_X_ALT_D3, alternate_protected_prefix, crc16_ccitt,
 };
 use crate::spatial::SpatialChannel;
 
@@ -37,47 +37,100 @@ use crate::spatial::SpatialChannel;
 pub const MAX_SOURCES: usize = 8;
 /// Channels of the compatible reference layout the folds are expressed over.
 pub const REFERENCE_CHANNELS: usize = 8;
-/// DCA speaker index behind each reference-layout column. The reference mask
-/// `0x084b` lists, in bit order, C, L/R, LFE, Lsr/Rsr and Lss/Rss.
+/// DCA speaker index behind each column of the 7.1 reference layout
+/// (`0x084b`: C, L/R, LFE, Lsr/Rsr and Lss/Rss in bit order).
 pub const REFERENCE_SPEAKERS: [usize; REFERENCE_CHANNELS] = [0, 1, 2, 5, 7, 8, 3, 4];
+/// The 7.1 reference mask every seven-channel profile uses.
+pub const REFERENCE_MASK_7_1: u32 = 0x084b;
+/// The 5.1 reference mask of the object-only variant (C, L/R, Ls/Rs, LFE).
+pub const REFERENCE_MASK_5_1: u32 = 0x000f;
+
+/// DCA speaker index behind each column of a reference mask, in mask bit
+/// order, and the column count. A mask carrying an unknown speaker bit, or
+/// both surround pairs that map to the same DCA indices, has no layout.
+fn reference_speakers(mask: u32) -> Option<([u8; REFERENCE_CHANNELS], usize)> {
+    if mask & (1 << 2) != 0 && mask & (1 << 11) != 0 {
+        return None;
+    }
+    let mut speakers = [0u8; REFERENCE_CHANNELS];
+    let mut count = 0;
+    for bit in 0..16 {
+        if mask & (1 << bit) == 0 {
+            continue;
+        }
+        let members: &[u8] = match bit {
+            0 => &[0],
+            1 => &[1, 2],
+            2 => &[3, 4],
+            3 => &[5],
+            4 => &[6],
+            6 => &[7, 8],
+            11 => &[3, 4],
+            _ => return None,
+        };
+        for &member in members {
+            if count == REFERENCE_CHANNELS {
+                return None;
+            }
+            speakers[count] = member;
+            count += 1;
+        }
+    }
+    (count > 0).then_some((speakers, count))
+}
+
+/// Columns of a full output layout (reference mask plus the height mask):
+/// for each column, the reference column it stands for, or the height feed
+/// it names. Height columns come from bits 5 (Lh/Rh) and 15 (Lhr/Rhr).
+fn full_columns(
+    output_mask: u32,
+) -> Option<([Result<usize, SpatialChannel>; MAX_FULL_COLUMNS], usize)> {
+    let mut columns = [Ok(0usize); MAX_FULL_COLUMNS];
+    let mut count = 0;
+    let mut reference = 0;
+    for bit in 0..16 {
+        if output_mask & (1 << bit) == 0 {
+            continue;
+        }
+        let entries: [Result<usize, SpatialChannel>; 2] = match bit {
+            5 => [
+                Err(SpatialChannel::TopFrontLeft),
+                Err(SpatialChannel::TopFrontRight),
+            ],
+            15 => [
+                Err(SpatialChannel::TopBackLeft),
+                Err(SpatialChannel::TopBackRight),
+            ],
+            0 | 3 | 4 => {
+                reference += 1;
+                [Ok(reference - 1), Ok(usize::MAX)]
+            }
+            1 | 2 | 6 | 11 => {
+                reference += 2;
+                [Ok(reference - 2), Ok(reference - 1)]
+            }
+            _ => return None,
+        };
+        for entry in entries {
+            if entry == Ok(usize::MAX) {
+                continue;
+            }
+            if count == MAX_FULL_COLUMNS {
+                return None;
+            }
+            columns[count] = entry;
+            count += 1;
+        }
+    }
+    Some((columns, count))
+}
 /// DCA speaker indices a [`FoldPlan`] can address.
 pub const FOLD_SPEAKERS: usize = 16;
 
-const REFERENCE_MASK: u32 = 0x084b;
-const FULL_MASK: u32 = 0x886b;
 const HEIGHT_MASK: u32 = 0x8020;
-const FULL_COLUMNS: usize = 12;
-/// Reference column of each column of the full 12-channel layout (`0x886b`:
-/// C, L, R, LFE, Lh, Rh, Lsr, Rsr, Lss, Rss, Lhr, Rhr), `None` for a height.
-const FULL_TO_REFERENCE: [Option<usize>; FULL_COLUMNS] = [
-    Some(0),
-    Some(1),
-    Some(2),
-    Some(3),
-    None,
-    None,
-    Some(4),
-    Some(5),
-    Some(6),
-    Some(7),
-    None,
-    None,
-];
-/// Height speaker of each height column of the full layout.
-const FULL_TO_HEIGHT: [Option<SpatialChannel>; FULL_COLUMNS] = [
-    None,
-    None,
-    None,
-    None,
-    Some(SpatialChannel::TopFrontLeft),
-    Some(SpatialChannel::TopFrontRight),
-    None,
-    None,
-    None,
-    None,
-    Some(SpatialChannel::TopBackLeft),
-    Some(SpatialChannel::TopBackRight),
-];
+/// Columns of the widest full layout: eight reference channels plus the
+/// four heights.
+const MAX_FULL_COLUMNS: usize = REFERENCE_CHANNELS + 4;
 /// The standard profile's height mask `0x8020` lists Lh/Rh then Lhr/Rhr.
 const STANDARD_HEIGHTS: [SpatialChannel; 4] = [
     SpatialChannel::TopFrontLeft,
@@ -88,7 +141,6 @@ const STANDARD_HEIGHTS: [SpatialChannel; 4] = [
 const FIXED_HEIGHT_COUNT: usize = 4;
 /// Unread type-3 control word; every corpus stream carries this value.
 const TYPE3_CONTROL: u32 = 0x3fa;
-const MAX_PREFIX: usize = 96;
 const UNITY_CODE: u32 = 61;
 const CENTRE_HEIGHT_MASK: u32 = 0x80;
 
@@ -240,11 +292,14 @@ pub struct SourceMetadata {
     pub fold: BedFold,
 }
 
-/// One frame's metadata for every extension waveform, in waveform order.
+/// One frame's metadata for every extension waveform, in waveform order,
+/// with the reference layout its folds are expressed over.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XMetadata {
     sources: [Option<SourceMetadata>; MAX_SOURCES],
     count: usize,
+    reference_speakers: [u8; REFERENCE_CHANNELS],
+    reference_count: usize,
 }
 
 impl XMetadata {
@@ -265,12 +320,19 @@ impl XMetadata {
         }
     }
 
-    /// Assemble metadata from already-decoded sources (consumers' tests and
-    /// fallbacks). `None` when there are more than [`MAX_SOURCES`].
+    /// Assemble metadata from already-decoded sources over the 7.1 reference
+    /// layout (consumers' tests and fallbacks). `None` when there are more
+    /// than [`MAX_SOURCES`].
     pub fn from_sources(sources: &[SourceMetadata]) -> Option<Self> {
+        Self::from_sources_on(sources, REFERENCE_MASK_7_1)
+    }
+
+    /// [`Self::from_sources`] over the reference layout `reference_mask`.
+    pub fn from_sources_on(sources: &[SourceMetadata], reference_mask: u32) -> Option<Self> {
         if sources.len() > MAX_SOURCES {
             return None;
         }
+        let (reference_speakers, reference_count) = reference_speakers(reference_mask)?;
         let mut stored = [None; MAX_SOURCES];
         for (slot, source) in stored.iter_mut().zip(sources) {
             *slot = Some(*source);
@@ -278,11 +340,18 @@ impl XMetadata {
         Some(Self {
             sources: stored,
             count: sources.len(),
+            reference_speakers,
+            reference_count,
         })
     }
 
     pub fn source_count(&self) -> usize {
         self.count
+    }
+
+    /// DCA speaker index behind each fold column.
+    pub fn reference_speakers(&self) -> &[u8] {
+        &self.reference_speakers[..self.reference_count]
     }
 
     pub fn source(&self, index: usize) -> Option<&SourceMetadata> {
@@ -339,9 +408,9 @@ impl FoldPlan {
         for (feed, source) in metadata.sources().enumerate() {
             match source.fold {
                 BedFold::Known(columns) => {
-                    for (column, &gain) in columns.iter().enumerate() {
+                    for (&speaker, &gain) in metadata.reference_speakers().iter().zip(&columns) {
                         if gain != 0.0 {
-                            let speaker = REFERENCE_SPEAKERS[column];
+                            let speaker = usize::from(speaker);
                             plan.gains[speaker][feed] = gain;
                             plan.used[speaker] |= 1 << feed;
                         }
@@ -397,8 +466,8 @@ fn parse_standard(payload: &[u8], source_count: usize) -> R<XMetadata> {
         bytes: payload,
         pos: 0,
     };
-    let (reference_mask, output_mask) = layout_header(&mut b, 2)?;
-    if reference_mask != REFERENCE_MASK || output_mask & !reference_mask != HEIGHT_MASK {
+    let (reference_mask, output_mask) = layout_header(&mut b, 2, REFERENCE_MASK_7_1)?;
+    if reference_mask != REFERENCE_MASK_7_1 || output_mask & !reference_mask != HEIGHT_MASK {
         return Err(XMetadataError::Unsupported("standard matrix layout"));
     }
     b.expect(5, 2, "matrix header field")?;
@@ -429,12 +498,14 @@ fn parse_standard(payload: &[u8], source_count: usize) -> R<XMetadata> {
     Ok(XMetadata {
         sources,
         count: FIXED_HEIGHT_COUNT,
+        reference_speakers: REFERENCE_SPEAKERS.map(|speaker| speaker as u8),
+        reference_count: REFERENCE_CHANNELS,
     })
 }
 
 /// Read the element header shared by the type-2 and type-3 layout elements.
 /// Every flag without a verified meaning is pinned to its observed value.
-fn layout_header(b: &mut Bits<'_>, kind: u32) -> R<(u32, u32)> {
+fn layout_header(b: &mut Bits<'_>, kind: u32, inherited: u32) -> R<(u32, u32)> {
     b.expect(8, kind, "element type")?;
     b.expect(8, 0, "element header byte")?;
     b.expect(1, 0, "header flag")?;
@@ -450,7 +521,7 @@ fn layout_header(b: &mut Bits<'_>, kind: u32) -> R<(u32, u32)> {
     } else {
         b.expect(1, 0, "implicit reference mask")?;
         b.expect(4, 0, "implicit reference field")?;
-        REFERENCE_MASK
+        inherited
     };
     b.expect(1, 1, "level field present")?;
     b.expect(6, UNITY_CODE, "level code")?;
@@ -475,52 +546,58 @@ fn sparse_row(b: &mut Bits<'_>, mask: u32, columns: usize) -> R<[f32; REFERENCE_
     Ok(row)
 }
 
-/// Length of the CRC-protected alternate prefix: the bytes before the outer
-/// control suffix whose CRC16 is zero. The same rule locates the audio.
-fn alternate_prefix_len(payload: &[u8]) -> R<usize> {
-    let mut result = None;
-    for end in 4..=payload.len().min(MAX_PREFIX) {
-        if payload.get(end..end + XLL_X_ALT_OUTER_SUFFIX.len()) == Some(&XLL_X_ALT_OUTER_SUFFIX)
-            && crc16_ccitt(&payload[..end]) == 0
-        {
-            if result.is_some() {
-                return Err(XMetadataError::Invalid("ambiguous alternate prefix"));
-            }
-            result = Some(end);
-        }
-    }
-    result.ok_or(XMetadataError::Invalid("alternate prefix CRC"))
+/// Length of the CRC-protected alternate prefix and the mask of channel
+/// sets that follow it, by the same rule the audio decoder applies.
+fn alternate_prefix_len(payload: &[u8]) -> R<(usize, u8)> {
+    alternate_protected_prefix(payload).map_err(|_| XMetadataError::Invalid("alternate prefix CRC"))
 }
 
 fn parse_alternate(payload: &[u8], source_count: usize) -> R<XMetadata> {
-    let object_count = source_count
-        .checked_sub(FIXED_HEIGHT_COUNT)
-        .filter(|&count| (1..=MAX_SOURCES - FIXED_HEIGHT_COUNT).contains(&count))
-        .ok_or(XMetadataError::Unsupported("alternate waveform count"))?;
-    let prefix = &payload[..alternate_prefix_len(payload)?];
+    let (prefix_len, _set_mask) = alternate_prefix_len(payload)?;
+    let prefix = &payload[..prefix_len];
     let mut sources = [None; MAX_SOURCES];
-    // The type-241 element is byte-aligned and self-delimiting; the type-3
-    // element follows it and must end exactly at the envelope CRC.
-    let type3_start = parse_type241(prefix, &mut sources[..object_count])?;
-    let heights = parse_type3(&prefix[type3_start..])?;
-    for (slot, height) in sources[object_count..source_count].iter_mut().zip(heights) {
-        *slot = Some(height);
+    // The type-241 element is byte-aligned and self-delimiting. Either the
+    // envelope CRC follows it directly (object-only variant), or a type-3
+    // element describing the height quartet does and must end exactly at
+    // the CRC.
+    let (type3_start, object_count, reference_mask) = parse_type241(prefix, &mut sources)?;
+    let (reference_speakers, reference_count) = reference_speakers(reference_mask)
+        .ok_or(XMetadataError::Unsupported("reference layout"))?;
+    let heights_present = type3_start + 2 != prefix.len();
+    let expected = if heights_present {
+        object_count + FIXED_HEIGHT_COUNT
+    } else {
+        object_count
+    };
+    if source_count != expected || source_count > MAX_SOURCES {
+        return Err(XMetadataError::Unsupported("alternate waveform count"));
+    }
+    if heights_present {
+        let heights = parse_type3(&prefix[type3_start..], reference_mask)?;
+        for (slot, height) in sources[object_count..source_count].iter_mut().zip(heights) {
+            *slot = Some(height);
+        }
     }
     Ok(XMetadata {
         sources,
         count: source_count,
+        reference_speakers,
+        reference_count,
     })
 }
 
-/// The type-3 element: four rows over the full 12-channel layout, one per
-/// fixed height in the order the second channel set decodes them. A row's
-/// height column names the feed; its reference columns are the feed's fold.
-fn parse_type3(bytes: &[u8]) -> R<[SourceMetadata; FIXED_HEIGHT_COUNT]> {
+/// The type-3 element: four rows over the full layout (reference channels
+/// plus the height pairs), one per fixed height in the order the second
+/// channel set decodes them. A row's height column names the feed; its
+/// reference columns are the feed's fold.
+fn parse_type3(bytes: &[u8], reference_mask: u32) -> R<[SourceMetadata; FIXED_HEIGHT_COUNT]> {
     let mut b = Bits { bytes, pos: 0 };
-    let (reference_mask, output_mask) = layout_header(&mut b, 3)?;
-    if reference_mask != REFERENCE_MASK || output_mask != FULL_MASK {
+    let (declared_reference, output_mask) = layout_header(&mut b, 3, reference_mask)?;
+    if declared_reference != reference_mask || output_mask != reference_mask | HEIGHT_MASK {
         return Err(XMetadataError::Unsupported("type-3 layout"));
     }
+    let (columns, column_count) =
+        full_columns(output_mask).ok_or(XMetadataError::Unsupported("type-3 layout"))?;
     b.expect(5, 2, "type-3 field")?;
     b.expect(6, 0, "type-3 value")?;
     b.expect(1, 1, "type-3 flag")?;
@@ -531,31 +608,30 @@ fn parse_type3(bytes: &[u8]) -> R<[SourceMetadata; FIXED_HEIGHT_COUNT]> {
         fold: BedFold::Unknown,
     }; FIXED_HEIGHT_COUNT];
     for height in &mut heights {
-        let mask = b.read(FULL_COLUMNS)?;
+        let mask = b.read(column_count)?;
         let mut identity = None;
-        let mut columns = [0.0; REFERENCE_CHANNELS];
-        for column in 0..FULL_COLUMNS {
+        let mut fold = [0.0; REFERENCE_CHANNELS];
+        for (column, entry) in columns.iter().enumerate().take(column_count) {
             if mask & (1 << column) == 0 {
                 continue;
             }
             let code = b.read(6)?;
-            match (FULL_TO_REFERENCE[column], FULL_TO_HEIGHT[column]) {
-                (Some(reference), _) => {
-                    columns[reference] = gain_code_linear(code)
+            match *entry {
+                Ok(reference) => {
+                    fold[reference] = gain_code_linear(code)
                         .ok_or(XMetadataError::Unsupported("type-3 gain code"))?;
                 }
-                (None, Some(speaker)) => {
+                Err(speaker) => {
                     if identity.replace(speaker).is_some() || code != UNITY_CODE {
                         return Err(XMetadataError::Unsupported("type-3 height column"));
                     }
                 }
-                (None, None) => return Err(XMetadataError::Unsupported("type-3 column")),
             }
         }
         let speaker = identity.ok_or(XMetadataError::Unsupported("type-3 row without height"))?;
         *height = SourceMetadata {
             role: SourceRole::Height(speaker),
-            fold: BedFold::Known(columns),
+            fold: BedFold::Known(fold),
         };
     }
     b.align("type-3 padding")?;
@@ -568,8 +644,9 @@ fn parse_type3(bytes: &[u8]) -> R<[SourceMetadata; FIXED_HEIGHT_COUNT]> {
 /// The type-241 element: object declarations, then one position record per
 /// object with optional reference rows, then optional auxiliary
 /// fixed-channel alternatives. Fills `objects` by declared index and returns
-/// the byte offset at which the next element starts.
-fn parse_type241(bytes: &[u8], objects: &mut [Option<SourceMetadata>]) -> R<usize> {
+/// the byte offset at which the next element starts, the declared object
+/// count and the reference mask the rows are expressed over.
+fn parse_type241(bytes: &[u8], objects: &mut [Option<SourceMetadata>]) -> R<(usize, usize, u32)> {
     let mut b = Bits { bytes, pos: 0 };
     for (width, value) in [
         (8, 241),
@@ -584,16 +661,16 @@ fn parse_type241(bytes: &[u8], objects: &mut [Option<SourceMetadata>]) -> R<usiz
         b.expect(width, value, "type-241 header")?;
     }
     let count = b.read(4)? as usize + 1;
-    if count != objects.len() {
+    if count > objects.len() {
         return Err(XMetadataError::Unsupported("type-241 declaration count"));
     }
     for (width, value) in [(1, 0), (1, 0), (1, 1), (1, 1), (2, 0), (3, 0)] {
         b.expect(width, value, "type-241 reference form")?;
     }
     let width = 4 * (b.read(3)? as usize + 1);
-    if b.read(width)? != REFERENCE_MASK {
-        return Err(XMetadataError::Unsupported("type-241 reference layout"));
-    }
+    let reference_mask = b.read(width)?;
+    let (_, columns) = reference_speakers(reference_mask)
+        .ok_or(XMetadataError::Unsupported("type-241 reference layout"))?;
     // No optional levels, additional layouts or timing parameters; precision
     // zero gives three-bit indices and two-bit modes.
     b.expect(8, 0, "type-241 optional fields")?;
@@ -601,7 +678,11 @@ fn parse_type241(bytes: &[u8], objects: &mut [Option<SourceMetadata>]) -> R<usiz
     let mut modes = [0u32; MAX_SOURCES];
     for record in 0..count {
         b.expect(1, 1, "inactive type-241 declaration")?;
-        b.expect(2, 3, "type-241 declaration field")?;
+        // A two-bit field with two observed values: 3 on the 7.1 profiles,
+        // 1 on the object-only 5.1 variant. Its meaning is not established.
+        if !matches!(b.read(2)?, 1 | 3) {
+            return Err(XMetadataError::Unsupported("type-241 declaration field"));
+        }
         let index = b.read(3)? as usize;
         if index >= count || indices[..record].contains(&index) {
             return Err(XMetadataError::Unsupported("type-241 declaration index"));
@@ -636,16 +717,16 @@ fn parse_type241(bytes: &[u8], objects: &mut [Option<SourceMetadata>]) -> R<usiz
         let fold = if modes[record] == 1 {
             let first = b.read(1)? != 0;
             let second = b.read(1)? != 0;
-            let columns = if first {
-                let mask = b.read(REFERENCE_CHANNELS)?;
-                sparse_row(&mut b, mask, REFERENCE_CHANNELS)?
+            let fold = if first {
+                let mask = b.read(columns)?;
+                sparse_row(&mut b, mask, columns)?
             } else {
                 [0.0; REFERENCE_CHANNELS]
             };
             if second {
                 return Err(XMetadataError::Unsupported("type-241 second reference row"));
             }
-            BedFold::Known(columns)
+            BedFold::Known(fold)
         } else {
             BedFold::Unknown
         };
@@ -688,7 +769,7 @@ fn parse_type241(bytes: &[u8], objects: &mut [Option<SourceMetadata>]) -> R<usiz
         }
     }
     b.align("type-241 padding")?;
-    Ok(b.pos / 8)
+    Ok((b.pos / 8, count, reference_mask))
 }
 
 #[cfg(test)]
@@ -697,6 +778,10 @@ pub(crate) mod fixtures {
     //! on values the corpus never shows.
 
     use super::*;
+    use crate::dcadec::xll::XLL_X_ALT_OUTER_SUFFIX;
+
+    /// The 7.1 full layout: reference channels plus the height pairs.
+    const FULL_MASK_7_1: u32 = REFERENCE_MASK_7_1 | HEIGHT_MASK;
 
     pub(crate) struct BitWriter {
         bits: Vec<u8>,
@@ -749,7 +834,7 @@ pub(crate) mod fixtures {
                 .push(0, 2)
                 .push(0, 3)
                 .push(2, 3)
-                .push(REFERENCE_MASK, 12);
+                .push(REFERENCE_MASK_7_1, 12);
         } else {
             w.push(0, 1).push(0, 1).push(0, 4);
         }
@@ -764,7 +849,7 @@ pub(crate) mod fixtures {
     /// height `i`, followed by the bare XLL bytes the decoder would find.
     pub(crate) fn standard_payload(rows: [(u32, u32); 4]) -> Vec<u8> {
         let mut w = BitWriter::new();
-        layout_header_bits(&mut w, 2, FULL_MASK, true);
+        layout_header_bits(&mut w, 2, FULL_MASK_7_1, true);
         w.push(2, 5)
             .push(0, 6)
             .push(1, 1)
@@ -834,7 +919,7 @@ pub(crate) mod fixtures {
             .push(1, 1)
             .push(0, 2)
             .push(0, 3);
-        w.push(2, 3).push(REFERENCE_MASK, 12).push(0, 8);
+        w.push(2, 3).push(REFERENCE_MASK_7_1, 12).push(0, 8);
         for record in records {
             w.push(1, 1)
                 .push(3, 2)
@@ -892,7 +977,7 @@ pub(crate) mod fixtures {
         let type241 = w.bytes();
 
         let mut w = BitWriter::new();
-        layout_header_bits(&mut w, 3, FULL_MASK, explicit_type3_mask);
+        layout_header_bits(&mut w, 3, FULL_MASK_7_1, explicit_type3_mask);
         w.push(2, 5)
             .push(0, 6)
             .push(1, 1)
@@ -900,10 +985,10 @@ pub(crate) mod fixtures {
             .push(TYPE3_CONTROL, 12);
         for (mask, code) in height_rows {
             w.push(mask, 12);
-            for column in 0..FULL_COLUMNS {
+            let (columns, column_count) = full_columns(FULL_MASK_7_1).unwrap();
+            for (column, entry) in columns.iter().enumerate().take(column_count) {
                 if mask & (1 << column) != 0 {
-                    let is_height = FULL_TO_HEIGHT[column].is_some();
-                    w.push(if is_height { UNITY_CODE } else { code }, 6);
+                    w.push(if entry.is_err() { UNITY_CODE } else { code }, 6);
                 }
             }
         }
@@ -914,6 +999,71 @@ pub(crate) mod fixtures {
         prefix.extend_from_slice(&type3);
         let mut payload = crc_appended(prefix);
         payload.extend_from_slice(&XLL_X_ALT_OUTER_SUFFIX);
+        payload.extend_from_slice(&[0xb2, 0, 0, 0, 0, 0, 0, 0]);
+        payload
+    }
+
+    /// The object-only variant on a 5.1 bed: one mode-1 record over the
+    /// reference mask `0x00f` (four-bit width field, six fold columns,
+    /// declaration field 1), no type-3 element, and an outer marker saying
+    /// that only the first channel set follows.
+    pub(crate) fn object_only_payload(record: &ObjectRecord) -> Vec<u8> {
+        let mut w = BitWriter::new();
+        w.push(0xf1, 8)
+            .push(0x40, 8)
+            .push(0, 4)
+            .push(0, 1)
+            .push(1, 4)
+            .push(1, 1)
+            .push(0, 1)
+            .push(1, 1)
+            .push(0, 4);
+        w.push(0, 1)
+            .push(0, 1)
+            .push(1, 1)
+            .push(1, 1)
+            .push(0, 2)
+            .push(0, 3);
+        w.push(0, 3).push(REFERENCE_MASK_5_1, 4).push(0, 8);
+        w.push(1, 1)
+            .push(1, 2)
+            .push(record.index, 3)
+            .push(record.mode, 2)
+            .push(0, 10);
+        if record.mode == 0 {
+            w.push(1, 4);
+        } else {
+            w.push(0, 3);
+        }
+        w.push(0x20, 7)
+            .push(1, 1)
+            .push(1, 1)
+            .push(0, 2)
+            .push(UNITY_CODE, 6);
+        w.push(record.distance, 6)
+            .push(record.azimuth, 8)
+            .push(record.elevation, 7)
+            .push(0, 1);
+        if record.mode == 1 {
+            match record.row {
+                Some((mask, code)) => {
+                    w.push(1, 1).push(0, 1).push(mask, 6);
+                    for column in 0..6 {
+                        if mask & (1 << column) != 0 {
+                            w.push(code, 6);
+                        }
+                    }
+                }
+                None => {
+                    w.push(0, 1).push(0, 1);
+                }
+            }
+        }
+        w.push(0, 1); // no auxiliary section
+        w.align();
+        let mut payload = crc_appended(w.bytes());
+        payload.push(0x01);
+        payload.extend_from_slice(&crate::dcadec::xll::XLL_X_ALT_MARKER_TAIL);
         payload.extend_from_slice(&[0xb2, 0, 0, 0, 0, 0, 0, 0]);
         payload
     }
@@ -1253,7 +1403,7 @@ mod tests {
     #[test]
     fn every_truncation_and_extension_of_an_alternate_prefix_is_rejected() {
         let payload = alternate_payload(&d3_records(), HEIGHT_ROWS_55);
-        let prefix_len = alternate_prefix_len(&payload).unwrap();
+        let (prefix_len, _) = alternate_prefix_len(&payload).unwrap();
         for end in 0..prefix_len {
             assert!(XMetadata::parse(&payload[..end], 8).is_err(), "end {end}");
         }
@@ -1285,6 +1435,47 @@ mod tests {
             metadata.source(4).unwrap().role,
             SourceRole::Height(SpatialChannel::TopFrontLeft)
         );
+    }
+
+    #[test]
+    fn object_only_variant_on_a_5_1_bed_has_one_object_and_no_heights() {
+        let record = ObjectRecord {
+            mode: 1,
+            index: 0,
+            distance: 63,
+            azimuth: 120,
+            elevation: 77,
+            row: Some((1 << 0 | 1 << 1 | 1 << 2, 46)),
+            centre_height: false,
+        };
+        let payload = object_only_payload(&record);
+        let metadata = XMetadata::parse(&payload, 1).expect("object-only metadata");
+        assert_eq!(metadata.source_count(), 1);
+        assert_eq!(metadata.reference_speakers(), &[0, 1, 2, 3, 4, 5]);
+        let object = metadata.source(0).unwrap();
+        let SourceRole::Object { position, .. } = object.role else {
+            panic!("the single feed is an object");
+        };
+        assert_eq!(position.elevation_half_degrees, 51);
+        let code46 = gain_code_linear(46).unwrap();
+        assert_eq!(
+            object.fold,
+            BedFold::Known([code46, code46, code46, 0.0, 0.0, 0.0, 0.0, 0.0])
+        );
+        // Only the six 5.1 speakers can receive a fold; the front three do.
+        let plan = FoldPlan::from_metadata(&metadata);
+        let sources = vec![vec![0.5f32]];
+        assert!((plan.clean(0, 1.0, 0, &sources) - (1.0 - code46 * 0.5)).abs() < 1e-6);
+        assert!((plan.clean(2, 1.0, 0, &sources) - (1.0 - code46 * 0.5)).abs() < 1e-6);
+        assert_eq!(plan.clean(3, 1.0, 0, &sources), 1.0);
+        assert_eq!(plan.clean(7, 1.0, 0, &sources), 1.0);
+        assert!(plan.source_is_known(0));
+
+        // The waveform count must match: no height quartet here.
+        assert!(XMetadata::parse(&payload, 5).is_err());
+        for end in 0..payload.len() - 8 {
+            assert!(XMetadata::parse(&payload[..end], 1).is_err(), "end {end}");
+        }
     }
 
     #[test]

--- a/dca/src/lib.rs
+++ b/dca/src/lib.rs
@@ -28,7 +28,8 @@ pub use hd::{exss_has_xll, exss_substream_size, HdDecoder, HdError, HdFrame};
 pub use pcm::{CorePcmFrame, DecodeError, PcmDecoder, PcmPushResult, bed_layout};
 pub use spatial::{SpatialChannel, XPresentation};
 pub use dcadec::xmeta::{
-    BedFold, FoldPlan, MAX_SOURCES, REFERENCE_CHANNELS, REFERENCE_SPEAKERS, SourceMetadata,
-    SourceRole, SphericalPosition, XMetadata, XMetadataError, gain_code_linear,
+    BedFold, FoldPlan, MAX_SOURCES, REFERENCE_CHANNELS, REFERENCE_MASK_5_1, REFERENCE_MASK_7_1,
+    REFERENCE_SPEAKERS, SourceMetadata, SourceRole, SphericalPosition, XMetadata, XMetadataError,
+    gain_code_linear,
 };
 pub use types::BedChannel;

--- a/dca/src/spatial.rs
+++ b/dca/src/spatial.rs
@@ -24,7 +24,8 @@
 //! `docs/private-metadata-probe.md`): the last four feeds are the fixed
 //! heights named by the type-3 rows, the first feeds are the declared objects,
 //! and D0's single object also declares the centre-height speaker as its
-//! fixed alternative. They are exposed as presentations rather than as
+//! fixed alternative. The object-only variant on a 5.1 bed carries one
+//! declared object and no height quartet at all. They are exposed as presentations rather than as
 //! research defaults, but no listening sign-off exists yet.
 
 use crate::hd::HdFrame;
@@ -61,6 +62,9 @@ pub enum XPresentation {
     /// Eight-feed alternate profile: four objects, then the four fixed
     /// heights.
     ObjectsD3,
+    /// Single-feed alternate profile on a 5.1 bed: one object, no fixed
+    /// heights. Its envelope carries the first channel set only.
+    ObjectOnly,
 }
 
 const HEIGHT_CHANNELS: [SpatialChannel; 4] = [
@@ -106,9 +110,14 @@ impl XPresentation {
         if !frame.x_imax {
             return None;
         }
-        [Self::FixedD0, Self::ObjectsD1, Self::ObjectsD3]
-            .into_iter()
-            .find(|presentation| feeds_are(presentation.feed_count()))
+        [
+            Self::FixedD0,
+            Self::ObjectsD1,
+            Self::ObjectsD3,
+            Self::ObjectOnly,
+        ]
+        .into_iter()
+        .find(|presentation| feeds_are(presentation.feed_count()))
     }
 
     /// Number of extension waveforms this presentation carries.
@@ -118,6 +127,7 @@ impl XPresentation {
             Self::FixedD0 => 5,
             Self::ObjectsD1 => 6,
             Self::ObjectsD3 => 8,
+            Self::ObjectOnly => 1,
         }
     }
 
@@ -136,6 +146,7 @@ impl XPresentation {
         match self {
             Self::Height | Self::ObjectsD1 | Self::ObjectsD3 => &HEIGHT_CHANNELS,
             Self::FixedD0 => &D0_CHANNELS,
+            Self::ObjectOnly => &[],
         }
     }
 
@@ -183,6 +194,7 @@ mod tests {
             (5usize, XPresentation::FixedD0),
             (6, XPresentation::ObjectsD1),
             (8, XPresentation::ObjectsD3),
+            (1, XPresentation::ObjectOnly),
         ] {
             let f = frame_with(vec![vec![0.0; 512]; n], true, 512);
             assert_eq!(XPresentation::detect(&f), Some(expected));
@@ -207,7 +219,7 @@ mod tests {
         assert_eq!(XPresentation::detect(&frame_with(x, false, 512)), None);
 
         // Feed counts that match no presentation.
-        for n in [0usize, 1, 2, 3, 7, 9] {
+        for n in [0usize, 2, 3, 7, 9] {
             let f = frame_with(vec![vec![0.0; 512]; n], true, 512);
             assert_eq!(XPresentation::detect(&f), None, "{n} feeds");
         }
@@ -232,6 +244,7 @@ mod tests {
             (XPresentation::FixedD0, 0..0, 0..5),
             (XPresentation::ObjectsD1, 0..2, 2..6),
             (XPresentation::ObjectsD3, 0..4, 4..8),
+            (XPresentation::ObjectOnly, 0..1, 1..1),
         ] {
             assert_eq!(presentation.object_feeds(), objects, "{presentation:?}");
             assert_eq!(presentation.fixed_feeds(), fixed, "{presentation:?}");

--- a/dca/tests/xmeta_corpus.rs
+++ b/dca/tests/xmeta_corpus.rs
@@ -85,9 +85,13 @@ fn survey(bytes: &[u8]) -> Survey {
                 let parsed = XMetadata::parse(&frame.x_payload, frame.x_samples.len())
                     .unwrap_or_else(|error| panic!("frame {frames}: {error:?}"));
                 assert_eq!(parsed.source_count(), detected.feed_count());
-                // The last four feeds of every profile are the fixed heights
-                // (D0's first fixed feed is its centre-height object).
-                for feed in detected.feed_count() - 4..detected.feed_count() {
+                // The last four feeds of every profile with a height quartet
+                // are the fixed heights (D0's first fixed feed is its
+                // centre-height object); the object-only variant has none.
+                for feed in detected.feed_count().saturating_sub(4)..detected.feed_count() {
+                    if detected == XPresentation::ObjectOnly {
+                        break;
+                    }
                     assert!(
                         matches!(parsed.source(feed).unwrap().role, SourceRole::Height(_)),
                         "frame {frames}: feed {feed} is a fixed height"
@@ -205,6 +209,29 @@ fn d1_folds_heights_at_minus_3_db_and_reads_two_object_positions() {
             ))
             .collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn object_only_variant_on_a_5_1_bed_parses_on_every_frame() {
+    let Some(bytes) = corpus("HARLETTY_ALT_51_CORPUS") else {
+        eprintln!("skipping: HARLETTY_ALT_51_CORPUS is not set");
+        return;
+    };
+    let survey = survey(&bytes);
+    assert_eq!(survey.presentation, XPresentation::ObjectOnly);
+    assert_eq!(survey.metadata.source_count(), 1);
+    assert_eq!(survey.metadata.reference_speakers(), &[0, 1, 2, 3, 4, 5]);
+    let object = survey.metadata.source(0).unwrap();
+    let SourceRole::Object { position, .. } = object.role else {
+        panic!("the single feed is an object");
+    };
+    assert_eq!(position.elevation_half_degrees, 51);
+    let BedFold::Known(columns) = object.fold else {
+        panic!("the object states its fold");
+    };
+    assert!(columns[0] > 0.8 && columns[1] > 0.4 && columns[2] > 0.4);
+    assert!(columns[3..].iter().all(|&gain| gain == 0.0));
+    eprintln!("object-only 5.1: {} frames", survey.frames);
 }
 
 #[test]

--- a/docs/private-metadata-probe.md
+++ b/docs/private-metadata-probe.md
@@ -329,6 +329,35 @@ heights and objects on top of a bed that still contains them, and cannot
 validate a subtraction. Coordinates and waveform identities from it remain
 useful; its rendering does not.
 
+### The object-only variant on a 5.1 bed
+
+A second alternate form exists that the corpus survey had not seen: the D0
+marker over a **5.1 reference layout** (mask `0x00f`, four-bit width
+field), found on an IMAX documentary with two such tracks. Its
+CRC-protected prefix is 20 bytes: the type-241 element declares one mode-1
+object at (0°, 25.5°, 1) with the same C:58, L:46, R:46 reference row as
+the 7.1 D0 object, over **six** fold columns, with a two-bit declaration
+field equal to 1 where the 7.1 profiles carry 3; there is no auxiliary
+section and **no type-3 element**. The outer marker reads `01 34 38 8c 4f
+00` instead of `03 …`: the byte before the constant tail is a mask of the
+channel sets that follow (`03` = object set and height quartet, `02` before
+the quartet, `01` = object set only), and this stream carries a single
+one-channel XLL set on every frame (2,000 frames checked, 2,000 first-set
+headers, never a four-channel header). So the variant is 5.1 plus one
+object, without fixed heights, which is why nothing describes a height
+fold.
+
+The decoder now accepts a payload whose outer marker announces the first
+set only, and the reader derives the fold columns and their DCA speakers
+from the declared reference mask instead of assuming the 7.1 layout. The
+compatible 5.1 bed stays bit-exact against FFmpeg on an eight-second
+excerpt (384,000 samples/channel, zero differing float bit patterns), the
+object waveform decodes with content, and its fold measures 0.840 in `C`
+in the clean blocks (code 58 is 0.8414) with nothing in `Ls`, `Rs` or
+`LFE`; `L` and `R` are masked by continuous programme. Both hosts present
+the stream as six labeled bed channels plus one object at its transmitted
+position, with the stated fold removed. The DAMF label is `DTS:X-5.1+1`.
+
 ### Remaining reading hypotheses
 
 - The control word `0x3fa` reads, against the type-2 grammar, as an inline

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -72,6 +72,7 @@ fn source_codec_for(presentation: XPresentation) -> SourceCodec {
         XPresentation::FixedD0 => SourceCodec::DtsX715,
         XPresentation::ObjectsD1 => SourceCodec::DtsX914,
         XPresentation::ObjectsD3 => SourceCodec::DtsX71Plus8,
+        XPresentation::ObjectOnly => SourceCodec::DtsX51Plus1,
     }
 }
 


### PR DESCRIPTION
A second alternate extension form exists that the corpus survey had not seen: the D0 marker over a **5.1 reference layout**, found on an IMAX documentary carrying two such tracks. Until now the decoder rejected its extension on every frame ("alternate prefix CRC/boundary") and the title played as plain 5.1.

What the stream carries (details in `docs/private-metadata-probe.md`, "The object-only variant on a 5.1 bed"):
- a 20-byte CRC-protected prefix whose type-241 element declares one mode-1 object at (0°, 25.5°, 1) with the same C:58, L:46, R:46 fold row as the 7.1 D0 object, over six fold columns (reference mask `0x00f`, four-bit width field, declaration field 1 instead of 3), no auxiliary section and **no type-3 element**;
- an outer marker `01 34 38 8c 4f 00`: the byte before the constant tail is a mask of the channel sets that follow (`03` on every 7.1 profile = object set + height quartet, `02` before the quartet, `01` = object set only). Every one of 2,000 frames checked carries a single one-channel XLL set and never a four-channel header.

So the variant is 5.1 plus one object, without fixed heights, which is why nothing describes a height fold.

Changes:
- Decoder: the outer marker is parsed as set mask + tail (`alternate_protected_prefix`, shared with the metadata reader); the alternate layout's second channel set is optional and the extension decode handles a single set. The 7.1 paths are unchanged (both-sets marker required to be `03`).
- Metadata reader: fold columns and their DCA speakers derive from the declared reference mask (5.1 or 7.1) instead of the fixed 7.1 table; the type-3 element is optional and its columns derive from the output mask; the two-bit declaration field accepts the two observed values.
- Presentation `XPresentation::ObjectOnly` (one feed, no fixed channels) in dca, the bridge (six labeled bed channels + one object channel with its transmitted position, fold removed, `has_objects` true) and the CLI (`DTS:X-5.1+1` DAMF label — Atmos Ranker currently stores this title as `DTS:X-?` and will need to learn the label).

Local validation (corpus present, every gated test ran):
- Warnings-denied all-target build; full suite 233 tests green. New: synthetic 5.1 fixture in the reader tests, `HARLETTY_ALT_51_CORPUS` checks in `dca/tests/xmeta_corpus.rs` (1,154 frames parse, fold on C/L/R only, reference speakers 0..5) and in the bridge (6 + 1 channels, positioned object), a bridge unit test of the 5.1 unfold.
- Compatible 5.1 bed bit-exact against FFmpeg on an eight-second excerpt (384,000 samples/channel, zero differing bit patterns); the object waveform decodes with content and its fold measures 0.840 in C (code 58 = 0.8414), nothing in Ls/Rs/LFE.
- Listened on the title itself with the workflow build (Studio shows 6 fixed channels + 1 object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
