### PR TITLE
feat(dts): decode the five-object alternate profile on a 7.1 bed

### DIFF
--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -160,7 +160,9 @@ pub(crate) struct AtmosBridge {
     /// True when the most recent `push_packet` used the DTS path.
     pub(crate) dts_active: bool,
     pub(crate) dts_fold_config: DtsFoldConfig,
-    /// Live stream fact: the latest DTS frame carried presented D3 objects.
+    /// Live stream fact: the latest DTS frame emitted object channels. Set
+    /// from what the frame presented rather than from its profile, so every
+    /// object-bearing presentation reaches it by the same route.
     pub(crate) dts_objects_active: bool,
     // ── Shared ───────────────────────────────────────────────────────
     pub(crate) presentation: u8,
@@ -703,10 +705,13 @@ impl FormatBridge for AtmosBridge {
             if self.dts_objects_active {
                 return true;
             }
-            // DTS core and the standard/D0 extension presentations are
-            // labeled fixed channels. Whether they are placed directly or
-            // virtualized remains the renderer's channel-mode decision. D1
-            // and D3 declare object channels for their object waveforms.
+            // DTS core, and the presentations whose feeds are all fixed - the
+            // standard height quartet and D0's five - are labeled fixed
+            // channels. Whether those are placed directly or virtualized
+            // remains the renderer's channel-mode decision. A presentation
+            // that declares objects labels those feeds as object channels
+            // instead: D1, D3 and D4 over the height quartet, and the
+            // object-only variant for the single one it carries alone.
             return false;
         }
         if self.eac3_active {

--- a/damf/src/damf.rs
+++ b/damf/src/damf.rs
@@ -116,12 +116,17 @@ pub enum SourceCodec {
     // DTS:X, one label per spatial presentation.
     //
     // These strings are not free choices. Atmos Ranker classifies DTS:X tracks
-    // at scan time by looking for the D0/D1/D3 syncwords in the elementary
-    // stream, and stores the result under exactly these names; its
+    // at scan time by looking for the alternate-profile syncwords in the
+    // elementary stream, and stores the result under exactly these names; its
     // `canonical_codec` maps them to themselves. Emitting anything else here —
     // a generic "DTS-X", say — would leave the same physical codec stored under
     // two different strings depending on whether it was scanned or decoded,
     // which is precisely what that function exists to prevent.
+    //
+    // The scanner's syncword list is not visible from this repository, so the
+    // agreement is an expectation held here rather than a thing checked here.
+    // A label that decodes but never ranks is the shape that disagreement
+    // takes, and the profile added most recently is where to look for it.
     /// Standard DTS:X: 7.1 bed plus four height feeds.
     #[serde(rename = "DTS:X-7.1.4")]
     DtsX714,
@@ -140,6 +145,10 @@ pub enum SourceCodec {
     /// among the objects; mapped likewise.)
     #[serde(rename = "DTS:X-7.1.4+4")]
     DtsX714Plus4,
+    /// Nine-feed presentation (D4): 7.1 bed, four fixed heights and five
+    /// objects.
+    #[serde(rename = "DTS:X-7.1.4+5")]
+    DtsX714Plus5,
     /// Object-only presentation on a 5.1 bed: one object waveform, no height
     /// quartet (the D0 marker with a 5.1 reference layout).
     #[serde(rename = "DTS:X-5.1+1")]

--- a/dca/src/dcadec/xll.rs
+++ b/dca/src/dcadec/xll.rs
@@ -23,6 +23,7 @@ pub(crate) const DCA_SYNCWORD_XLL_X: u32 = 0x0200_0850;
 pub(crate) const DCA_SYNCWORD_XLL_X_ALT_D0: u32 = 0xF140_00D0;
 pub(crate) const DCA_SYNCWORD_XLL_X_ALT_D1: u32 = 0xF140_00D1;
 pub(crate) const DCA_SYNCWORD_XLL_X_ALT_D3: u32 = 0xF140_00D3;
+pub(crate) const DCA_SYNCWORD_XLL_X_ALT_D4: u32 = 0xF140_00D4;
 const DCA_SYNCWORD_XLL: u32 = 0x41A2_9547;
 const XLL_X_ALT_FRAME_SAMPLES: usize = 512;
 const XLL_X_ALT_MAX_SEGMENTS: usize = 8;
@@ -72,6 +73,7 @@ enum AlternateProfile {
     D0,
     D1,
     D3,
+    D4,
 }
 
 #[derive(Clone, Copy)]
@@ -291,6 +293,7 @@ fn alternate_outer_layout(
                 AlternateProfile::D0 => XllError::Invalid("alternate D0 control tag"),
                 AlternateProfile::D1 => XllError::Invalid("alternate D1 control tag"),
                 AlternateProfile::D3 => XllError::Invalid("alternate D3 control tag"),
+                AlternateProfile::D4 => XllError::Invalid("alternate D4 control tag"),
             });
         }
     };
@@ -307,6 +310,7 @@ fn alternate_layout(payload: &[u8]) -> R<AlternateLayout> {
         DCA_SYNCWORD_XLL_X_ALT_D0 => AlternateProfile::D0,
         DCA_SYNCWORD_XLL_X_ALT_D1 => AlternateProfile::D1,
         DCA_SYNCWORD_XLL_X_ALT_D3 => AlternateProfile::D3,
+        DCA_SYNCWORD_XLL_X_ALT_D4 => AlternateProfile::D4,
         _ => return Err(XllError::Invalid("unknown alternate XLL profile")),
     };
     let (control_start, control_size, offset_bias, set_mask) =
@@ -317,8 +321,19 @@ fn alternate_layout(payload: &[u8]) -> R<AlternateLayout> {
     let outer_control = payload
         .get(control_start..first_header_offset)
         .ok_or(XllError::Invalid("short alternate XLL outer control"))?;
+    // D4 needs the extra bit for its `c6` outer control, which puts the
+    // geometry at 26 where every other form of the same profile puts it at 25
+    // or below. `c6` is rare, and it arrives late: 273 frames in 46,169 across
+    // six streams, absent entirely from three of them, and in the three that
+    // carry it the first one is 15 to 18 seconds in - past the 4 MiB prefix the
+    // corpus tests read. Every stream here parses clean at a bound of 25 when
+    // only its prefix is measured, so this bound has to be measured over whole
+    // streams or it reads as settled while it is silently dropping the
+    // extension on those frames. Widening it costs nothing: no frame in the
+    // corpus has a second valid geometry at 26 to become ambiguous with.
     let first_geometry_end = match profile {
         AlternateProfile::D3 => 31,
+        AlternateProfile::D4 => 26,
         AlternateProfile::D0 | AlternateProfile::D1 => 25,
     };
     let (common_bit, first_geometry) =
@@ -329,6 +344,7 @@ fn alternate_layout(payload: &[u8]) -> R<AlternateLayout> {
         AlternateProfile::D0 => 1,
         AlternateProfile::D1 => 2,
         AlternateProfile::D3 => 4,
+        AlternateProfile::D4 => 5,
     };
     if first_header.channels != expected_first_channels {
         return Err(XllError::Invalid(
@@ -341,7 +357,7 @@ fn alternate_layout(payload: &[u8]) -> R<AlternateLayout> {
         let inner_control = alternate_inner_control(payload, second_header.offset)?;
         let second_geometry_start = match profile {
             AlternateProfile::D0 => 18,
-            AlternateProfile::D1 | AlternateProfile::D3 => 19,
+            AlternateProfile::D1 | AlternateProfile::D3 | AlternateProfile::D4 => 19,
         };
         let (_, second_geometry) =
             alternate_unique_geometry(inner_control, second_geometry_start, 26)?;
@@ -740,7 +756,10 @@ impl XllDecoder {
         match gb.show_bits(32) {
             Some(DCA_SYNCWORD_XLL_X) => self.x_syncword_present = true,
             Some(
-                DCA_SYNCWORD_XLL_X_ALT_D0 | DCA_SYNCWORD_XLL_X_ALT_D1 | DCA_SYNCWORD_XLL_X_ALT_D3,
+                DCA_SYNCWORD_XLL_X_ALT_D0
+                | DCA_SYNCWORD_XLL_X_ALT_D1
+                | DCA_SYNCWORD_XLL_X_ALT_D3
+                | DCA_SYNCWORD_XLL_X_ALT_D4,
             ) => self.x_imax_syncword_present = true,
             _ => return,
         }

--- a/dca/src/dcadec/xmeta.rs
+++ b/dca/src/dcadec/xmeta.rs
@@ -28,13 +28,13 @@
 use crate::dcadec::tables::DMIXTABLE;
 use crate::dcadec::xll::{
     DCA_SYNCWORD_XLL_X, DCA_SYNCWORD_XLL_X_ALT_D0, DCA_SYNCWORD_XLL_X_ALT_D1,
-    DCA_SYNCWORD_XLL_X_ALT_D3, alternate_protected_prefix, crc16_ccitt,
+    DCA_SYNCWORD_XLL_X_ALT_D3, DCA_SYNCWORD_XLL_X_ALT_D4, alternate_protected_prefix, crc16_ccitt,
 };
 use crate::spatial::SpatialChannel;
 
-/// Most extension waveforms any known profile carries (four objects plus the
+/// Most extension waveforms any known profile carries (five objects plus the
 /// four fixed heights).
-pub const MAX_SOURCES: usize = 8;
+pub const MAX_SOURCES: usize = 9;
 /// Channels of the compatible reference layout the folds are expressed over.
 pub const REFERENCE_CHANNELS: usize = 8;
 /// DCA speaker index behind each column of the 7.1 reference layout
@@ -313,7 +313,10 @@ impl XMetadata {
             .ok_or(XMetadataError::Truncated)?;
         match syncword {
             DCA_SYNCWORD_XLL_X => parse_standard(payload, source_count),
-            DCA_SYNCWORD_XLL_X_ALT_D0 | DCA_SYNCWORD_XLL_X_ALT_D1 | DCA_SYNCWORD_XLL_X_ALT_D3 => {
+            DCA_SYNCWORD_XLL_X_ALT_D0
+            | DCA_SYNCWORD_XLL_X_ALT_D1
+            | DCA_SYNCWORD_XLL_X_ALT_D3
+            | DCA_SYNCWORD_XLL_X_ALT_D4 => {
                 parse_alternate(payload, source_count)
             }
             _ => Err(XMetadataError::Unsupported("extension profile")),
@@ -369,10 +372,11 @@ impl XMetadata {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FoldPlan {
     gains: [[f32; MAX_SOURCES]; FOLD_SPEAKERS],
-    /// Bit `k` set when waveform `k` contributes to that speaker.
-    used: [u8; FOLD_SPEAKERS],
+    /// Bit `k` set when waveform `k` contributes to that speaker. Sixteen bits
+    /// because the widest profile carries nine waveforms, one more than a byte.
+    used: [u16; FOLD_SPEAKERS],
     /// Bit `k` set when waveform `k` has no known fold.
-    unknown: u8,
+    unknown: u16,
     count: usize,
 }
 
@@ -384,7 +388,7 @@ impl FoldPlan {
         Self {
             gains: [[0.0; MAX_SOURCES]; FOLD_SPEAKERS],
             used: [0; FOLD_SPEAKERS],
-            unknown: ((1u16 << count) - 1) as u8,
+            unknown: (1u16 << count) - 1,
             count,
         }
     }

--- a/dca/src/spatial.rs
+++ b/dca/src/spatial.rs
@@ -62,6 +62,9 @@ pub enum XPresentation {
     /// Eight-feed alternate profile: four objects, then the four fixed
     /// heights.
     ObjectsD3,
+    /// Nine-feed alternate profile: five objects, then the four fixed
+    /// heights.
+    ObjectsD4,
     /// Single-feed alternate profile on a 5.1 bed: one object, no fixed
     /// heights. Its envelope carries the first channel set only.
     ObjectOnly,
@@ -114,6 +117,7 @@ impl XPresentation {
             Self::FixedD0,
             Self::ObjectsD1,
             Self::ObjectsD3,
+            Self::ObjectsD4,
             Self::ObjectOnly,
         ]
         .into_iter()
@@ -127,6 +131,7 @@ impl XPresentation {
             Self::FixedD0 => 5,
             Self::ObjectsD1 => 6,
             Self::ObjectsD3 => 8,
+            Self::ObjectsD4 => 9,
             Self::ObjectOnly => 1,
         }
     }
@@ -144,7 +149,7 @@ impl XPresentation {
     /// Speaker position of each fixed feed, in feed order.
     pub fn fixed_channels(self) -> &'static [SpatialChannel] {
         match self {
-            Self::Height | Self::ObjectsD1 | Self::ObjectsD3 => &HEIGHT_CHANNELS,
+            Self::Height | Self::ObjectsD1 | Self::ObjectsD3 | Self::ObjectsD4 => &HEIGHT_CHANNELS,
             Self::FixedD0 => &D0_CHANNELS,
             Self::ObjectOnly => &[],
         }
@@ -194,6 +199,7 @@ mod tests {
             (5usize, XPresentation::FixedD0),
             (6, XPresentation::ObjectsD1),
             (8, XPresentation::ObjectsD3),
+            (9, XPresentation::ObjectsD4),
             (1, XPresentation::ObjectOnly),
         ] {
             let f = frame_with(vec![vec![0.0; 512]; n], true, 512);
@@ -219,7 +225,7 @@ mod tests {
         assert_eq!(XPresentation::detect(&frame_with(x, false, 512)), None);
 
         // Feed counts that match no presentation.
-        for n in [0usize, 2, 3, 7, 9] {
+        for n in [0usize, 2, 3, 7, 10] {
             let f = frame_with(vec![vec![0.0; 512]; n], true, 512);
             assert_eq!(XPresentation::detect(&f), None, "{n} feeds");
         }

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -65,13 +65,15 @@ pub struct DtsDecodeHandler {
 /// Which DAMF codec label a spatial presentation is stored under.
 ///
 /// The taxonomy is Atmos Ranker's, derived independently at scan time from the
-/// D0/D1/D3 syncwords; both sides must agree or the Rank codec filter splits.
+/// alternate-profile syncwords; both sides must agree or the Rank codec filter
+/// splits. [`SourceCodec`] says what that agreement rests on.
 fn source_codec_for(presentation: XPresentation) -> SourceCodec {
     match presentation {
         XPresentation::Height => SourceCodec::DtsX714,
         XPresentation::FixedD0 => SourceCodec::DtsX715,
         XPresentation::ObjectsD1 => SourceCodec::DtsX714Plus2,
         XPresentation::ObjectsD3 => SourceCodec::DtsX714Plus4,
+        XPresentation::ObjectsD4 => SourceCodec::DtsX714Plus5,
         XPresentation::ObjectOnly => SourceCodec::DtsX51Plus1,
     }
 }


### PR DESCRIPTION
## What

`0xF14000D4` was not among the recognised DTS:X extension syncwords, so the match fell through to the bare `_ => return` that captures no payload and raises no error. A stream carrying it decoded as an ordinary 7.1 bed: no extension, no presentation, `has_objects` false, and nothing for the renderer or a player screen to show.

This names it — five objects over the 7.1 bed and the same four fixed heights the other alternate profiles carry, labelled `DTS:X-7.1.4+5`. It is the envelope DTS:X Pro material uses; every sample of that kind I have is D4.

## Why it is the same envelope, not a new format

Measured over **46,169 frames — six complete elementary streams, every frame of each**, not a prefix:

- the protected prefix carries the same constant marker tail and a zero-remainder CRC16;
- the channel-set mask is `0x03`, so both sets follow;
- the first channel set has five channels, the second the usual four;
- the inner control resolves exactly one geometry in bits `19..=26`.

Not one frame of the six failed either resolution, so D4 takes D1/D3's inner start; its outer range and first channel count are its own. The object count follows the pattern the syncword's low nibble already sets for D0, D1 and D3.

Everything downstream was already written against the declared counts — the metadata reader takes the object count from the type-241 element and the height count from the type-3 element, and the bridge splits feeds by `object_feeds()` and `fixed_feeds()` — so naming the profile was most of the work.

## The outer bound is 26, and prefix-length measurement will not show you that

D4's outer range is `18..=26`, one wider than D0 and D1 use. A `c6` outer control puts the geometry at bit 26, and on **273 frames** a bound of 25 resolves nothing and silently drops that frame's extension.

What hides it is depth, not breadth. `c6` is absent from three of the six streams, and in the other three the first occurrence is 15 to 18 seconds in — past the 4 MiB prefix that `dca/tests/xmeta_corpus.rs` reads. Every one of the six streams parses 100% clean at a bound of 25 when only its prefix is measured; only the whole-stream survey shows the 273. I derived 25 from four streams and had to measure all six end to end to find 26. (26 is also what MediaInfo's reader uses: `Sync==0xF14000D4 ? 26 : 25`.)

## Nine waveforms needed wider masks

Five objects plus four fixed heights is nine, one more than the eight the fold plan's bitmasks could hold. `used` and `unknown` were bytes, so the ninth feed shifted past the end of the mask — a panic in debug, and in release an `all_unknown` count that silently truncated to eight. Both are 16 bits now, which is where the ninth feed actually fits rather than where it happened not to crash.

## Objects actually move

Across the six streams each of the five objects takes between **71 and 833 distinct positions**, sweeping the full azimuth circle and reaching the point directly overhead. No object is static in any stream.

## Comments corrected alongside

Four comments name the alternate profiles by listing them, and each list was missing a member. `dts_objects_active` was documented as a D3 fact, though it is assigned from what a frame emitted and knows nothing about profiles — D1, D3, D4 and the object-only variant all set it. `has_objects` split the presentations into the fixed ones and "D1 and D3", which leaves out that same object-only variant: it carries one declared object over a bed with no height quartet, so its single feed is on the object side of that line. The two `SourceCodec` notes named the scan-time syncwords as D0/D1/D3; that list is generalised rather than extended, because the scanner's own list is not visible from this repository and naming D4 in it would assert something this side cannot check.

## Known gaps, stated plainly

- **No D4 corpus-gated test.** `xmeta_corpus.rs` has `HARLETTY_D0_CORPUS`, `HARLETTY_D1_CORPUS` and `HARLETTY_D3_CORPUS`; I did not add a D4 one. Worth noting that at the module's current 4 MiB `PREFIX_BYTES` such a test would *not* catch a regression of the outer bound above — I verified that specifically. A D4 corpus test wants to read deeper than the prefix.
- **`dca/examples/xll_alt_layout_probe.rs` still matches only `d0`/`d1`/`d3`**, so it skips D4 frames. Research tool, not on the realtime path; left alone rather than widened here.
- **The Atmos Ranker side is not visible from this repository.** That `DTS:X-7.1.4+5` matches what the scanner stores is an expectation here, not something checked here; the `SourceCodec` comment says so.
- **The streams behind these numbers are not in the repo**, so this PR cannot ship its own reproducer.

## Verification

- `cargo test --workspace`: 233 passed, 0 failed.
- Six-sample survey via `cargo run -p dca --release --example xmeta_survey`: 4165/4165, 4164/4164, 8698/8698, 3649/3649, 12746/12746, 12747/12747 — 46,169 frames, zero parse errors.
- Reverting the outer bound to 25 loses exactly 130 + 130 + 13 = 273 of those frames, in three streams, confirming the bound is load-bearing rather than defensive.