### PR TITLE
Unfold Auro-3D carriers into their bed and height layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ version = "0.7.4"
 dependencies = [
  "abi_stable",
  "anyhow",
+ "auro",
  "bridge_api",
  "dca",
  "eac3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "auro"
+version = "0.7.4"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +573,7 @@ name = "harletty"
 version = "0.7.4"
 dependencies = [
  "anyhow",
+ "auro",
  "chrono",
  "clap",
  "damf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 # CLI must never pull in the Omniphony bridge ABI. See
 # docs/plan-truehdd-resurrection-in-harletty.md.
 [workspace]
-members = ["bridge", "harletty", "eac3", "dca", "damf"]
+members = ["bridge", "harletty", "eac3", "dca", "damf", "auro"]
 resolver = "2"
 
 # Kept from the pre-workspace root package: the CLI ships under this profile.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ config where it is. That's the whole job.
 > **Looking for the command-line converter instead?** This repo also
 > ships **`harletty`** — a fork of
 > [`truehdd`](https://github.com/truehdd/truehdd) by
-> [Rainbaby](https://github.com/truehdd), extended with E-AC-3 JOC and
-> DTS input — which turns those bitstreams into Dolby Atmos master files
-> on disk. That one you *do* run yourself; see
+> [Rainbaby](https://github.com/truehdd), extended with E-AC-3 JOC, DTS
+> and Auro-3D input — which turns those bitstreams into Dolby Atmos
+> master files on disk. That one you *do* run yourself; see
 > **[docs/harletty-cli.md](docs/harletty-cli.md)** for the command
 > reference and the provenance in detail.
 
@@ -226,7 +226,9 @@ unix and `target\release\harletty_bridge.dll` on Windows. Point
 by [Rainbaby](https://github.com/truehdd)** — 85% of the shared-lineage
 code is byte-identical to upstream, including the whole DAMF master-set
 writer and the CAF/Wave64 writers. What was added here is E-AC-3 JOC and
-DTS/DTS:X input, the latter exported as ADM.
+DTS/DTS:X input, the latter exported as ADM, and the unfolding of
+Auro-3D carriers (a DTS-HD MA track whose low bits hold a folded 9.1 to
+13.1 layout) into their bed and height layer.
 
 It turns those bitstreams into Dolby Atmos master files (`.atmos`,
 `.atmos.metadata`, plus CAF/WAV audio), reading a file or stdin, so it
@@ -270,6 +272,7 @@ truehdd-macros/      # proc macros used by the CAF writer and `info`
 truehd/              # TrueHD decoder crate (vendored, Apache-2.0)
 eac3/                # E-AC-3 (JOC) decoder crate
 dca/                 # DTS (core / DTS-HD MA / XLL) decoder crate
+auro/                # Auro-Codec side channel: detection and unfold
 docs/                # protocol notes (IEC61937, OAMD shape, …)
 EAC3_PATCH_NOTES.md  # upstream patches to the E-AC-3 decoder
 OBJECT_SIZE_NOTES.md # notes on OAMD object_size handling
@@ -296,8 +299,8 @@ Concretely, what is Rainbaby's:
   `info` report and `truehdd-macros/` are all upstream work.
 
 What is ours: the `bridge_api` ABI wrapper and the OAMD plumbing the
-renderer needs; the `eac3` and `dca` crates; the E-AC-3 JOC and DTS/DTS:X
-routing in the CLI; and decoder robustness fixes. Upstream is Apache-2.0,
+renderer needs; the `eac3`, `dca` and `auro` crates; the E-AC-3 JOC,
+DTS/DTS:X and Auro-3D routing in the CLI; and decoder robustness fixes. Upstream is Apache-2.0,
 as is this repo.
 
 So: huge thanks to Rainbaby and the `truehdd` project. **If any of this

--- a/auro/Cargo.toml
+++ b/auro/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "auro"
+version = "0.7.4"
+edition = "2024"
+license = "Apache-2.0"
+description = "Auro-Codec side-channel detector: finds the Auro-3D layout carried in the low bits of 24-bit PCM"
+repository = "https://github.com/harletty/harletty-bridge"
+rust-version = "1.87.0"
+
+[lib]
+name = "auro"
+crate-type = ["lib"]
+
+# Deliberately dependency-free: the detector runs inside the realtime decode
+# path on every lossless sample, so it must stay as small as the bit twiddling
+# it does.
+[dependencies]

--- a/auro/src/block.rs
+++ b/auro/src/block.rs
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// One Auro-Codec block: the sync signature, the CRC that guards it, and the
+// bit-multiplexed side channel that carries the ADOL configuration.
+//
+// Everything here works on 24-bit samples held in `i32` (sign-extended or
+// not: only the low 24 bits are ever read). A carrier channel is a plain PCM
+// channel whose `m` least-significant bits have been replaced, block by
+// block, with a serial bitstream. The first sixteen samples of a block are
+// its header:
+//
+// ```text
+//   bit 0 of samples 0..16   sync: all ones
+//   bit 1 of samples 0..16   CRC-16/CCITT of the block, MSB first
+//   bit 2 of samples 0..8    block-size code, MSB first
+//   bit 2 of samples 8..12   four flag bits
+//   bit 2 of samples 12..16  14 - m, the count of LSBs this block borrows
+// ```
+//
+// The remaining bits of the header samples (bits 3..m) and the low `m` bits
+// of every later sample, MSB first, form the payload. One bit every `16 * m`
+// payload positions is reserved and must read zero; for `m = 3` that is
+// bit 0 of every sixteenth sample, which is what stops a sync run at exactly
+// sixteen ones.
+//
+// The bit layout follows the public description of the format
+// (MediaInfoLib PR #2531 and almirus/Orua-D3, both derived from the
+// commercial decoder). Nothing in this file interprets audio.
+
+use crate::layout::ChannelConfig;
+
+/// Samples in a block header, all of which carry the sync signature.
+pub const SYNC_SAMPLES: usize = 16;
+/// Largest block the size code can express (`0x7F << 5 | 0x10`, plus 16).
+pub const MAX_BLOCK: usize = 4096;
+/// Smallest `m` the header can announce.
+pub const MIN_LSB_BITS: u8 = 3;
+/// Largest `m` the header can announce (`14 - 0`).
+pub const MAX_LSB_BITS: u8 = 14;
+
+/// The block-size code that means 1000 samples: the only size that is not a
+/// multiple of sixteen, so it gets a code of its own.
+const SIZE_CODE_1000: u32 = 0x3D0;
+
+/// What the sixteen header samples announce about their block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SyncHeader {
+    /// Samples in the block, header included. At most [`MAX_BLOCK`].
+    pub block_size: u16,
+    /// Least-significant bits borrowed from every sample of this block.
+    pub lsb_bits: u8,
+}
+
+#[inline]
+fn low24(sample: i32) -> u32 {
+    (sample as u32) & 0x00FF_FFFF
+}
+
+#[inline]
+fn bit(sample: i32, index: u32) -> u32 {
+    (low24(sample) >> index) & 1
+}
+
+/// Read the sync signature and the size and width codes off the first
+/// sixteen samples. `None` when the samples are not a block header.
+///
+/// This is the cheap test that runs on every sixteen-ones run; the CRC and
+/// the reserved-bit check need the whole block and come later.
+pub fn parse_sync(samples: &[i32]) -> Option<SyncHeader> {
+    if samples.len() < SYNC_SAMPLES {
+        return None;
+    }
+    if samples[..SYNC_SAMPLES].iter().any(|&s| bit(s, 0) == 0) {
+        return None;
+    }
+    let mut size_code = 0u32;
+    for &s in &samples[..8] {
+        size_code = (size_code << 1) | bit(s, 2);
+    }
+    // Seven bits of block count in units of 32, one bit in units of 16.
+    let raw = size_code << 4;
+    let block_size = if raw == SIZE_CODE_1000 {
+        1000
+    } else {
+        raw + SYNC_SAMPLES as u32
+    };
+    let mut width_code = 0u32;
+    for &s in &samples[12..16] {
+        width_code = (width_code << 1) | bit(s, 2);
+    }
+    let lsb_bits = 14u32.checked_sub(width_code)?;
+    if lsb_bits < u32::from(MIN_LSB_BITS) {
+        return None;
+    }
+    Some(SyncHeader {
+        block_size: block_size as u16,
+        lsb_bits: lsb_bits as u8,
+    })
+}
+
+/// Where payload position `pos` lives for a block borrowing `m` bits:
+/// `(sample index, bit index)`.
+///
+/// `skip_reserved` selects the payload view, in which the reserved bit every
+/// `16 * m` positions is stepped over, from the raw view used to locate
+/// those reserved bits themselves.
+#[inline]
+pub fn bit_location(pos: usize, m: usize, skip_reserved: bool) -> (usize, u32) {
+    if pos < 48 {
+        // The three header bit planes: sync, CRC, codes.
+        return (pos & 15, (pos >> 4) as u32);
+    }
+    let header_bits = SYNC_SAMPLES * m;
+    if pos < header_bits {
+        // Bits 3..m of the header samples, MSB first.
+        let per_sample = m - 3;
+        let rel = pos - 48;
+        let idx = rel / per_sample;
+        let rem = rel % per_sample;
+        return (idx, (m - 1 - rem) as u32);
+    }
+    let pos = if skip_reserved {
+        pos + (pos - m) / (header_bits - 1)
+    } else {
+        pos
+    };
+    (pos / m, (m - 1 - pos % m) as u32)
+}
+
+/// The reserved-bit check: one raw position every `16 * m`, starting at
+/// `17 * m - 1`, must read zero over the whole block.
+pub fn reserved_bits_clear(samples: &[i32], header: SyncHeader) -> bool {
+    let m = usize::from(header.lsb_bits);
+    let block = usize::from(header.block_size);
+    if samples.len() < block {
+        return false;
+    }
+    let total_bits = m * block;
+    let mut pos = 17 * m - 1;
+    while pos < total_bits {
+        let (idx, b) = bit_location(pos, m, false);
+        if idx >= block || bit(samples[idx], b) != 0 {
+            return false;
+        }
+        pos += SYNC_SAMPLES * m;
+    }
+    true
+}
+
+#[inline]
+fn crc16_ccitt_update(crc: u16, byte: u8) -> u16 {
+    let mut c = crc ^ (u16::from(byte) << 8);
+    for _ in 0..8 {
+        c = if c & 0x8000 != 0 {
+            (c << 1) ^ 0x1021
+        } else {
+            c << 1
+        };
+    }
+    c
+}
+
+/// CRC-16/CCITT over the three bytes of every sample of the block, low byte
+/// first, with the CRC's own bit plane (bit 1 of the header samples) masked
+/// out, inverted at the end.
+pub fn block_crc(samples: &[i32]) -> u16 {
+    let mut crc = 0u16;
+    for (i, &s) in samples.iter().enumerate() {
+        let w = low24(s);
+        let mut b0 = (w & 0xFF) as u8;
+        if i < SYNC_SAMPLES {
+            b0 &= 0xFD;
+        }
+        crc = crc16_ccitt_update(crc, b0);
+        crc = crc16_ccitt_update(crc, ((w >> 8) & 0xFF) as u8);
+        crc = crc16_ccitt_update(crc, ((w >> 16) & 0xFF) as u8);
+    }
+    !crc
+}
+
+/// The CRC the header carries: bit 1 of samples 0..16, MSB first.
+pub fn stored_crc(samples: &[i32]) -> u16 {
+    samples[..SYNC_SAMPLES]
+        .iter()
+        .fold(0u16, |acc, &s| (acc << 1) | bit(s, 1) as u16)
+}
+
+/// Why a block that looked like one could not be read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlockError {
+    /// Fewer samples than the header announces.
+    Truncated,
+    /// A reserved bit was set.
+    ReservedBit,
+    /// The CRC does not match.
+    Crc,
+    /// The payload ended inside a field.
+    Underrun,
+    /// The stream-id count has no defined table size.
+    StreamCount,
+    /// An ADOL block did not start with tag 1.
+    AdolTag,
+    /// An ADOL opcode outside the known set.
+    AdolOpcode(u8),
+}
+
+/// Sequential reader over the payload view of one block.
+struct BitReader<'a> {
+    samples: &'a [i32],
+    m: usize,
+    pos: usize,
+}
+
+impl BitReader<'_> {
+    fn read(&mut self, bits: u32) -> Result<u32, BlockError> {
+        let mut v = 0u32;
+        for _ in 0..bits {
+            let (idx, b) = bit_location(self.pos, self.m, true);
+            if idx >= self.samples.len() {
+                return Err(BlockError::Underrun);
+            }
+            v = (v << 1) | bit(self.samples[idx], b);
+            self.pos += 1;
+        }
+        Ok(v)
+    }
+}
+
+/// One ADOL instruction: an opcode and up to two operands.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AdolInstruction {
+    pub opcode: u8,
+    pub operand: u32,
+    /// Second operand of the two-operand opcode `0x40`; zero otherwise.
+    pub operand2: u32,
+}
+
+/// Most ADOL instructions one block is allowed to carry before parsing
+/// stops. A layout announcement is a handful; this bounds a hostile stream.
+pub const MAX_ADOL_INSTRUCTIONS: usize = 64;
+
+/// What one validated block says.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockInfo {
+    pub header: SyncHeader,
+    /// The four stream-id slots of this carrier; `0xFF` marks an empty slot.
+    pub stream_ids: [u8; 4],
+    /// The channel-input configuration announced by ADOL `0x1E`, when the
+    /// block carries one.
+    pub config: Option<ChannelConfig>,
+    /// Instructions parsed, including the terminators.
+    pub adol_instructions: usize,
+}
+
+/// Validate a whole block (reserved bits, CRC) and read its configuration.
+///
+/// `samples` must hold at least `header.block_size` samples starting at the
+/// sync; anything beyond is ignored.
+pub fn parse_block(samples: &[i32], header: SyncHeader) -> Result<BlockInfo, BlockError> {
+    let block = usize::from(header.block_size);
+    if samples.len() < block {
+        return Err(BlockError::Truncated);
+    }
+    let samples = &samples[..block];
+    if !reserved_bits_clear(samples, header) {
+        return Err(BlockError::ReservedBit);
+    }
+    if block_crc(samples) != stored_crc(samples) {
+        return Err(BlockError::Crc);
+    }
+
+    let mut r = BitReader {
+        samples,
+        m: usize::from(header.lsb_bits),
+        // Positions 32..48 are the size, flag and width codes parse_sync read.
+        pos: 48,
+    };
+    // Fixed fields ahead of the ADOL bytecode. Their meaning is not public;
+    // they are stepped over at the widths the reference parser uses.
+    r.read(8)?;
+    r.read(8)?;
+    r.read(1)?;
+    r.read(1)?;
+    r.read(2)?;
+    r.read(4)?;
+    r.read(8)?;
+    let adol_blocks = r.read(8)?;
+    r.read(8)?;
+    let mut stream_ids = [0xFFu8; 4];
+    let mut streams = 0usize;
+    for slot in &mut stream_ids {
+        *slot = r.read(8)? as u8;
+        if *slot != 0xFF {
+            streams += 1;
+        }
+    }
+    for _ in 0..4 {
+        r.read(8)?;
+    }
+    let table_words = match streams {
+        0 | 1 => 0,
+        2 => 2,
+        3 => 5,
+        _ => return Err(BlockError::StreamCount),
+    };
+    for _ in 0..table_words {
+        r.read(32)?;
+    }
+
+    let mut config = None;
+    let mut adol_instructions = 0usize;
+    for _ in 0..adol_blocks {
+        if r.read(8)? != 1 {
+            return Err(BlockError::AdolTag);
+        }
+        loop {
+            if adol_instructions >= MAX_ADOL_INSTRUCTIONS {
+                return Err(BlockError::Underrun);
+            }
+            let ins = read_instruction(&mut r)?;
+            adol_instructions += 1;
+            if ins.opcode == 0x1E {
+                config = Some(ChannelConfig(ins.operand as u8));
+            }
+            if ins.opcode == 0 {
+                break;
+            }
+        }
+    }
+
+    Ok(BlockInfo {
+        header,
+        stream_ids,
+        config,
+        adol_instructions,
+    })
+}
+
+fn read_instruction(r: &mut BitReader<'_>) -> Result<AdolInstruction, BlockError> {
+    let opcode = r.read(8)? as u8;
+    let mut ins = AdolInstruction {
+        opcode,
+        operand: 0,
+        operand2: 0,
+    };
+    match opcode {
+        0x00 => {}
+        0x01 | 0x03 | 0x5A..=0x62 => ins.operand = r.read(16)?,
+        0x02 | 0x04 | 0x1E | 0x1F | 0x41 | 0x47 | 0x50..=0x58 => ins.operand = r.read(8)?,
+        0x0E | 0x46 | 0x6E..=0x76 | 0x80..=0x85 | 0x8C..=0x90 => ins.operand = r.read(32)?,
+        0x40 => {
+            ins.operand = r.read(8)?;
+            ins.operand2 = r.read(8)?;
+        }
+        0x64..=0x6C => ins.operand = r.read(24)?,
+        other => return Err(BlockError::AdolOpcode(other)),
+    }
+    Ok(ins)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_bit_planes_come_first() {
+        for m in [3usize, 5, 10] {
+            for pos in 0..48 {
+                assert_eq!(bit_location(pos, m, true), (pos % 16, (pos / 16) as u32));
+            }
+        }
+    }
+
+    #[test]
+    fn header_samples_lend_their_remaining_bits_before_the_body() {
+        // m = 5: header samples carry bits 3 and 4 as payload positions 48..80.
+        assert_eq!(bit_location(48, 5, true), (0, 4));
+        assert_eq!(bit_location(49, 5, true), (0, 3));
+        assert_eq!(bit_location(50, 5, true), (1, 4));
+        assert_eq!(bit_location(79, 5, true), (15, 3));
+        assert_eq!(bit_location(80, 5, true), (16, 4));
+        // m = 3: nothing left in the header, the body starts at sample 16.
+        assert_eq!(bit_location(48, 3, true), (16, 2));
+        assert_eq!(bit_location(50, 3, false), (16, 0));
+    }
+
+    #[test]
+    fn the_payload_view_steps_over_the_reserved_bit() {
+        // m = 3: raw position 50 (sample 16, bit 0) is reserved; payload
+        // position 50 is the next raw one.
+        assert_eq!(bit_location(50, 3, true), (17, 2));
+        // and again every 48 positions: raw 98 is sample 32, bit 0.
+        assert_eq!(bit_location(98, 3, false), (32, 0));
+        assert_eq!(bit_location(96, 3, true), (32, 1));
+        assert_eq!(bit_location(97, 3, true), (33, 2));
+    }
+
+    #[test]
+    fn a_sync_needs_sixteen_ones() {
+        let mut s = [1i32; 16];
+        assert!(parse_sync(&s).is_some());
+        s[7] = 0;
+        assert!(parse_sync(&s).is_none());
+        assert!(parse_sync(&s[..15]).is_none());
+    }
+
+    #[test]
+    fn crc_reads_bit_one_of_the_header() {
+        let mut s = [1i32; 16];
+        // 0xA5C3, MSB first.
+        for (i, sample) in s.iter_mut().enumerate() {
+            let b = (0xA5C3u16 >> (15 - i)) & 1;
+            *sample |= i32::from(b) << 1;
+        }
+        assert_eq!(stored_crc(&s), 0xA5C3);
+    }
+}

--- a/auro/src/decode.rs
+++ b/auro/src/decode.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A carrier channel decoded block by block: detection, stream layer,
+// residuals, unmix. Storage is allocated once per channel; decoding a block
+// allocates nothing.
+
+use crate::block::{BlockInfo, MAX_BLOCK, SyncHeader};
+use crate::detect::{ChannelDetector, ChannelStats};
+use crate::rice::{Codebook, RiceError, decode_residuals};
+use crate::stream::{MAX_STREAMS, Payload, StreamBlock, StreamError, parse_stream};
+use crate::unmix::{GainTable, unmix};
+
+/// Stream identities the fold refers to. The numbering is the encoder's;
+/// the names come from where each stream showed up on channel
+/// identification material.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StreamId(pub u8);
+
+impl StreamId {
+    pub fn name(self) -> &'static str {
+        match self.0 {
+            0 => "L",
+            1 => "R",
+            2 => "C",
+            3 => "LFE",
+            4 => "Ls",
+            5 => "Rs",
+            6 => "Cs",
+            7 => "Lb",
+            8 => "Rb",
+            9 => "HL",
+            10 => "HR",
+            11 => "HC",
+            12 => "T",
+            13 => "HLs",
+            14 => "HRs",
+            _ => "?",
+        }
+    }
+
+    /// Height layer (and the top) versus the bed.
+    pub fn is_height(self) -> bool {
+        (9..=14).contains(&self.0)
+    }
+}
+
+/// Why one block was not decoded. The carrier still plays as authored.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DecodeError {
+    Stream(StreamError),
+    Rice(RiceError),
+    /// A gain index outside the table.
+    Gain,
+}
+
+/// One decoded block of one carrier.
+pub struct Decoded<'a> {
+    /// Absolute index of the block's first sample in this channel.
+    pub start: u64,
+    pub header: SyncHeader,
+    pub info: BlockInfo,
+    pub stream: StreamBlock,
+    /// The restored streams, `stream.mode` of them, each `block_size` long.
+    pub outputs: [(StreamId, &'a [i32]); MAX_STREAMS],
+}
+
+/// Decoder for one carrier channel.
+pub struct ChannelDecoder {
+    detector: ChannelDetector,
+    scratch: Box<[i32]>,
+    payload: Box<Payload>,
+    codebook: Box<Codebook>,
+    residuals: Box<[i32]>,
+    outputs: [Box<[i32]>; MAX_STREAMS],
+    gains: GainTable,
+    /// Blocks that validated but did not decode, by cause, most recent.
+    pub last_error: Option<DecodeError>,
+    pub decode_errors: u64,
+}
+
+impl ChannelDecoder {
+    pub fn new() -> Self {
+        Self {
+            detector: ChannelDetector::new(),
+            scratch: vec![0; MAX_BLOCK].into_boxed_slice(),
+            payload: Box::new(Payload::new()),
+            codebook: Box::new(Codebook::new()),
+            residuals: vec![0; 2 * MAX_BLOCK].into_boxed_slice(),
+            outputs: [
+                vec![0; MAX_BLOCK].into_boxed_slice(),
+                vec![0; MAX_BLOCK].into_boxed_slice(),
+                vec![0; MAX_BLOCK].into_boxed_slice(),
+            ],
+            gains: GainTable::new(),
+            last_error: None,
+            decode_errors: 0,
+        }
+    }
+
+    pub fn stats(&self) -> ChannelStats {
+        self.detector.stats()
+    }
+
+    /// Samples pushed so far.
+    pub fn position(&self) -> u64 {
+        self.detector.count()
+    }
+
+    pub fn reset(&mut self) {
+        self.detector.reset();
+        self.last_error = None;
+        self.decode_errors = 0;
+    }
+
+    /// Push samples; every block that validates and decodes is handed to
+    /// `on_block`.
+    pub fn push(&mut self, samples: &[i32], mut on_block: impl FnMut(Decoded<'_>)) {
+        let Self {
+            detector,
+            scratch,
+            payload,
+            codebook,
+            residuals,
+            outputs,
+            gains,
+            last_error,
+            decode_errors,
+        } = self;
+        detector.push(
+            samples,
+            scratch,
+            |start, block, header, info| match decode_block(
+                block, header, payload, codebook, residuals, outputs, gains,
+            ) {
+                Ok(stream) => {
+                    let n = usize::from(header.block_size);
+                    let ids = stream.ids;
+                    let outs: [(StreamId, &[i32]); MAX_STREAMS] = [
+                        (StreamId(ids[0]), &outputs[0][..n]),
+                        (StreamId(ids[1]), &outputs[1][..n]),
+                        (StreamId(ids[2]), &outputs[2][..n]),
+                    ];
+                    on_block(Decoded {
+                        start,
+                        header,
+                        info,
+                        stream,
+                        outputs: outs,
+                    });
+                }
+                Err(e) => {
+                    *last_error = Some(e);
+                    *decode_errors += 1;
+                }
+            },
+        );
+    }
+}
+
+impl Default for ChannelDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decode one validated block into `outputs`.
+pub fn decode_block(
+    block: &[i32],
+    header: SyncHeader,
+    payload: &mut Payload,
+    codebook: &mut Codebook,
+    residuals: &mut [i32],
+    outputs: &mut [Box<[i32]>; MAX_STREAMS],
+    gains: &GainTable,
+) -> Result<StreamBlock, DecodeError> {
+    let n = usize::from(header.block_size);
+    let block = &block[..n];
+    payload.gather(block, header);
+    let stream = parse_stream(payload).map_err(DecodeError::Stream)?;
+    if stream.mode >= 2 {
+        codebook.load(payload, &stream);
+        decode_residuals(payload, &stream, codebook, n, residuals).map_err(DecodeError::Rice)?;
+    }
+    let [o0, o1, o2] = outputs;
+    let mut outs: [&mut [i32]; MAX_STREAMS] = [&mut o0[..n], &mut o1[..n], &mut o2[..n]];
+    if !unmix(&stream, gains, header.lsb_bits, block, residuals, &mut outs) {
+        return Err(DecodeError::Gain);
+    }
+    Ok(stream)
+}

--- a/auro/src/detect.rs
+++ b/auro/src/detect.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Streaming detection over the lossless channels of a decoder.
+//
+// Each carrier channel gets a fixed ring of recent samples and a small
+// candidate list. A run of sixteen sync ones proposes a block; when the
+// block's last sample arrives it is copied out contiguously and validated.
+// Storage is allocated once, at construction, and nothing is allocated per
+// sample: this runs inside the realtime decode path.
+
+use crate::block::{BlockError, BlockInfo, MAX_BLOCK, SYNC_SAMPLES, parse_block, parse_sync};
+use crate::layout::{ChannelConfig, Layout};
+
+/// Ring capacity per channel. A power of two so indexing is a mask; larger
+/// than [`MAX_BLOCK`] plus the longest run a candidate can be proposed at.
+const RING: usize = 8192;
+const RING_MASK: u64 = (RING - 1) as u64;
+/// Sync candidates kept per channel. A block can hold a few accidental runs
+/// of sixteen ones in its audio bits; each is checked and dropped.
+const MAX_PENDING: usize = 4;
+/// Validated blocks that must agree before a configuration is announced.
+const CONFIRMATIONS: u8 = 3;
+
+/// A latched Auro-Codec carrier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Detection {
+    pub config: ChannelConfig,
+    /// What a full decode would restore.
+    pub original: Layout,
+    /// What the PCM plays as without a decoder.
+    pub carrier: Layout,
+    /// Block length in samples.
+    pub block_size: u16,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ChannelStats {
+    /// Blocks that passed the reserved-bit and CRC checks.
+    pub valid_blocks: u64,
+    /// Sync runs that did not turn into a valid block.
+    pub rejected: u64,
+    /// Smallest and largest LSB width seen on valid blocks (0 when none).
+    pub min_lsb_bits: u8,
+    pub max_lsb_bits: u8,
+}
+
+struct Candidate {
+    start: u64,
+    block_size: u16,
+}
+
+struct ChannelDetector {
+    ring: Box<[i32]>,
+    /// Samples pushed so far; the next sample lands at `count & RING_MASK`.
+    count: u64,
+    run_ones: u32,
+    pending: [Candidate; MAX_PENDING],
+    pending_len: usize,
+    stats: ChannelStats,
+}
+
+impl ChannelDetector {
+    fn new() -> Self {
+        Self {
+            ring: vec![0; RING].into_boxed_slice(),
+            count: 0,
+            run_ones: 0,
+            pending: std::array::from_fn(|_| Candidate {
+                start: 0,
+                block_size: 0,
+            }),
+            pending_len: 0,
+            stats: ChannelStats::default(),
+        }
+    }
+
+    #[inline]
+    fn at(&self, index: u64) -> i32 {
+        self.ring[(index & RING_MASK) as usize]
+    }
+
+    fn copy_out(&self, start: u64, len: usize, into: &mut [i32]) {
+        for (i, slot) in into[..len].iter_mut().enumerate() {
+            *slot = self.at(start + i as u64);
+        }
+    }
+
+    /// Push samples; every validated block is handed to `on_block`.
+    fn push(&mut self, samples: &[i32], scratch: &mut [i32], mut on_block: impl FnMut(BlockInfo)) {
+        for &s in samples {
+            self.ring[(self.count & RING_MASK) as usize] = s;
+            self.count += 1;
+            if s & 1 != 0 {
+                self.run_ones += 1;
+            } else {
+                // A header is sixteen ones followed by the block's first
+                // reserved bit, which is always clear. So a candidate is
+                // proposed by the zero that ends a run, for the sixteen
+                // samples before that zero: a stray one ahead of a header
+                // (the previous block's last payload bit) lengthens the run
+                // without moving the header.
+                if self.run_ones >= SYNC_SAMPLES as u32 {
+                    let start = self.count - 1 - SYNC_SAMPLES as u64;
+                    self.copy_out(start, SYNC_SAMPLES, scratch);
+                    if let Some(header) = parse_sync(&scratch[..SYNC_SAMPLES]) {
+                        if self.pending_len < MAX_PENDING {
+                            self.pending[self.pending_len] = Candidate {
+                                start,
+                                block_size: header.block_size,
+                            };
+                            self.pending_len += 1;
+                        }
+                    }
+                }
+                self.run_ones = 0;
+            }
+            self.settle(scratch, &mut on_block);
+        }
+    }
+
+    /// Validate every candidate whose block is now complete.
+    fn settle(&mut self, scratch: &mut [i32], on_block: &mut impl FnMut(BlockInfo)) {
+        let mut i = 0;
+        while i < self.pending_len {
+            let Candidate { start, block_size } = self.pending[i];
+            let len = usize::from(block_size);
+            if start + len as u64 > self.count {
+                i += 1;
+                continue;
+            }
+            // Remove by swapping the last candidate in; order is irrelevant.
+            self.pending_len -= 1;
+            self.pending.swap(i, self.pending_len);
+
+            self.copy_out(start, len, scratch);
+            let block = &scratch[..len];
+            let Some(header) = parse_sync(block) else {
+                self.stats.rejected += 1;
+                continue;
+            };
+            match parse_block(block, header) {
+                Ok(info) => {
+                    self.stats.valid_blocks += 1;
+                    let m = header.lsb_bits;
+                    if self.stats.min_lsb_bits == 0 || m < self.stats.min_lsb_bits {
+                        self.stats.min_lsb_bits = m;
+                    }
+                    if m > self.stats.max_lsb_bits {
+                        self.stats.max_lsb_bits = m;
+                    }
+                    on_block(info);
+                }
+                Err(BlockError::Truncated) => unreachable!("block copied whole"),
+                Err(_) => self.stats.rejected += 1,
+            }
+        }
+    }
+}
+
+/// Detector over the lossless channels of one stream.
+pub struct Detector {
+    channels: Vec<ChannelDetector>,
+    scratch: Box<[i32]>,
+    latched: Option<Detection>,
+    /// The configuration seen on the last valid block, and how many blocks in
+    /// a row agreed with it.
+    candidate: Option<(ChannelConfig, u16, u8)>,
+}
+
+impl Detector {
+    /// A detector for `channels` carrier channels. All storage is allocated
+    /// here.
+    pub fn new(channels: usize) -> Self {
+        Self {
+            channels: (0..channels).map(|_| ChannelDetector::new()).collect(),
+            scratch: vec![0; MAX_BLOCK].into_boxed_slice(),
+            latched: None,
+            candidate: None,
+        }
+    }
+
+    pub fn channel_count(&self) -> usize {
+        self.channels.len()
+    }
+
+    /// Feed the next samples of one channel. Returns the detection the first
+    /// time it latches, `None` on every other call.
+    pub fn push(&mut self, channel: usize, samples: &[i32]) -> Option<Detection> {
+        let already = self.latched.is_some();
+        let Some(det) = self.channels.get_mut(channel) else {
+            return None;
+        };
+        let scratch = &mut self.scratch;
+        let latched = &mut self.latched;
+        let candidate = &mut self.candidate;
+        det.push(samples, scratch, |info| {
+            if latched.is_some() {
+                return;
+            }
+            let Some(config) = info.config else {
+                return;
+            };
+            let (Some(original), Some(carrier)) = (config.original(), config.carrier()) else {
+                return;
+            };
+            let block_size = info.header.block_size;
+            let agreed = match *candidate {
+                Some((c, b, n)) if c == config && b == block_size => n + 1,
+                _ => 1,
+            };
+            *candidate = Some((config, block_size, agreed));
+            if agreed >= CONFIRMATIONS {
+                *latched = Some(Detection {
+                    config,
+                    original,
+                    carrier,
+                    block_size,
+                });
+            }
+        });
+        if already { None } else { self.latched }
+    }
+
+    pub fn detection(&self) -> Option<Detection> {
+        self.latched
+    }
+
+    pub fn stats(&self, channel: usize) -> ChannelStats {
+        self.channels
+            .get(channel)
+            .map(|c| c.stats)
+            .unwrap_or_default()
+    }
+
+    /// Forget everything; storage is kept.
+    pub fn reset(&mut self) {
+        for c in &mut self.channels {
+            c.count = 0;
+            c.run_ones = 0;
+            c.pending_len = 0;
+            c.stats = ChannelStats::default();
+        }
+        self.latched = None;
+        self.candidate = None;
+    }
+}

--- a/auro/src/detect.rs
+++ b/auro/src/detect.rs
@@ -8,7 +8,9 @@
 // Storage is allocated once, at construction, and nothing is allocated per
 // sample: this runs inside the realtime decode path.
 
-use crate::block::{BlockError, BlockInfo, MAX_BLOCK, SYNC_SAMPLES, parse_block, parse_sync};
+use crate::block::{
+    BlockError, BlockInfo, MAX_BLOCK, SYNC_SAMPLES, SyncHeader, parse_block, parse_sync,
+};
 use crate::layout::{ChannelConfig, Layout};
 
 /// Ring capacity per channel. A power of two so indexing is a mask; larger
@@ -49,7 +51,7 @@ struct Candidate {
     block_size: u16,
 }
 
-struct ChannelDetector {
+pub(crate) struct ChannelDetector {
     ring: Box<[i32]>,
     /// Samples pushed so far; the next sample lands at `count & RING_MASK`.
     count: u64,
@@ -60,7 +62,7 @@ struct ChannelDetector {
 }
 
 impl ChannelDetector {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             ring: vec![0; RING].into_boxed_slice(),
             count: 0,
@@ -74,6 +76,22 @@ impl ChannelDetector {
         }
     }
 
+    pub(crate) fn reset(&mut self) {
+        self.count = 0;
+        self.run_ones = 0;
+        self.pending_len = 0;
+        self.stats = ChannelStats::default();
+    }
+
+    pub(crate) fn stats(&self) -> ChannelStats {
+        self.stats
+    }
+
+    /// Samples pushed so far.
+    pub(crate) fn count(&self) -> u64 {
+        self.count
+    }
+
     #[inline]
     fn at(&self, index: u64) -> i32 {
         self.ring[(index & RING_MASK) as usize]
@@ -85,8 +103,15 @@ impl ChannelDetector {
         }
     }
 
-    /// Push samples; every validated block is handed to `on_block`.
-    fn push(&mut self, samples: &[i32], scratch: &mut [i32], mut on_block: impl FnMut(BlockInfo)) {
+    /// Push samples; every validated block is handed to `on_block` with its
+    /// samples, its header and what its ADOL layer said. `start` is the
+    /// absolute index of the block's first sample in this channel's stream.
+    pub(crate) fn push(
+        &mut self,
+        samples: &[i32],
+        scratch: &mut [i32],
+        mut on_block: impl FnMut(u64, &[i32], SyncHeader, BlockInfo),
+    ) {
         for &s in samples {
             self.ring[(self.count & RING_MASK) as usize] = s;
             self.count += 1;
@@ -119,7 +144,11 @@ impl ChannelDetector {
     }
 
     /// Validate every candidate whose block is now complete.
-    fn settle(&mut self, scratch: &mut [i32], on_block: &mut impl FnMut(BlockInfo)) {
+    fn settle(
+        &mut self,
+        scratch: &mut [i32],
+        on_block: &mut impl FnMut(u64, &[i32], SyncHeader, BlockInfo),
+    ) {
         let mut i = 0;
         while i < self.pending_len {
             let Candidate { start, block_size } = self.pending[i];
@@ -148,7 +177,7 @@ impl ChannelDetector {
                     if m > self.stats.max_lsb_bits {
                         self.stats.max_lsb_bits = m;
                     }
-                    on_block(info);
+                    on_block(start, block, header, info);
                 }
                 Err(BlockError::Truncated) => unreachable!("block copied whole"),
                 Err(_) => self.stats.rejected += 1,
@@ -193,7 +222,7 @@ impl Detector {
         let scratch = &mut self.scratch;
         let latched = &mut self.latched;
         let candidate = &mut self.candidate;
-        det.push(samples, scratch, |info| {
+        det.push(samples, scratch, |_, _, _, info| {
             if latched.is_some() {
                 return;
             }
@@ -235,10 +264,7 @@ impl Detector {
     /// Forget everything; storage is kept.
     pub fn reset(&mut self) {
         for c in &mut self.channels {
-            c.count = 0;
-            c.run_ones = 0;
-            c.pending_len = 0;
-            c.stats = ChannelStats::default();
+            c.reset();
         }
         self.latched = None;
         self.candidate = None;

--- a/auro/src/layout.rs
+++ b/auro/src/layout.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Auro speaker layouts and the channel-input configurations that map onto
+// them.
+//
+// The numeric ids are the encoder's own. Their names come from the public
+// reverse-engineering of the format (almirus/Orua-D3, MIT) and are used as
+// labels only: nothing here derives speaker geometry from a name.
+
+/// An Auro speaker layout, by the id the bitstream uses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Layout(pub u32);
+
+impl Layout {
+    /// The layout's conventional name (`5.1_4H`, `7.1_5H_1T`, ...), or `None`
+    /// for an id the public tables do not know.
+    pub fn name(self) -> Option<&'static str> {
+        Some(match self.0 {
+            3 => "2.0",
+            4 => "1.0",
+            7 => "3.0",
+            8 => "0.1",
+            11 => "2.1",
+            12 => "1.1",
+            15 => "3.1",
+            51 => "4.0",
+            55 => "5.0",
+            59 => "4.1",
+            63 => "5.1",
+            71 => "LCRS",
+            119 => "6.0",
+            127 => "6.1",
+            435 => "7.0_no_C",
+            439 => "7.0",
+            443 => "7.1_no_C",
+            447 => "7.1",
+            1539 => "2.0_2H",
+            1543 => "3.0_2H",
+            1547 => "2.1_2H",
+            1551 => "3.1_2H",
+            1587 => "4.0_2H",
+            1591 => "5.0_2H",
+            1595 => "4.1_2H",
+            1599 => "5.1_2H",
+            1971 => "7.0_2H_no_C",
+            1975 => "7.0_2H",
+            1979 => "7.1_2H_no_C",
+            1983 => "7.1_2H",
+            3591 => "3.0_3H",
+            3599 => "3.1_3H",
+            26163 => "4.0_4H",
+            26167 => "5.0_4H",
+            26171 => "4.1_4H",
+            26175 => "5.1_4H",
+            26547 => "7.0_4H_no_C",
+            26551 => "7.0_4H",
+            26555 => "7.1_4H_no_C",
+            26559 => "7.1_4H",
+            28211 => "4.0_5H",
+            28215 => "5.0_5H",
+            28219 => "4.1_5H",
+            28223 => "5.1_5H",
+            28595 => "7.0_5H_no_C",
+            28599 => "7.0_5H",
+            28603 => "7.1_5H_no_C",
+            28607 => "7.1_5H",
+            30259 => "4.0_4H_1T",
+            30263 => "5.0_4H_1T",
+            30267 => "4.1_4H_1T",
+            30271 => "5.1_4H_1T",
+            30643 => "7.0_4H_1T_no_C",
+            30647 => "7.0_4H_1T",
+            30651 => "7.1_4H_1T_no_C",
+            30655 => "7.1_4H_1T",
+            32307 => "4.0_5H_1T",
+            32311 => "5.0_5H_1T",
+            32315 => "4.1_5H_1T",
+            32319 => "5.1_5H_1T",
+            32691 => "7.0_5H_1T_no_C",
+            32695 => "7.0_5H_1T",
+            32699 => "7.1_5H_1T_no_C",
+            32703 => "7.1_5H_1T",
+            805332543 => "5.1_4H_2T",
+            805332927 => "7.1_4H_2T",
+            805334591 => "5.1_5H_2T",
+            805334975 => "7.1_5H_2T",
+            1006659519 => "9.1_4H_2T",
+            1006661567 => "9.1_5H_2T",
+            2052 => "TestMix2.0",
+            6148 => "TestMix3.0",
+            _ => return None,
+        })
+    }
+}
+
+/// A channel-input configuration: which original layout was folded into
+/// which carrier. Announced by ADOL instruction `0x1E`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ChannelConfig(pub u8);
+
+impl ChannelConfig {
+    /// The layout the encoder was fed, i.e. what a full decode restores.
+    pub fn original(self) -> Option<Layout> {
+        Some(Layout(match self.0 {
+            1 => 55,
+            2 => 63,
+            8 => 71,
+            11 => 1587,
+            12 => 51,
+            15 => 1599,
+            20 => 26163,
+            30 => 26175,
+            40 => 30271,
+            50 => 32319,
+            54 => 26559,
+            62 => 32703,
+            64 => 3,
+            66 => 7,
+            67 => 119,
+            68 => 127,
+            69 => 439,
+            70 => 447,
+            71 => 26167,
+            72 => 30263,
+            73 => 32311,
+            74 => 26551,
+            75 => 1983,
+            76 => 30647,
+            77 => 30655,
+            78 => 32695,
+            128 => 4,
+            129 => 2052,
+            130 => 6148,
+            _ => return None,
+        }))
+    }
+
+    /// The layout physically present in the PCM, i.e. what plays without a
+    /// decoder.
+    pub fn carrier(self) -> Option<Layout> {
+        Some(Layout(match self.0 {
+            1 | 8 | 11 | 12 | 66 => 3,
+            2 => 11,
+            15 | 30 | 40 | 50 | 68 | 70 => 63,
+            20 => 51,
+            54 | 62 | 75 | 77 => 447,
+            64 | 128 | 129 | 130 => 4,
+            67 | 69 | 71 | 72 | 73 => 55,
+            74 | 76 | 78 => 439,
+            _ => return None,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_configuration_names_both_of_its_layouts() {
+        for id in 0..=255u8 {
+            let cfg = ChannelConfig(id);
+            match (cfg.original(), cfg.carrier()) {
+                (None, None) => {}
+                (Some(original), Some(carrier)) => {
+                    assert!(
+                        original.name().is_some(),
+                        "config {id}: original {original:?}"
+                    );
+                    assert!(carrier.name().is_some(), "config {id}: carrier {carrier:?}");
+                }
+                other => panic!("config {id} is half-defined: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn the_thirteen_one_demo_configuration() {
+        let cfg = ChannelConfig(62);
+        assert_eq!(cfg.original().and_then(Layout::name), Some("7.1_5H_1T"));
+        assert_eq!(cfg.carrier().and_then(Layout::name), Some("7.1"));
+    }
+}

--- a/auro/src/layout.rs
+++ b/auro/src/layout.rs
@@ -93,6 +93,121 @@ impl Layout {
     }
 }
 
+/// The stream ids a layout is made of, in the order this crate reports
+/// them: bed first (the ids of [`crate::decode::StreamId`]), then heights,
+/// then the top.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Streams {
+    pub ids: [u8; 16],
+    pub len: usize,
+}
+
+impl Streams {
+    pub fn as_slice(&self) -> &[u8] {
+        &self.ids[..self.len]
+    }
+}
+
+impl Layout {
+    /// Which streams the layout holds, read off its name: `7.1_5H_1T` is
+    /// L R C LFE Ls Rs Lb Rb, then HL HR HC HLs HRs, then T. `None` when
+    /// the name is unknown or does not follow the bed/height/top grammar.
+    pub fn streams(self) -> Option<Streams> {
+        let name = self.name()?;
+        let mut ids = [0u8; 16];
+        let mut len = 0usize;
+        let mut push = |id: u8| {
+            if len < 16 {
+                ids[len] = id;
+                len += 1;
+            }
+        };
+        let mut parts = name.split('_');
+        let bed = parts.next()?;
+        let (fronts, lfe) = bed.split_once('.')?;
+        let fronts: u8 = fronts.parse().ok()?;
+        let lfe: u8 = lfe.parse().ok()?;
+        let no_c = name.ends_with("_no_C");
+        match fronts {
+            1 => push(2),
+            2 => {
+                push(0);
+                push(1);
+            }
+            3 => {
+                push(0);
+                push(1);
+                push(2);
+            }
+            4 => {
+                push(0);
+                push(1);
+                push(4);
+                push(5);
+            }
+            5 | 6 => {
+                push(0);
+                push(1);
+                push(2);
+                push(4);
+                push(5);
+                if fronts == 6 {
+                    push(6);
+                }
+            }
+            7 => {
+                push(0);
+                push(1);
+                if !no_c {
+                    push(2);
+                }
+                push(4);
+                push(5);
+                push(7);
+                push(8);
+            }
+            _ => return None,
+        }
+        if lfe == 1 {
+            push(3);
+        }
+        for part in parts {
+            match part {
+                "2H" => {
+                    push(9);
+                    push(10);
+                }
+                "3H" => {
+                    push(9);
+                    push(10);
+                    push(11);
+                }
+                "4H" => {
+                    push(9);
+                    push(10);
+                    push(13);
+                    push(14);
+                }
+                "5H" => {
+                    push(9);
+                    push(10);
+                    push(11);
+                    push(13);
+                    push(14);
+                }
+                "1T" => push(12),
+                "2T" => {
+                    push(12);
+                    push(15);
+                }
+                "no" | "C" => {}
+                _ => return None,
+            }
+        }
+        Some(Streams { ids, len })
+    }
+}
+
 /// A channel-input configuration: which original layout was folded into
 /// which carrier. Announced by ADOL instruction `0x1E`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -172,6 +287,32 @@ mod tests {
                 other => panic!("config {id} is half-defined: {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn layout_names_expand_to_stream_ids() {
+        assert_eq!(
+            Layout(32703).streams().unwrap().as_slice(),
+            &[0, 1, 2, 4, 5, 7, 8, 3, 9, 10, 11, 13, 14, 12]
+        );
+        assert_eq!(
+            Layout(26175).streams().unwrap().as_slice(),
+            &[0, 1, 2, 4, 5, 3, 9, 10, 13, 14]
+        );
+        assert_eq!(
+            Layout(63).streams().unwrap().as_slice(),
+            &[0, 1, 2, 4, 5, 3]
+        );
+        assert_eq!(Layout(11).streams().unwrap().as_slice(), &[0, 1, 3]);
+        assert_eq!(
+            Layout(26163).streams().unwrap().as_slice(),
+            &[0, 1, 4, 5, 9, 10, 13, 14]
+        );
+        assert_eq!(
+            Layout(26555).streams().unwrap().as_slice(),
+            &[0, 1, 4, 5, 7, 8, 3, 9, 10, 13, 14]
+        );
+        assert!(Layout(0xFFFFFF).streams().is_none());
     }
 
     #[test]

--- a/auro/src/layout.rs
+++ b/auro/src/layout.rs
@@ -208,6 +208,23 @@ impl Layout {
     }
 }
 
+impl Layout {
+    /// The label a decoded stream is catalogued under, by the channel count
+    /// of the layout: `Auro-3D-13.1` for `7.1_5H_1T`, `Auro-3D-9.1` for
+    /// `5.1_4H`, and the bare `Auro-3D` for the layouts with no common
+    /// name. Shared by the DAMF `sourceCodec` and the catalogue's probe so
+    /// the same layout is never stored under two strings.
+    pub fn source_codec_label(self) -> &'static str {
+        match self.streams().map(|s| s.len) {
+            Some(10) => "Auro-3D-9.1",
+            Some(11) => "Auro-3D-10.1",
+            Some(12) => "Auro-3D-11.1",
+            Some(14) => "Auro-3D-13.1",
+            _ => "Auro-3D",
+        }
+    }
+}
+
 /// A channel-input configuration: which original layout was folded into
 /// which carrier. Announced by ADOL instruction `0x1E`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -313,6 +330,16 @@ mod tests {
             &[0, 1, 4, 5, 7, 8, 3, 9, 10, 13, 14]
         );
         assert!(Layout(0xFFFFFF).streams().is_none());
+    }
+
+    #[test]
+    fn catalogue_labels_count_the_channels() {
+        assert_eq!(Layout(32703).source_codec_label(), "Auro-3D-13.1");
+        assert_eq!(Layout(26175).source_codec_label(), "Auro-3D-9.1");
+        assert_eq!(Layout(32319).source_codec_label(), "Auro-3D-11.1");
+        assert_eq!(Layout(26559).source_codec_label(), "Auro-3D-11.1");
+        assert_eq!(Layout(30271).source_codec_label(), "Auro-3D-10.1");
+        assert_eq!(Layout(26163).source_codec_label(), "Auro-3D");
     }
 
     #[test]

--- a/auro/src/lib.rs
+++ b/auro/src/lib.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Auro-Codec carrier detection.
+//!
+//! Auro-3D ships its height layer inside ordinary 24-bit PCM: the encoder
+//! folds the height channels into a 5.1 or 7.1 carrier mix and borrows the
+//! low bits of every carrier sample for a side channel that describes the
+//! fold and carries the residuals a decoder needs to undo it. The carrier
+//! plays as plain surround anywhere; only a decoder sees the side channel.
+//! On disc the carrier is usually a DTS-HD MA track, so the side channel
+//! survives only a bit-exact lossless decode.
+//!
+//! This crate reads the part of that side channel that is public: the block
+//! sync, its CRC, and the ADOL configuration that names the original and
+//! carrier layouts. It says *that* a stream is an Auro carrier and *what* it
+//! holds; it does not reconstruct the height channels. The residual layer
+//! (predictor seeds, Golomb-Rice residuals, the unmix) is not publicly
+//! specified.
+//!
+//! Sources: the public reverse-engineering by almirus (Orua-D3, MIT;
+//! MediaInfoLib PR #2531). The tables in [`layout`] are theirs.
+
+pub mod block;
+pub mod detect;
+pub mod layout;
+
+pub use block::{BlockError, BlockInfo, SyncHeader, parse_block, parse_sync};
+pub use detect::{ChannelStats, Detection, Detector};
+pub use layout::{ChannelConfig, Layout};

--- a/auro/src/lib.rs
+++ b/auro/src/lib.rs
@@ -10,20 +10,30 @@
 //! On disc the carrier is usually a DTS-HD MA track, so the side channel
 //! survives only a bit-exact lossless decode.
 //!
-//! This crate reads the part of that side channel that is public: the block
-//! sync, its CRC, and the ADOL configuration that names the original and
-//! carrier layouts. It says *that* a stream is an Auro carrier and *what* it
-//! holds; it does not reconstruct the height channels. The residual layer
-//! (predictor seeds, Golomb-Rice residuals, the unmix) is not publicly
-//! specified.
+//! This crate reads the whole side channel. [`block`] and [`detect`] find
+//! the blocks, check their CRC and read the ADOL configuration that names
+//! the original and carrier layouts. [`stream`], [`rice`] and [`unmix`]
+//! then read what each carrier folded — the seeds, gains, codebook and
+//! Golomb-Rice residuals — and restore the folded streams sample by sample,
+//! so that a 7.1 carrier gives back its 7.1 bed and its height layer.
+//! [`decode`] runs the whole chain on one carrier channel.
 //!
-//! Sources: the public reverse-engineering by almirus (Orua-D3, MIT;
-//! MediaInfoLib PR #2531). The tables in [`layout`] are theirs.
+//! The layout layer follows the public description by almirus (Orua-D3,
+//! MIT; MediaInfoLib PR #2531). The residual layer was worked out here by
+//! analysis; it is checked against a published original/encoded pair.
 
 pub mod block;
+pub mod decode;
 pub mod detect;
 pub mod layout;
+pub mod rice;
+pub mod stream;
+pub mod unfold;
+pub mod unmix;
 
 pub use block::{BlockError, BlockInfo, SyncHeader, parse_block, parse_sync};
+pub use decode::{ChannelDecoder, DecodeError, Decoded, StreamId};
 pub use detect::{ChannelStats, Detection, Detector};
-pub use layout::{ChannelConfig, Layout};
+pub use layout::{ChannelConfig, Layout, Streams};
+pub use stream::{StreamBlock, StreamError};
+pub use unfold::Unfolder;

--- a/auro/src/rice.rs
+++ b/auro/src/rice.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Residuals: a Golomb-Rice coded index per sample selects an entry of the
+// block's codebook. Two streams folded into one carrier share one index
+// that selects from two codebooks laid end to end.
+
+use crate::stream::{Cursor, MAX_CODEBOOK, Payload, StreamBlock};
+
+/// Why residuals could not be decoded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RiceError {
+    /// An index reached past the codebook.
+    Index,
+    /// The unary prefix ran past any sane length: the stream is not a Rice
+    /// stream.
+    Prefix,
+}
+
+/// Unary prefixes longer than this are noise, not data.
+const MAX_PREFIX: u32 = 64;
+
+/// The decoded codebook of one block: `count` entries per stream, sign and
+/// magnitude packed in `width` bits.
+pub struct Codebook {
+    pub entries: [i32; MAX_CODEBOOK],
+    pub count: usize,
+    pub streams: usize,
+}
+
+impl Codebook {
+    pub const fn new() -> Self {
+        Self {
+            entries: [0; MAX_CODEBOOK],
+            count: 0,
+            streams: 0,
+        }
+    }
+
+    pub fn load(&mut self, payload: &Payload, block: &StreamBlock) {
+        let width = u32::from(block.width);
+        self.count = usize::from(block.count);
+        self.streams = if block.mode == 3 { 2 } else { 1 };
+        let mut c = Cursor {
+            payload,
+            pos: block.codebook_pos,
+        };
+        let top = if width == 0 || width >= 32 {
+            0
+        } else {
+            1u32 << (width - 1)
+        };
+        for e in self.entries.iter_mut().take(self.count * self.streams) {
+            let v = c.read(width);
+            *e = if width < 32 {
+                let mag = (v & top.wrapping_sub(1)) as i32;
+                if v & top != 0 { -mag } else { mag }
+            } else {
+                v as i32
+            };
+        }
+    }
+}
+
+impl Default for Codebook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decode `n` residual entries into `out` (one value per entry, or two
+/// interleaved for a three-stream fold). Returns the payload position
+/// reached.
+pub fn decode_residuals(
+    payload: &Payload,
+    block: &StreamBlock,
+    codebook: &Codebook,
+    n: usize,
+    out: &mut [i32],
+) -> Result<usize, RiceError> {
+    let mut c = Cursor {
+        payload,
+        pos: block.rice_pos,
+    };
+    let mut k = u32::from(block.k);
+    let mut counter = 0u32;
+    let two = codebook.streams == 2;
+    for i in 0..n {
+        if block.adaptive && counter == 0 {
+            k = c.read(3);
+        }
+        counter = if counter + 1 < 32 { counter + 1 } else { 0 };
+        let mut q = 0u32;
+        while c.bit() == 1 {
+            q += 1;
+            if q > MAX_PREFIX {
+                return Err(RiceError::Prefix);
+            }
+        }
+        // The suffix is sent least-significant bit first.
+        let mut val = 0u32;
+        for b in 0..k {
+            if c.bit() == 1 {
+                val |= 1 << b;
+            }
+        }
+        let index = ((q << k) | val) as usize;
+        if index >= codebook.count {
+            return Err(RiceError::Index);
+        }
+        if two {
+            out[2 * i] = codebook.entries[index];
+            out[2 * i + 1] = codebook.entries[codebook.count + index];
+        } else {
+            out[i] = codebook.entries[index];
+        }
+    }
+    Ok(c.pos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload_from_bits(bits: &[u32]) -> Payload {
+        let mut p = Payload::new();
+        for (i, &b) in bits.iter().enumerate() {
+            p.words[i / 32] |= b << (31 - i % 32);
+        }
+        p.len_bits = bits.len();
+        p
+    }
+
+    #[test]
+    fn rice_index_is_unary_prefix_then_lsb_first_suffix() {
+        // k = 2, codebook of 8 entries (width 4, sign-magnitude): entry i = i,
+        // entry 5 = -1 (0b1001).
+        let mut bits = Vec::new();
+        for e in [0u32, 1, 2, 3, 4, 0b1001, 6, 7] {
+            for b in (0..4).rev() {
+                bits.push((e >> b) & 1);
+            }
+        }
+        let codebook_pos = 0;
+        let rice_pos = bits.len();
+        // index 5 = q 1, val 1: prefix "10", suffix lsb-first "10"
+        bits.extend([1, 0, 1, 0]);
+        // index 2 = q 0, val 2: "0", suffix "01"
+        bits.extend([0, 0, 1]);
+        // index 7 = q 1, val 3: "10", "11"
+        bits.extend([1, 0, 1, 1]);
+        let p = payload_from_bits(&bits);
+        let block = StreamBlock {
+            ids: [0, 9, 0xff],
+            mode: 2,
+            seeds: [0; 5],
+            gain_codes: [0; 3],
+            gain_offset: 0,
+            config: None,
+            k: 2,
+            adaptive: false,
+            count: 8,
+            width: 4,
+            codebook_pos,
+            rice_pos,
+        };
+        let mut cb = Codebook::new();
+        cb.load(&p, &block);
+        assert_eq!(&cb.entries[..8], &[0, 1, 2, 3, 4, -1, 6, 7]);
+        let mut out = [0i32; 3];
+        let end = decode_residuals(&p, &block, &cb, 3, &mut out).unwrap();
+        assert_eq!(out, [-1, 2, 7]);
+        assert_eq!(end, bits.len());
+    }
+
+    #[test]
+    fn an_index_past_the_codebook_is_an_error() {
+        let bits = [1u32, 1, 1, 0]; // q = 3, k = 0 -> index 3 of a 2-entry book
+        let p = payload_from_bits(&bits);
+        let block = StreamBlock {
+            ids: [0, 9, 0xff],
+            mode: 2,
+            seeds: [0; 5],
+            gain_codes: [0; 3],
+            gain_offset: 0,
+            config: None,
+            k: 0,
+            adaptive: false,
+            count: 2,
+            width: 4,
+            codebook_pos: 0,
+            rice_pos: 0,
+        };
+        let mut cb = Codebook::new();
+        cb.count = 2;
+        cb.streams = 1;
+        let mut out = [0i32; 1];
+        assert_eq!(
+            decode_residuals(&p, &block, &cb, 1, &mut out),
+            Err(RiceError::Index)
+        );
+    }
+}

--- a/auro/src/stream.rs
+++ b/auro/src/stream.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The stream layer of one block: the payload bits gathered into words, and
+// the per-block description of what the carrier holds — which streams, how
+// they were folded, and where their residual data starts.
+//
+// Every carrier channel describes itself. After the 48 header bits parsed by
+// [`crate::block`], the payload opens with a 112-bit fixed header, the
+// predictor seeds, the ADOL bytecode (also used for the layout), a small
+// codebook of residual values, and finally the Golomb-Rice coded indices
+// that pick from that codebook, one per sample (two in the three-stream
+// fold).
+
+use crate::block::{MAX_BLOCK, SYNC_SAMPLES, SyncHeader};
+
+/// Payload words for the largest block at the widest borrow: `14 * 4096`
+/// bits.
+pub const PAYLOAD_WORDS: usize = (14 * MAX_BLOCK).div_ceil(32);
+
+/// Largest codebook the count code can express (`8 * 0x53 - 64`), twice
+/// for the three-stream fold.
+pub const MAX_CODEBOOK: usize = 2 * (8 * 0x53 - 64);
+
+/// Most streams one carrier folds.
+pub const MAX_STREAMS: usize = 3;
+
+/// The side-channel bits of one block, MSB first, packed in `u32` words.
+pub struct Payload {
+    pub words: [u32; PAYLOAD_WORDS],
+    pub len_bits: usize,
+}
+
+impl Payload {
+    pub const fn new() -> Self {
+        Self {
+            words: [0; PAYLOAD_WORDS],
+            len_bits: 0,
+        }
+    }
+
+    /// Gather the payload of `block` (all `header.block_size` samples). The
+    /// header samples lend bits `3..m`; every later sample lends its low
+    /// `m` bits except bit 0 of every sixteenth sample, which is reserved.
+    pub fn gather(&mut self, block: &[i32], header: SyncHeader) {
+        let m = u32::from(header.lsb_bits);
+        let mut n = 0usize;
+        let mut word = 0u32;
+        let mut fill = 0u32;
+        let mut push = |bit: u32| {
+            word = (word << 1) | bit;
+            fill += 1;
+            if fill == 32 {
+                self.words[n / 32] = word;
+                word = 0;
+                fill = 0;
+            }
+            n += 1;
+        };
+        for (i, &s) in block.iter().enumerate() {
+            let low = if i < SYNC_SAMPLES {
+                3
+            } else if i % 16 == 0 {
+                1
+            } else {
+                0
+            };
+            let v = s as u32;
+            let mut b = m;
+            while b > low {
+                b -= 1;
+                push((v >> b) & 1);
+            }
+        }
+        if fill != 0 {
+            self.words[n / 32] = word << (32 - fill);
+        }
+        self.len_bits = n;
+    }
+
+    /// Bit at `pos`, or 0 past the end.
+    #[inline]
+    pub fn bit(&self, pos: usize) -> u32 {
+        if pos >= self.len_bits {
+            return 0;
+        }
+        (self.words[pos / 32] >> (31 - (pos % 32))) & 1
+    }
+}
+
+impl Default for Payload {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Sequential MSB-first reader over a [`Payload`].
+pub struct Cursor<'a> {
+    pub payload: &'a Payload,
+    pub pos: usize,
+}
+
+impl Cursor<'_> {
+    #[inline]
+    pub fn bit(&mut self) -> u32 {
+        let b = self.payload.bit(self.pos);
+        self.pos += 1;
+        b
+    }
+
+    pub fn read(&mut self, bits: u32) -> u32 {
+        let mut v = 0u32;
+        for _ in 0..bits {
+            v = (v << 1) | self.bit();
+        }
+        v
+    }
+}
+
+/// Why a block's stream layer could not be read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StreamError {
+    /// The fixed header's first field is outside the accepted range.
+    Header,
+    /// The codebook count code has no defined size.
+    CountCode,
+    /// An ADOL block did not start with tag 1 or 2.
+    AdolTag,
+    /// An ADOL opcode outside the known set.
+    AdolOpcode(u8),
+    /// The bytecode did not terminate within the instruction budget.
+    AdolRunaway,
+    /// The codebook does not fit in the payload.
+    CodebookOverrun,
+    /// A gain index (code + offset) is outside the gain table.
+    Gain,
+}
+
+/// What one carrier holds in one block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StreamBlock {
+    /// Streams folded into this carrier, in fold order; `mode` of them are
+    /// valid.
+    pub ids: [u8; MAX_STREAMS],
+    /// 1, 2 or 3 streams (0 = nothing announced).
+    pub mode: u8,
+    /// Predictor seeds: two for the two-stream fold, five for three.
+    pub seeds: [i32; 5],
+    /// Gain codes per stream (ADOL `0x40`), in tenths of a dB.
+    pub gain_codes: [u8; MAX_STREAMS],
+    /// Gain offset added to every code (ADOL `0x41`).
+    pub gain_offset: u8,
+    /// Channel-input configuration announced by ADOL `0x1E`, if any.
+    pub config: Option<u8>,
+    /// Rice parameter, or the initial one when `adaptive`.
+    pub k: u8,
+    /// Re-read the Rice parameter from the stream every 32 samples.
+    pub adaptive: bool,
+    /// Codebook entries per stream and bits per entry.
+    pub count: u16,
+    pub width: u8,
+    /// Payload bit position of the codebook and of the Golomb-Rice stream.
+    pub codebook_pos: usize,
+    pub rice_pos: usize,
+}
+
+/// Codebook entries from the count code: three ranges of linear steps.
+pub fn codebook_count(code: u32) -> Option<u16> {
+    Some(match code {
+        0..=4 => 2 * code + 8,
+        5..=15 => 4 * code,
+        16..=0x53 => 8 * code - 64,
+        _ => return None,
+    } as u16)
+}
+
+/// Most ADOL instructions the stream layer follows before giving up.
+const MAX_INSTRUCTIONS: usize = 256;
+
+/// Parse the stream layer from a gathered payload.
+pub fn parse_stream(payload: &Payload) -> Result<StreamBlock, StreamError> {
+    let mut c = Cursor { payload, pos: 0 };
+    let hdr = c.read(16);
+    if !(hdr < 0x200 && (hdr < 0x100 || (hdr & 0xff) < 0xb)) {
+        return Err(StreamError::Header);
+    }
+    let w = c.read(32);
+    let ids_word = c.read(32);
+    let _ids2 = c.read(32);
+    let mut ids = [0xffu8; MAX_STREAMS];
+    let mut mode = 0u8;
+    for (j, slot) in ids.iter_mut().enumerate() {
+        *slot = ((ids_word >> (24 - 8 * j)) & 0xff) as u8;
+        if *slot != 0xff {
+            mode += 1;
+        }
+    }
+    // A missing slot ahead of a present one would leave a hole in the fold.
+    let mode = if ids[..usize::from(mode)].iter().any(|&v| v == 0xff) {
+        0
+    } else {
+        mode
+    };
+    let nseeds = match mode {
+        3 => 5,
+        2 => 2,
+        _ => 0,
+    };
+    let mut seeds = [0i32; 5];
+    for seed in seeds.iter_mut().take(nseeds) {
+        *seed = c.read(32) as i32;
+    }
+    let adol_blocks = (w >> 8) & 0xf;
+    let width = (w & 0xff) as u8;
+    let count = codebook_count((w >> 16) & 0xff).ok_or(StreamError::CountCode)?;
+    let k = ((w >> 24) & 0xf) as u8;
+    let adaptive = w & 0x4000_0000 != 0;
+
+    let mut gain_codes = [0u8; MAX_STREAMS];
+    let mut gain_offset = 0u8;
+    let mut config = None;
+    let mut budget = MAX_INSTRUCTIONS;
+    for _ in 0..adol_blocks {
+        match c.read(8) {
+            1 => loop {
+                if budget == 0 {
+                    return Err(StreamError::AdolRunaway);
+                }
+                budget -= 1;
+                let op = c.read(8) as u8;
+                match op {
+                    0x00 => break,
+                    0x01 | 0x03 | 0x5A..=0x62 => {
+                        c.read(16);
+                    }
+                    0x40 => {
+                        let ch = c.read(8) as u8;
+                        let scaler = c.read(8) as u8;
+                        for j in 0..usize::from(mode) {
+                            if ids[j] == ch {
+                                gain_codes[j] = scaler;
+                            }
+                        }
+                    }
+                    0x41 => gain_offset = c.read(8) as u8,
+                    0x1E => config = Some(c.read(8) as u8),
+                    0x02 | 0x04 | 0x1F | 0x47 | 0x50..=0x58 => {
+                        c.read(8);
+                    }
+                    0x0E | 0x46 | 0x6E..=0x76 | 0x80..=0x85 | 0x8C..=0x90 => {
+                        c.read(32);
+                    }
+                    0x64..=0x6C => {
+                        c.read(24);
+                    }
+                    other => return Err(StreamError::AdolOpcode(other)),
+                }
+            },
+            2 => {
+                let n = (c.read(24) >> 16) & 0xff;
+                for _ in 0..n {
+                    c.read(32);
+                }
+            }
+            _ => return Err(StreamError::AdolTag),
+        }
+    }
+    let codebook_pos = c.pos;
+    let streams = if mode == 3 { 2 } else { 1 };
+    let codebook_bits = usize::from(count) * usize::from(width) * streams;
+    if codebook_pos + codebook_bits > payload.len_bits {
+        return Err(StreamError::CodebookOverrun);
+    }
+    Ok(StreamBlock {
+        ids,
+        mode,
+        seeds,
+        gain_codes,
+        gain_offset,
+        config,
+        k,
+        adaptive,
+        count,
+        width,
+        codebook_pos,
+        rice_pos: codebook_pos + codebook_bits,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codebook_sizes_follow_the_three_ranges() {
+        assert_eq!(codebook_count(0), Some(8));
+        assert_eq!(codebook_count(4), Some(16));
+        assert_eq!(codebook_count(5), Some(20));
+        assert_eq!(codebook_count(15), Some(60));
+        assert_eq!(codebook_count(16), Some(64));
+        assert_eq!(codebook_count(0x53), Some(600));
+        assert_eq!(codebook_count(0x54), None);
+    }
+
+    #[test]
+    fn gather_takes_bits_three_up_in_the_header_then_m_per_sample() {
+        // m = 4, block of 20 samples: 16 header samples give bit 3 each,
+        // sample 16 gives bits 3..1 (bit 0 reserved), 17..20 give 4 bits.
+        let mut block = [0i32; 20];
+        block[0] = 0b1000; // header: bit 3 set -> first payload bit 1
+        block[16] = 0b0111; // bits 3,2,1 -> 0,1,1 (bit 0 ignored)
+        block[17] = 0b1001;
+        let header = SyncHeader {
+            block_size: 20,
+            lsb_bits: 4,
+        };
+        let mut p = Payload::new();
+        p.gather(&block, header);
+        assert_eq!(p.len_bits, 16 + 3 + 3 * 4);
+        let bits: Vec<u32> = (0..p.len_bits).map(|i| p.bit(i)).collect();
+        assert_eq!(
+            &bits[..16],
+            &[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+        assert_eq!(&bits[16..19], &[0, 1, 1]);
+        assert_eq!(&bits[19..23], &[1, 0, 0, 1]);
+        assert_eq!(p.bit(1000), 0);
+    }
+}

--- a/auro/src/unfold.rs
+++ b/auro/src/unfold.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The carrier channels of one stream, unfolded together.
+//
+// Each carrier is decoded on its own; this joins them. Blocks are only
+// decodable once their last sample has arrived, so output lags input by one
+// block. Samples no block claims — before the first block, after the last,
+// or in a block that failed — play the carrier as authored for the bed and
+// silence for the heights, which is what the disc sounds like without a
+// decoder. A stream folded into two carriers is averaged.
+
+use crate::block::MAX_BLOCK;
+use crate::decode::{ChannelDecoder, StreamId};
+use crate::detect::ChannelStats;
+
+/// Output ring per stream. Holds the latency plus the largest push plus one
+/// block. Power of two.
+const RING: usize = 16384;
+const RING_MASK: u64 = (RING - 1) as u64;
+/// Largest single push the ring is sized for.
+pub const MAX_PUSH: usize = 4096;
+/// Output lags input by this many samples.
+pub const LATENCY: usize = MAX_BLOCK;
+
+/// Stream ids run 0..16.
+const STREAMS: usize = 16;
+
+struct Ring {
+    sum: Box<[i32]>,
+    hits: Box<[u8]>,
+}
+
+impl Ring {
+    fn new() -> Self {
+        Self {
+            sum: vec![0; RING].into_boxed_slice(),
+            hits: vec![0; RING].into_boxed_slice(),
+        }
+    }
+}
+
+struct Carrier {
+    decoder: ChannelDecoder,
+    /// The bed stream this carrier plays as without a decoder.
+    id: StreamId,
+    /// The carrier as authored, for the samples no block claims.
+    plain: Box<[i32]>,
+    /// Which samples a decoded block claimed.
+    claimed: Box<[u8]>,
+}
+
+pub struct Unfolder {
+    carriers: Vec<Carrier>,
+    rings: Vec<Option<Ring>>,
+    released: u64,
+    latency: usize,
+}
+
+impl Unfolder {
+    /// `carrier_ids` says which bed stream each carrier channel plays as;
+    /// `outputs` which streams will be asked for.
+    pub fn new(carrier_ids: &[StreamId], outputs: &[StreamId]) -> Self {
+        let mut rings: Vec<Option<Ring>> = (0..STREAMS).map(|_| None).collect();
+        for id in outputs {
+            if let Some(slot) = rings.get_mut(usize::from(id.0)) {
+                *slot = Some(Ring::new());
+            }
+        }
+        Self {
+            carriers: carrier_ids
+                .iter()
+                .map(|&id| Carrier {
+                    decoder: ChannelDecoder::new(),
+                    id,
+                    plain: vec![0; RING].into_boxed_slice(),
+                    claimed: vec![0; RING].into_boxed_slice(),
+                })
+                .collect(),
+            rings,
+            released: 0,
+            latency: LATENCY,
+        }
+    }
+
+    pub fn carrier_count(&self) -> usize {
+        self.carriers.len()
+    }
+
+    pub fn stats(&self, carrier: usize) -> ChannelStats {
+        self.carriers[carrier].decoder.stats()
+    }
+
+    pub fn decode_errors(&self) -> u64 {
+        self.carriers.iter().map(|c| c.decoder.decode_errors).sum()
+    }
+
+    /// Feed the next samples of one carrier. At most [`MAX_PUSH`] at a
+    /// time; every carrier must be fed the same amount before `take`.
+    pub fn push(&mut self, carrier: usize, samples: &[i32]) {
+        debug_assert!(samples.len() <= MAX_PUSH);
+        let Self {
+            carriers, rings, ..
+        } = self;
+        let c = &mut carriers[carrier];
+        let base = c.decoder.position();
+        for (i, &s) in samples.iter().enumerate() {
+            let at = ((base + i as u64) & RING_MASK) as usize;
+            c.plain[at] = s;
+            c.claimed[at] = 0;
+        }
+        let claimed = &mut c.claimed;
+        c.decoder.push(samples, |d| {
+            let n = usize::from(d.header.block_size);
+            for i in 0..n {
+                claimed[((d.start + i as u64) & RING_MASK) as usize] = 1;
+            }
+            for (id, out) in d.outputs.iter().take(usize::from(d.stream.mode)) {
+                let Some(Some(ring)) = rings.get_mut(usize::from(id.0)) else {
+                    continue;
+                };
+                for (i, &v) in out[..n].iter().enumerate() {
+                    let at = ((d.start + i as u64) & RING_MASK) as usize;
+                    if ring.hits[at] == 0 {
+                        ring.sum[at] = v;
+                    } else {
+                        ring.sum[at] = ring.sum[at].saturating_add(v);
+                    }
+                    ring.hits[at] = ring.hits[at].saturating_add(1);
+                }
+            }
+        });
+    }
+
+    /// Samples every carrier has passed, minus the latency.
+    fn frontier(&self) -> u64 {
+        let min = self
+            .carriers
+            .iter()
+            .map(|c| c.decoder.position())
+            .min()
+            .unwrap_or(0);
+        min.saturating_sub(self.latency as u64)
+    }
+
+    /// Samples that can be taken now.
+    pub fn ready(&self) -> usize {
+        (self.frontier() - self.released) as usize
+    }
+
+    /// No more input is coming: everything pushed becomes takeable.
+    pub fn finish(&mut self) {
+        self.latency = 0;
+    }
+
+    /// Take up to `out.len() / ids.len()` frames, interleaved in the order
+    /// of `ids`. Returns the frames written.
+    pub fn take(&mut self, ids: &[StreamId], out: &mut [i32]) -> usize {
+        if ids.is_empty() {
+            return 0;
+        }
+        let frames = self.ready().min(out.len() / ids.len());
+        for f in 0..frames {
+            let pos = self.released + f as u64;
+            let at = (pos & RING_MASK) as usize;
+            for (j, id) in ids.iter().enumerate() {
+                out[f * ids.len() + j] = self.sample(*id, at);
+            }
+        }
+        // Clear what was taken so the ring is clean when it wraps back.
+        for f in 0..frames {
+            let at = ((self.released + f as u64) & RING_MASK) as usize;
+            for ring in self.rings.iter_mut().flatten() {
+                ring.hits[at] = 0;
+                ring.sum[at] = 0;
+            }
+            for c in &mut self.carriers {
+                c.claimed[at] = 0;
+            }
+        }
+        self.released += frames as u64;
+        frames
+    }
+
+    fn sample(&self, id: StreamId, at: usize) -> i32 {
+        if let Some(Some(ring)) = self.rings.get(usize::from(id.0)) {
+            let hits = ring.hits[at];
+            if hits == 1 {
+                return ring.sum[at];
+            }
+            if hits > 1 {
+                return ring.sum[at] / i32::from(hits);
+            }
+        }
+        // Nothing decoded here: the carrier as authored, when it is this
+        // stream and no block claimed the sample.
+        for c in &self.carriers {
+            if c.id == id && c.claimed[at] == 0 {
+                return c.plain[at];
+            }
+        }
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_pcm_passes_through_after_the_latency() {
+        let ids = [StreamId(0), StreamId(1)];
+        let mut u = Unfolder::new(&ids, &[StreamId(0), StreamId(1), StreamId(9)]);
+        let left: Vec<i32> = (0..6000).map(|i| i * 8).collect();
+        let right: Vec<i32> = (0..6000).map(|i| -i * 8).collect();
+        for chunk in 0..6 {
+            u.push(0, &left[chunk * 1000..(chunk + 1) * 1000]);
+            u.push(1, &right[chunk * 1000..(chunk + 1) * 1000]);
+        }
+        assert_eq!(u.ready(), 6000 - LATENCY);
+        let mut out = vec![0i32; 3 * 6000];
+        let n = u.take(&[StreamId(0), StreamId(1), StreamId(9)], &mut out);
+        assert_eq!(n, 6000 - LATENCY);
+        assert_eq!(&out[..6], &[0, 0, 0, 8, -8, 0]);
+        u.finish();
+        let n2 = u.take(&[StreamId(0), StreamId(1), StreamId(9)], &mut out);
+        assert_eq!(n2, LATENCY);
+        assert_eq!(out[0], (6000 - LATENCY as i32) * 8);
+    }
+}

--- a/auro/src/unfold.rs
+++ b/auro/src/unfold.rs
@@ -152,6 +152,13 @@ impl Unfolder {
         self.latency = 0;
     }
 
+    /// Lag output by `samples` instead of the default [`LATENCY`]. One block
+    /// is enough once the block size is known: a block decodes the moment
+    /// its last sample arrives. Never below what has already been released.
+    pub fn set_latency(&mut self, samples: usize) {
+        self.latency = samples.min(LATENCY);
+    }
+
     /// Take up to `out.len() / ids.len()` frames, interleaved in the order
     /// of `ids`. Returns the frames written.
     pub fn take(&mut self, ids: &[StreamId], out: &mut [i32]) -> usize {

--- a/auro/src/unmix.rs
+++ b/auro/src/unmix.rs
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Undo the fold: from one carrier and its residuals, restore the two or
+// three streams that were mixed into it.
+//
+// The carrier, with its borrowed bits dropped, is the exact sum of the
+// folded streams. Each sample, one stream is extrapolated from its own
+// recent history while the others are derived from the sum; the residuals
+// steer the extrapolation so the derived values land on the originals. Two
+// streams alternate sample by sample with a linear extrapolator; three
+// streams rotate through a three-phase one. The arithmetic below is the
+// integer arithmetic a decoder has to reproduce exactly — the outputs are
+// defined by it, not by any nicer formulation.
+
+use crate::stream::{MAX_STREAMS, StreamBlock};
+
+/// Gain codes count tenths of a decibel; the table holds codes 0..244 with
+/// the exact powers of two pinned at 6, 12, 18 and 24 dB.
+pub const GAIN_CODES: usize = 244;
+
+pub struct GainTable {
+    pub linear: [f32; GAIN_CODES],
+}
+
+impl GainTable {
+    pub fn new() -> Self {
+        let step = 0.011_512_926_f32; // ln(10) / 200
+        let mut linear = [0f32; GAIN_CODES];
+        for (i, g) in linear.iter_mut().enumerate() {
+            *g = ((i as f32) * step).exp();
+        }
+        linear[60] = 2.0;
+        linear[120] = 4.0;
+        linear[180] = 8.0;
+        linear[240] = 16.0;
+        Self { linear }
+    }
+
+    /// Linear gain for `code + offset`, or `None` past the table.
+    pub fn get(&self, code: u8, offset: u8) -> Option<f32> {
+        self.linear
+            .get(usize::from(code) + usize::from(offset))
+            .copied()
+    }
+}
+
+impl Default for GainTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[inline]
+fn clamp24(v: i32) -> i32 {
+    v.clamp(-0x7f_ffff, 0x7f_ffff)
+}
+
+/// Scale a restored stream back to 24-bit: multiply in single precision,
+/// truncate, restore the borrowed bits' weight, clamp.
+#[inline]
+fn scale(v: i32, gain: f32, m: u32) -> i32 {
+    let f = (v as f32) * gain;
+    // `as i32` truncates toward zero and saturates, as the reference does.
+    clamp24((f as i32).wrapping_shl(m))
+}
+
+/// Restore the streams of one block. `carrier` holds the block's samples,
+/// `residuals` what [`crate::rice::decode_residuals`] produced (one or two
+/// per sample), and `out[j]` receives stream `j` for `j < mode`. Each `out`
+/// slice must be at least as long as `carrier`.
+///
+/// Returns `false` when a gain index falls outside the table.
+pub fn unmix(
+    block: &StreamBlock,
+    gains: &GainTable,
+    lsb_bits: u8,
+    carrier: &[i32],
+    residuals: &[i32],
+    out: &mut [&mut [i32]; MAX_STREAMS],
+) -> bool {
+    let n = carrier.len();
+    let m = u32::from(lsb_bits);
+    let mode = usize::from(block.mode);
+    let mut g = [1f32; MAX_STREAMS];
+    for j in 0..mode {
+        match gains.get(block.gain_codes[j], block.gain_offset) {
+            Some(v) => g[j] = v,
+            None => return false,
+        }
+    }
+    match mode {
+        1 => {
+            let mask = -1i32 << m;
+            for i in 0..n {
+                out[0][i] = clamp24(((carrier[i] & mask) as f32 * g[0]) as i32);
+            }
+        }
+        2 => {
+            let (a, rest) = out.split_at_mut(1);
+            let (a, b) = (&mut *a[0], &mut *rest[0]);
+            let c = |i: usize| carrier[i] >> m;
+            if n == 0 {
+                return true;
+            }
+            b[0] = block.seeds[1].wrapping_add(residuals[0]);
+            a[0] = c(0).wrapping_sub(b[0]);
+            let mut s3 = a[0];
+            if n == 1 {
+                a[0] = scale(a[0], g[0], m);
+                b[0] = scale(b[0], g[1], m);
+                return true;
+            }
+            a[1] = residuals[1].wrapping_add(block.seeds[0]);
+            b[1] = c(1).wrapping_sub(a[1]);
+            let mut s2 = block.seeds[0];
+            let mut s4 = b[1];
+            // From here the roles alternate: `ext` is extrapolated, `der`
+            // derived from the sum.
+            let mut a_is_ext = true;
+            for i in 2..n {
+                let pred = s2.wrapping_mul(2).wrapping_sub(s3);
+                let der = c(i).wrapping_sub(pred);
+                if a_is_ext {
+                    a[i] = pred;
+                    b[i] = der;
+                } else {
+                    b[i] = pred;
+                    a[i] = der;
+                }
+                s3 = s4;
+                s2 = der.wrapping_sub(residuals[i]);
+                s4 = pred;
+                a_is_ext = !a_is_ext;
+            }
+            for i in 0..n {
+                a[i] = scale(a[i], g[0], m);
+                b[i] = scale(b[i], g[1], m);
+            }
+        }
+        3 => {
+            let (a, rest) = out.split_at_mut(1);
+            let (b, rest) = rest.split_at_mut(1);
+            let (a, b, cc) = (&mut *a[0], &mut *b[0], &mut *rest[0]);
+            let c = |i: usize| carrier[i] >> m;
+            let r = |i: usize, j: usize| residuals[2 * i + j];
+            let s = &block.seeds;
+            if n == 0 {
+                return true;
+            }
+            // Three warm-up samples seeded from the header.
+            b[0] = s[0];
+            cc[0] = s[1];
+            a[0] = c(0)
+                .wrapping_sub(r(0, 1))
+                .wrapping_sub(s[1])
+                .wrapping_sub(r(0, 0))
+                .wrapping_sub(b[0]);
+            let mut s7 = cc[0];
+            let mut s9 = a[0];
+            let mut s8 = 0i32;
+            let mut s6 = 0i32;
+            if n > 1 {
+                cc[1] = s[3];
+                a[1] = s[2];
+                b[1] = c(1)
+                    .wrapping_sub(r(1, 1))
+                    .wrapping_sub(r(1, 0))
+                    .wrapping_sub(a[1])
+                    .wrapping_sub(cc[1]);
+                s7 = a[1];
+                s8 = s9;
+                s9 = b[1];
+            }
+            if n > 2 {
+                let pred = s7.wrapping_mul(4).wrapping_sub(s8.wrapping_mul(3));
+                let mut t = s8.wrapping_add(pred.wrapping_mul(3));
+                if t < 0 {
+                    t = t.wrapping_add(3);
+                }
+                a[2] = t >> 2;
+                b[2] = s[4];
+                cc[2] = c(2)
+                    .wrapping_sub(r(2, 1))
+                    .wrapping_sub(r(2, 0))
+                    .wrapping_sub(b[2])
+                    .wrapping_sub(a[2]);
+                s7 = b[2];
+                s8 = s9;
+                s9 = cc[2];
+                s6 = pred;
+            }
+            // Roles rotate: `l78` gets the fresh extrapolation, `p16` the
+            // previous one, `lres8` is derived from the sum.
+            let (mut l70, mut lres8, mut l78) = (1usize, 2usize, 0usize); // B, C, A
+            for i in 3..n {
+                let p16 = l78;
+                l78 = l70;
+                let pred = s7.wrapping_mul(4).wrapping_sub(s8.wrapping_mul(3));
+                let mut t = s8.wrapping_add(pred.wrapping_mul(3));
+                if t < 0 {
+                    t = t.wrapping_add(3);
+                }
+                let derived = c(i)
+                    .wrapping_sub(r(i, 1))
+                    .wrapping_sub(s6)
+                    .wrapping_sub(r(i, 0))
+                    .wrapping_sub(t >> 2);
+                set(a, b, cc, lres8, i, derived);
+                set(a, b, cc, p16, i, s6);
+                set(a, b, cc, l78, i, t >> 2);
+                s7 = derived;
+                s8 = s9;
+                s9 = s6;
+                s6 = pred;
+                l70 = lres8;
+                lres8 = p16;
+            }
+            // Put the residuals back on the two non-derived streams.
+            let mut ph = 0usize;
+            for i in 0..n {
+                let (x, y) = match ph % 3 {
+                    1 => (0usize, 2usize),
+                    2 => (0, 1),
+                    _ => (1, 2),
+                };
+                add(a, b, cc, x, i, r(i, 0));
+                add(a, b, cc, y, i, r(i, 1));
+                ph += 1;
+            }
+            for i in 0..n {
+                a[i] = scale(a[i], g[0], m);
+                b[i] = scale(b[i], g[1], m);
+                cc[i] = scale(cc[i], g[2], m);
+            }
+        }
+        _ => {}
+    }
+    true
+}
+
+#[inline]
+fn set(a: &mut [i32], b: &mut [i32], c: &mut [i32], which: usize, i: usize, v: i32) {
+    match which {
+        0 => a[i] = v,
+        1 => b[i] = v,
+        _ => c[i] = v,
+    }
+}
+
+#[inline]
+fn add(a: &mut [i32], b: &mut [i32], c: &mut [i32], which: usize, i: usize, v: i32) {
+    match which {
+        0 => a[i] = a[i].wrapping_add(v),
+        1 => b[i] = b[i].wrapping_add(v),
+        _ => c[i] = c[i].wrapping_add(v),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gain_codes_are_tenths_of_a_decibel_with_exact_octaves() {
+        let g = GainTable::new();
+        assert_eq!(g.get(0, 0), Some(1.0));
+        assert!((g.get(20, 0).unwrap() - 1.258_925).abs() < 1e-5);
+        assert_eq!(g.get(60, 0), Some(2.0));
+        assert_eq!(g.get(120, 0), Some(4.0));
+        assert_eq!(g.get(40, 20), Some(2.0));
+        assert_eq!(g.get(243, 0).is_some(), true);
+        assert_eq!(g.get(243, 1), None);
+    }
+
+    /// Fold two smooth streams the way an encoder would: an honest sum for
+    /// the carrier, and residuals that hand the decoder the derived
+    /// stream's error so its predictor tracks the truth.
+    fn fold_two(a_true: &[i32], b_true: &[i32], m: u32) -> (Vec<i32>, Vec<i32>, [i32; 5]) {
+        let n = a_true.len();
+        let mut carrier = vec![0i32; n];
+        let mut res = vec![0i32; n];
+        for i in 0..n {
+            carrier[i] = (a_true[i] + b_true[i]) << m;
+        }
+        let seeds = [a_true[1], b_true[0], 0, 0, 0];
+        // Replay the decoder to find the derived values it will see.
+        let c = |i: usize| carrier[i] >> m;
+        let b0 = seeds[1];
+        let mut s3 = c(0) - b0;
+        let mut s2 = seeds[0];
+        let mut s4 = c(1) - seeds[0];
+        let mut a_is_ext = true;
+        for i in 2..n {
+            let pred = 2 * s2 - s3;
+            let der = c(i) - pred;
+            let truth = if a_is_ext { b_true[i] } else { a_true[i] };
+            res[i] = der - truth;
+            s3 = s4;
+            s2 = der - res[i];
+            s4 = pred;
+            a_is_ext = !a_is_ext;
+        }
+        (carrier, res, seeds)
+    }
+
+    #[test]
+    fn two_folded_streams_come_back_close_and_sum_exactly() {
+        let n = 512;
+        let a_true: Vec<i32> = (0..n)
+            .map(|i| (30000.0 * (i as f64 * 0.05).sin()) as i32)
+            .collect();
+        let b_true: Vec<i32> = (0..n)
+            .map(|i| (12000.0 * (i as f64 * 0.11 + 1.0).cos()) as i32)
+            .collect();
+        let m = 3u32;
+        let (carrier, res, seeds) = fold_two(&a_true, &b_true, m);
+        let block = StreamBlock {
+            ids: [0, 9, 0xff],
+            mode: 2,
+            seeds,
+            gain_codes: [0; 3],
+            gain_offset: 0,
+            config: None,
+            k: 0,
+            adaptive: false,
+            count: 1,
+            width: 1,
+            codebook_pos: 0,
+            rice_pos: 0,
+        };
+        let mut a = vec![0i32; n];
+        let mut b = vec![0i32; n];
+        let mut cc = vec![0i32; n];
+        let mut out: [&mut [i32]; 3] = [&mut a, &mut b, &mut cc];
+        assert!(unmix(
+            &block,
+            &GainTable::new(),
+            m as u8,
+            &carrier,
+            &res,
+            &mut out
+        ));
+        let mut err = 0f64;
+        let mut sig = 0f64;
+        for i in 0..n {
+            assert_eq!(a[i] + b[i], carrier[i], "sample {i}");
+            err += f64::from(a[i] - (a_true[i] << m)).powi(2);
+            sig += f64::from(a_true[i] << m).powi(2);
+        }
+        let rel_db = 10.0 * (err / sig).log10();
+        assert!(rel_db < -40.0, "stream A is {rel_db:.1} dB off");
+    }
+
+    #[test]
+    fn three_streams_sum_back_to_the_carrier() {
+        let block = StreamBlock {
+            ids: [0, 9, 12],
+            mode: 3,
+            seeds: [7, -3, 11, 2, -9],
+            gain_codes: [0; 3],
+            gain_offset: 0,
+            config: None,
+            k: 0,
+            adaptive: false,
+            count: 1,
+            width: 1,
+            codebook_pos: 0,
+            rice_pos: 0,
+        };
+        let m = 4u8;
+        let n = 12;
+        let carrier: Vec<i32> = (0..n)
+            .map(|i| (((i * 611) % 300) as i32 - 150) * 16)
+            .collect();
+        let residuals: Vec<i32> = (0..2 * n).map(|i| (i % 7) as i32 - 3).collect();
+        let mut a = vec![0i32; n];
+        let mut b = vec![0i32; n];
+        let mut cc = vec![0i32; n];
+        let mut out: [&mut [i32]; 3] = [&mut a, &mut b, &mut cc];
+        assert!(unmix(
+            &block,
+            &GainTable::new(),
+            m,
+            &carrier,
+            &residuals,
+            &mut out
+        ));
+        for i in 0..n {
+            assert_eq!(a[i] + b[i] + cc[i], carrier[i], "sample {i}");
+        }
+    }
+}

--- a/auro/tests/corpus.rs
+++ b/auro/tests/corpus.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Against a real carrier, when one is at hand. `HARLETTY_AURO_CORPUS` names
+// an interleaved little-endian 32-bit PCM file (24-bit samples left-aligned,
+// as `ffmpeg -f s32le` writes them) and `HARLETTY_AURO_CORPUS_CHANNELS` its
+// channel count; `HARLETTY_AURO_CORPUS_LAYOUT` the layout name expected.
+
+use auro::{Detector, Layout};
+
+#[test]
+fn a_real_carrier_latches_its_layout() {
+    let (Ok(path), Ok(channels)) = (
+        std::env::var("HARLETTY_AURO_CORPUS"),
+        std::env::var("HARLETTY_AURO_CORPUS_CHANNELS"),
+    ) else {
+        eprintln!("skipping: HARLETTY_AURO_CORPUS is not set");
+        return;
+    };
+    let channels: usize = channels.parse().unwrap();
+    let expected =
+        std::env::var("HARLETTY_AURO_CORPUS_LAYOUT").unwrap_or_else(|_| "7.1_5H_1T".into());
+    let bytes = std::fs::read(&path).unwrap();
+    let frames = bytes.len() / (4 * channels);
+    let mut det = Detector::new(channels);
+    let mut latched = None;
+    let chunk = 512;
+    let mut buf = vec![0i32; chunk];
+    for start in (0..frames).step_by(chunk) {
+        let n = chunk.min(frames - start);
+        for ch in 0..channels {
+            for (i, slot) in buf[..n].iter_mut().enumerate() {
+                let o = ((start + i) * channels + ch) * 4;
+                *slot =
+                    i32::from_le_bytes([bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]]) >> 8;
+            }
+            if let Some(d) = det.push(ch, &buf[..n]) {
+                latched = Some(d);
+            }
+        }
+    }
+    let d = latched.expect("the corpus should latch");
+    assert_eq!(d.original.name(), Some(expected.as_str()));
+    assert_eq!(d.carrier, Layout(if channels == 8 { 447 } else { 63 }));
+    for ch in 0..channels {
+        let s = det.stats(ch);
+        eprintln!("channel {ch}: {s:?}");
+        assert!(s.valid_blocks > 10 * s.rejected, "channel {ch}: {s:?}");
+    }
+}

--- a/auro/tests/pair.rs
+++ b/auro/tests/pair.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The published original/encoded pair, when it is at hand: an Auro-2D
+// carrier (three channels) that folds a 5.1 mix, and that 5.1 mix.
+// `HARLETTY_AURO_PAIR_CARRIER` and `HARLETTY_AURO_PAIR_ORIGINAL` name the two
+// as interleaved little-endian 32-bit PCM (24-bit left-aligned), with
+// `HARLETTY_AURO_PAIR_CHANNELS` = "3,6".
+
+use auro::{ChannelDecoder, StreamId};
+
+fn read_s32(path: &str, channels: usize) -> Vec<Vec<i32>> {
+    let bytes = std::fs::read(path).unwrap();
+    let frames = bytes.len() / (4 * channels);
+    let mut out = vec![vec![0i32; frames]; channels];
+    for f in 0..frames {
+        for (c, ch) in out.iter_mut().enumerate() {
+            let o = (f * channels + c) * 4;
+            ch[f] = i32::from_le_bytes([bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]]) >> 8;
+        }
+    }
+    out
+}
+
+#[test]
+fn the_folded_five_one_comes_back_out_of_the_stereo_carrier() {
+    let (Ok(carrier_path), Ok(original_path)) = (
+        std::env::var("HARLETTY_AURO_PAIR_CARRIER"),
+        std::env::var("HARLETTY_AURO_PAIR_ORIGINAL"),
+    ) else {
+        eprintln!("skipping: HARLETTY_AURO_PAIR_CARRIER is not set");
+        return;
+    };
+    let chans = std::env::var("HARLETTY_AURO_PAIR_CHANNELS").unwrap_or_else(|_| "3,6".into());
+    let mut it = chans.split(',').map(|s| s.parse::<usize>().unwrap());
+    let (nc, no) = (it.next().unwrap(), it.next().unwrap());
+    let carrier = read_s32(&carrier_path, nc);
+    let original = read_s32(&original_path, no);
+    let frames = carrier[0].len();
+
+    // Restored streams by id, and how many carriers contributed to each
+    // sample (a stream folded into two carriers comes back twice).
+    let mut restored: Vec<Vec<i64>> = vec![vec![0; frames]; 16];
+    let mut hits: Vec<Vec<u8>> = vec![vec![0; frames]; 16];
+    let mut blocks = 0u64;
+    let mut errors = 0u64;
+    for ch in &carrier {
+        let mut dec = ChannelDecoder::new();
+        for chunk in ch.chunks(1024) {
+            dec.push(chunk, |d| {
+                blocks += 1;
+                let n = usize::from(d.header.block_size);
+                let start = d.start as usize;
+                for (id, out) in d.outputs.iter().take(usize::from(d.stream.mode)) {
+                    let StreamId(i) = *id;
+                    for (k, &v) in out[..n].iter().enumerate() {
+                        restored[usize::from(i)][start + k] += i64::from(v);
+                        hits[usize::from(i)][start + k] += 1;
+                    }
+                }
+            });
+        }
+        errors += dec.decode_errors;
+    }
+    eprintln!("blocks {blocks}, decode errors {errors}");
+    assert!(blocks > 0);
+    assert_eq!(errors, 0);
+
+    // Stream ids 0..6 are the 5.1 in the original's order.
+    for id in 0..6usize {
+        let orig = &original[id];
+        let mut sxy = 0f64;
+        let mut sxx = 0f64;
+        let mut syy = 0f64;
+        let mut covered = 0usize;
+        for f in 0..frames {
+            if hits[id][f] == 0 {
+                continue;
+            }
+            let x = restored[id][f] as f64 / f64::from(hits[id][f]);
+            let y = f64::from(orig[f]);
+            sxy += x * y;
+            sxx += x * x;
+            syy += y * y;
+            covered += 1;
+        }
+        if syy == 0.0 {
+            eprintln!(
+                "id {id} ({}): original is silent, skipped",
+                StreamId(id as u8).name()
+            );
+            continue;
+        }
+        let corr = sxy / (sxx.sqrt() * syy.sqrt());
+        let gain_db = 10.0 * (sxx / syy).log10();
+        eprintln!(
+            "id {id} ({}): covered {covered}/{frames}, corr {corr:.6}, gain {gain_db:+.3} dB",
+            StreamId(id as u8).name()
+        );
+        assert!(covered > frames / 2, "id {id} barely covered");
+        assert!(corr > 0.9999, "id {id}: corr {corr}");
+        assert!(gain_db.abs() < 0.1, "id {id}: gain {gain_db} dB");
+    }
+}

--- a/auro/tests/synthetic.rs
+++ b/auro/tests/synthetic.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Blocks built here by a writer that mirrors the reader's bit map, so the
+// parser and the detector are exercised without any real carrier.
+
+use auro::block::{MAX_BLOCK, SYNC_SAMPLES, bit_location, block_crc};
+use auro::{BlockError, ChannelConfig, Detector, Layout, parse_block, parse_sync};
+
+/// Deterministic 24-bit "audio": a linear congruential generator, so the
+/// low bits are as random as a real mix's before the encoder borrows them.
+struct Lcg(u32);
+
+impl Lcg {
+    fn next(&mut self) -> i32 {
+        self.0 = self.0.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        ((self.0 >> 8) as i32) << 8 >> 8
+    }
+}
+
+fn set_bit(samples: &mut [i32], idx: usize, bit: u32, value: u32) {
+    let mask = 1i32 << bit;
+    if value & 1 != 0 {
+        samples[idx] |= mask;
+    } else {
+        samples[idx] &= !mask;
+    }
+}
+
+struct Writer<'a> {
+    samples: &'a mut [i32],
+    m: usize,
+    pos: usize,
+}
+
+impl Writer<'_> {
+    fn put(&mut self, bits: u32, value: u32) {
+        for i in (0..bits).rev() {
+            let (idx, b) = bit_location(self.pos, self.m, true);
+            set_bit(self.samples, idx, b, (value >> i) & 1);
+            self.pos += 1;
+        }
+    }
+}
+
+/// Build one block: `block_size` samples borrowing `m` bits, announcing
+/// `config` on stream slot `slot`. `adol` is appended after the `0x1E`
+/// announcement, before the terminator.
+fn build_block(
+    seed: u32,
+    block_size: usize,
+    m: usize,
+    config: u8,
+    slot: u8,
+    adol: &[(u8, u32, u32)],
+) -> Vec<i32> {
+    assert!(block_size <= MAX_BLOCK);
+    let mut lcg = Lcg(seed);
+    let mut s: Vec<i32> = (0..block_size).map(|_| lcg.next()).collect();
+    // Header planes.
+    for (i, v) in s.iter_mut().enumerate().take(SYNC_SAMPLES) {
+        *v &= !0b111;
+        *v |= 1;
+        let _ = i;
+    }
+    let size_code = if block_size == 1000 {
+        0x3Du32
+    } else {
+        ((block_size - SYNC_SAMPLES) >> 4) as u32
+    };
+    for i in 0..8 {
+        set_bit(&mut s, i, 2, (size_code >> (7 - i)) & 1);
+    }
+    for i in 8..12 {
+        set_bit(&mut s, i, 2, 0);
+    }
+    let width_code = 14 - m as u32;
+    for i in 12..16 {
+        set_bit(&mut s, i, 2, (width_code >> (15 - i)) & 1);
+    }
+    // Payload.
+    let mut w = Writer {
+        samples: &mut s,
+        m,
+        pos: 48,
+    };
+    w.put(8, 1);
+    w.put(8, 10);
+    w.put(1, 0);
+    w.put(1, 0);
+    w.put(2, 0);
+    w.put(4, 0);
+    w.put(8, 3);
+    w.put(8, 1); // one ADOL block
+    w.put(8, 5);
+    w.put(8, u32::from(slot));
+    w.put(8, 0xFF);
+    w.put(8, 0xFF);
+    w.put(8, 0xFF);
+    for _ in 0..4 {
+        w.put(8, 0);
+    }
+    w.put(8, 1); // tag
+    w.put(8, 0x1E);
+    w.put(8, u32::from(config));
+    for &(op, a, b) in adol {
+        w.put(8, u32::from(op));
+        match op {
+            0x40 => {
+                w.put(8, a);
+                w.put(8, b);
+            }
+            0x01 | 0x03 | 0x5A..=0x62 => w.put(16, a),
+            0x64..=0x6C => w.put(24, a),
+            0x0E | 0x46 | 0x6E..=0x76 | 0x80..=0x85 | 0x8C..=0x90 => w.put(32, a),
+            _ => w.put(8, a),
+        }
+    }
+    w.put(8, 0);
+    // Reserved bits.
+    let mut pos = 17 * m - 1;
+    while pos < m * block_size {
+        let (idx, b) = bit_location(pos, m, false);
+        set_bit(&mut s, idx, b, 0);
+        pos += SYNC_SAMPLES * m;
+    }
+    // CRC last: it covers everything else.
+    let crc = block_crc(&s);
+    for i in 0..16 {
+        set_bit(&mut s, i, 1, u32::from((crc >> (15 - i)) & 1));
+    }
+    s
+}
+
+#[test]
+fn a_synthetic_block_parses_back() {
+    let block = build_block(7, 1000, 3, 62, 0, &[(0x64, 0x010203, 0), (0x40, 2, 200)]);
+    let header = parse_sync(&block).expect("sync");
+    assert_eq!(header.block_size, 1000);
+    assert_eq!(header.lsb_bits, 3);
+    let info = parse_block(&block, header).expect("block");
+    assert_eq!(info.config, Some(ChannelConfig(62)));
+    assert_eq!(info.stream_ids, [0, 0xFF, 0xFF, 0xFF]);
+    assert_eq!(info.adol_instructions, 4);
+}
+
+#[test]
+fn wider_borrow_and_a_power_of_two_block() {
+    for m in [4usize, 5, 8, 10] {
+        let block = build_block(11 + m as u32, 1024, m, 50, 4, &[]);
+        let header = parse_sync(&block).expect("sync");
+        assert_eq!((header.block_size, header.lsb_bits), (1024, m as u8));
+        let info = parse_block(&block, header).expect("block");
+        assert_eq!(info.config, Some(ChannelConfig(50)));
+    }
+}
+
+#[test]
+fn one_flipped_audio_bit_fails_the_crc() {
+    let mut block = build_block(3, 1000, 3, 62, 0, &[]);
+    let header = parse_sync(&block).unwrap();
+    block[500] ^= 1 << 12;
+    assert_eq!(parse_block(&block, header), Err(BlockError::Crc));
+}
+
+#[test]
+fn a_set_reserved_bit_is_rejected_before_the_crc() {
+    let mut block = build_block(3, 1000, 3, 62, 0, &[]);
+    let header = parse_sync(&block).unwrap();
+    // m = 3: bit 0 of sample 16 is the first reserved bit.
+    block[16] |= 1;
+    assert_eq!(parse_block(&block, header), Err(BlockError::ReservedBit));
+}
+
+#[test]
+fn the_detector_latches_after_three_agreeing_blocks() {
+    let mut stream = Vec::new();
+    for seed in 0..4u32 {
+        stream.extend(build_block(100 + seed, 1000, 3, 62, 0, &[]));
+    }
+    let mut det = Detector::new(2);
+    let mut latched = None;
+    let mut announcements = 0;
+    // Odd chunking, and a second channel that carries nothing.
+    for (i, chunk) in stream.chunks(333).enumerate() {
+        if let Some(d) = det.push(0, chunk) {
+            announcements += 1;
+            latched = Some((d, i));
+        }
+        det.push(1, &vec![0x1234 << 3; chunk.len()]);
+    }
+    let (d, when) = latched.expect("latched");
+    assert_eq!(announcements, 1);
+    assert_eq!(d.config, ChannelConfig(62));
+    assert_eq!(d.original, Layout(32703));
+    assert_eq!(d.carrier, Layout(447));
+    assert_eq!(d.block_size, 1000);
+    // Three blocks are 3000 samples: latched on the chunk that completes them.
+    assert_eq!(when, 3000 / 333);
+    assert_eq!(det.stats(0).valid_blocks, 4);
+    assert_eq!(det.stats(1).valid_blocks, 0);
+}
+
+#[test]
+fn noise_never_latches() {
+    let mut lcg = Lcg(99);
+    let noise: Vec<i32> = (0..200_000).map(|_| lcg.next()).collect();
+    let mut det = Detector::new(1);
+    assert!(det.push(0, &noise).is_none());
+    assert!(det.detection().is_none());
+    assert_eq!(det.stats(0).valid_blocks, 0);
+}
+
+#[test]
+fn a_disagreeing_block_restarts_the_count() {
+    let mut stream = Vec::new();
+    stream.extend(build_block(1, 1000, 3, 62, 0, &[]));
+    stream.extend(build_block(2, 1000, 3, 62, 0, &[]));
+    stream.extend(build_block(3, 1000, 3, 50, 0, &[]));
+    stream.extend(build_block(4, 1000, 3, 62, 0, &[]));
+    stream.extend(build_block(5, 1000, 3, 62, 0, &[]));
+    let mut det = Detector::new(1);
+    assert!(det.push(0, &stream).is_none());
+    stream.clear();
+    stream.extend(build_block(6, 1000, 3, 62, 0, &[]));
+    assert_eq!(
+        det.push(0, &stream).map(|d| d.config),
+        Some(ChannelConfig(62))
+    );
+}

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -29,6 +29,7 @@ sys = { version = "0.1.0", path = "../../Omniphony/omniphony-renderer/sys" }
 truehd = { version = "0.7.1" }
 eac3 = { version = "0.7.4", path = "../eac3" }
 dca = { version = "0.7.4", path = "../dca" }
+auro = { version = "0.7.4", path = "../auro" }
 abi_stable = "0.11"
 log = "0.4"
 anyhow = "1.0"

--- a/bridge/src/auro_pipeline.rs
+++ b/bridge/src/auro_pipeline.rs
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Auro-3D over the DTS-HD MA path.
+//
+// A lossless DTS-HD track may be an Auro-Codec carrier: the low bits of its
+// PCM then fold a larger layout (a 7.1 carrier holding 13.1). Whether it is
+// one is only known a few blocks in, and unfolding lags input by a block,
+// so the frames decoded so far are held back until the question is settled.
+// If the carrier is confirmed, the held frames are replayed into the
+// unfolder and every frame from then on is the unfolded layout, with the
+// bed and the height layer as labelled fixed channels. If it is not, the
+// held frames go out as they are and this stage steps aside for the rest
+// of the stream.
+//
+// Costs: nothing per sample beyond the detector's ring writes; per block,
+// one payload gather, one residual decode and one unmix on fixed storage.
+// The unfolder and the decoders are allocated once, when the carrier is
+// confirmed.
+
+use abi_stable::std_types::RVec;
+use auro::{Detector, StreamId, Unfolder};
+use bridge_api::{RChannelLabel, RDecodedFrame};
+
+use crate::labels::auro_stream_to_r;
+
+/// Samples to hold back before giving up on a stream that shows no valid
+/// block at all: two of the largest blocks, so a block of any size has had
+/// time to complete once.
+const NO_BLOCK_LIMIT: usize = 2 * auro::block::MAX_BLOCK;
+/// Samples to hold back while blocks validate but the layout has not
+/// latched yet.
+const HOLD_LIMIT: usize = 4 * auro::block::MAX_BLOCK;
+
+/// The bed stream a DCA speaker index plays as.
+fn speaker_stream(speaker: usize) -> StreamId {
+    StreamId(match speaker {
+        0 => 2,
+        1 => 0,
+        2 => 1,
+        3 => 4,
+        4 => 5,
+        5 => 3,
+        6 => 6,
+        7 => 7,
+        8 => 8,
+        _ => 0xff,
+    })
+}
+
+struct Held {
+    frame: RDecodedFrame,
+    /// DCA speaker index of each of the frame's first channels.
+    speakers: Vec<usize>,
+}
+
+enum Phase {
+    Undecided {
+        detector: Detector,
+        held: Vec<Held>,
+        held_samples: usize,
+    },
+    Unfolding {
+        unfolder: Unfolder,
+        /// DCA speaker index of each carrier channel, in unfolder order.
+        speakers: Vec<usize>,
+        outputs: Vec<StreamId>,
+        labels: RVec<RChannelLabel>,
+        sample_rate: u32,
+        scratch: Vec<i32>,
+    },
+    Plain,
+}
+
+pub(crate) struct DtsAuroState {
+    phase: Phase,
+}
+
+impl Default for DtsAuroState {
+    fn default() -> Self {
+        Self {
+            phase: Phase::Undecided {
+                detector: Detector::new(0),
+                held: Vec::new(),
+                held_samples: 0,
+            },
+        }
+    }
+}
+
+impl DtsAuroState {
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn is_unfolding(&self) -> bool {
+        matches!(self.phase, Phase::Unfolding { .. })
+    }
+
+    /// One built DTS-HD frame, whose first `speakers.len()` channels are the
+    /// lossless bed in that speaker order, with the decoder's integer
+    /// output for it. Appends to `out` whatever can go out now.
+    pub(crate) fn route<'a>(
+        &mut self,
+        frame: RDecodedFrame,
+        speakers: &[usize],
+        lossless: impl Iterator<Item = (usize, &'a [i32])>,
+        out: &mut RVec<RDecodedFrame>,
+    ) {
+        match &mut self.phase {
+            Phase::Plain => out.push(frame),
+            Phase::Unfolding {
+                unfolder,
+                speakers: carriers,
+                outputs,
+                labels,
+                sample_rate,
+                scratch,
+            } => {
+                for (speaker, samples) in lossless {
+                    if let Some(index) = carriers.iter().position(|&s| s == speaker) {
+                        for chunk in samples.chunks(auro::unfold::MAX_PUSH) {
+                            unfolder.push(index, chunk);
+                        }
+                    }
+                }
+                Self::drain(unfolder, outputs, labels, *sample_rate, scratch, out);
+            }
+            Phase::Undecided {
+                detector,
+                held,
+                held_samples,
+            } => {
+                // A frame with more channels than its bed carries a DTS:X
+                // presentation, which no Auro carrier does.
+                if frame.channel_count as usize != speakers.len() {
+                    self.give_up(out);
+                    out.push(frame);
+                    return;
+                }
+                if detector.channel_count() == 0 {
+                    let count = speakers.iter().copied().max().map_or(0, |m| m + 1);
+                    *detector = Detector::new(count);
+                }
+                let n = frame.sample_count as usize;
+                let mut latched = None;
+                for (speaker, samples) in lossless {
+                    if let Some(d) = detector.push(speaker, samples) {
+                        latched = Some(d);
+                    }
+                }
+                held.push(Held {
+                    frame,
+                    speakers: speakers.to_vec(),
+                });
+                *held_samples += n;
+                if let Some(detection) = latched {
+                    self.start_unfolding(detection, out);
+                    return;
+                }
+                let any_block = speakers.iter().any(|&s| detector.stats(s).valid_blocks > 0);
+                let limit = if any_block {
+                    HOLD_LIMIT
+                } else {
+                    NO_BLOCK_LIMIT
+                };
+                if *held_samples > limit {
+                    self.give_up(out);
+                }
+            }
+        }
+    }
+
+    /// A frame without lossless output (core only) cannot be a carrier.
+    pub(crate) fn not_a_carrier(&mut self, out: &mut RVec<RDecodedFrame>) {
+        if matches!(self.phase, Phase::Undecided { .. }) {
+            self.give_up(out);
+        }
+    }
+
+    fn give_up(&mut self, out: &mut RVec<RDecodedFrame>) {
+        let phase = std::mem::replace(&mut self.phase, Phase::Plain);
+        if let Phase::Undecided { held, .. } = phase {
+            for h in held {
+                out.push(h.frame);
+            }
+        }
+    }
+
+    fn start_unfolding(&mut self, detection: auro::Detection, out: &mut RVec<RDecodedFrame>) {
+        let phase = std::mem::replace(&mut self.phase, Phase::Plain);
+        let Phase::Undecided { held, .. } = phase else {
+            return;
+        };
+        let Some(first) = held.first() else {
+            return;
+        };
+        let outputs: Vec<StreamId> = match detection.original.streams() {
+            Some(streams) => streams.as_slice().iter().map(|&id| StreamId(id)).collect(),
+            None => {
+                log::warn!(
+                    "dts: Auro-3D layout {:?} has no known stream list; keeping the carrier as is",
+                    detection.original
+                );
+                for h in held {
+                    out.push(h.frame);
+                }
+                return;
+            }
+        };
+        let name = |layout: auro::Layout| layout.name().unwrap_or("?");
+        log::info!(
+            "dts: Auro-3D carrier {} folded into {} ({}-sample blocks); unfolding to {} channels",
+            name(detection.original),
+            name(detection.carrier),
+            detection.block_size,
+            outputs.len()
+        );
+        let speakers = first.speakers.clone();
+        let carrier_ids: Vec<StreamId> = speakers.iter().map(|&s| speaker_stream(s)).collect();
+        let labels: RVec<RChannelLabel> = outputs.iter().map(|&id| auro_stream_to_r(id)).collect();
+        let sample_rate = first.frame.sampling_frequency;
+        let mut unfolder = Unfolder::new(&carrier_ids, &outputs);
+        unfolder.set_latency(usize::from(detection.block_size));
+        let mut scratch = Vec::new();
+        // Replay what was held: the frames' PCM is the lossless bed exactly.
+        let mut column = Vec::new();
+        for h in &held {
+            let channels = h.frame.channel_count as usize;
+            let n = h.frame.sample_count as usize;
+            for index in 0..speakers.len() {
+                column.clear();
+                column.extend((0..n).map(|s| h.frame.pcm[s * channels + index]));
+                for chunk in column.chunks(auro::unfold::MAX_PUSH) {
+                    unfolder.push(index, chunk);
+                }
+            }
+            Self::drain(
+                &mut unfolder,
+                &outputs,
+                &labels,
+                sample_rate,
+                &mut scratch,
+                out,
+            );
+        }
+        self.phase = Phase::Unfolding {
+            unfolder,
+            speakers,
+            outputs,
+            labels,
+            sample_rate,
+            scratch,
+        };
+    }
+
+    fn drain(
+        unfolder: &mut Unfolder,
+        outputs: &[StreamId],
+        labels: &RVec<RChannelLabel>,
+        sample_rate: u32,
+        scratch: &mut Vec<i32>,
+        out: &mut RVec<RDecodedFrame>,
+    ) {
+        let ready = unfolder.ready();
+        if ready == 0 {
+            return;
+        }
+        scratch.clear();
+        scratch.resize(ready * outputs.len(), 0);
+        let frames = unfolder.take(outputs, scratch);
+        scratch.truncate(frames * outputs.len());
+        let mut pcm: RVec<i32> = RVec::with_capacity(scratch.len());
+        pcm.extend(scratch.iter().copied());
+        out.push(RDecodedFrame {
+            sampling_frequency: sample_rate,
+            sample_count: frames as u32,
+            channel_count: outputs.len() as u32,
+            pcm,
+            channel_labels: labels.clone(),
+            metadata: RVec::new(),
+            drc_gain: 1.0,
+            drc_ramp_duration: 0,
+            dialogue_level: None.into(),
+            is_new_segment: false,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use auro::block::{SYNC_SAMPLES, bit_location, block_crc};
+
+    const BLOCK: usize = 1024;
+    const M: usize = 3;
+
+    fn set_bit(samples: &mut [i32], idx: usize, bit: u32, value: u32) {
+        let mask = 1i32 << bit;
+        if value & 1 != 0 {
+            samples[idx] |= mask;
+        } else {
+            samples[idx] &= !mask;
+        }
+    }
+
+    /// One block whose payload announces a single stream `id` on channel
+    /// configuration `config`, over `audio` (its low bits are replaced).
+    fn block(audio: &[i32], config: u8, id: u8) -> Vec<i32> {
+        let mut s: Vec<i32> = audio.iter().map(|&v| v & !0b111).collect();
+        for v in s.iter_mut().take(SYNC_SAMPLES) {
+            *v |= 1;
+        }
+        let size_code = ((BLOCK - SYNC_SAMPLES) >> 4) as u32;
+        for i in 0..8 {
+            set_bit(&mut s, i, 2, (size_code >> (7 - i)) & 1);
+        }
+        let width_code = 14 - M as u32;
+        for i in 12..16 {
+            set_bit(&mut s, i, 2, (width_code >> (15 - i)) & 1);
+        }
+        let mut pos = 48usize;
+        let mut put = |s: &mut [i32], bits: u32, value: u32| {
+            for i in (0..bits).rev() {
+                let (idx, b) = bit_location(pos, M, true);
+                set_bit(s, idx, b, (value >> i) & 1);
+                pos += 1;
+            }
+        };
+        put(&mut s, 8, 1);
+        put(&mut s, 8, 10);
+        put(&mut s, 8, 0); // fixed Rice parameter 0
+        put(&mut s, 8, 0); // codebook count code
+        put(&mut s, 8, 1); // one ADOL block
+        put(&mut s, 8, 0); // codebook width
+        put(&mut s, 8, u32::from(id));
+        for _ in 0..3 {
+            put(&mut s, 8, 0xff);
+        }
+        for _ in 0..4 {
+            put(&mut s, 8, 0);
+        }
+        put(&mut s, 8, 1);
+        put(&mut s, 8, 0x1E);
+        put(&mut s, 8, u32::from(config));
+        put(&mut s, 8, 0);
+        // Everything after the announcement is zero; clear the reserved bits.
+        let mut rp = 17 * M - 1;
+        while rp < M * BLOCK {
+            let (idx, b) = bit_location(rp, M, false);
+            set_bit(&mut s, idx, b, 0);
+            rp += SYNC_SAMPLES * M;
+        }
+        let crc = block_crc(&s);
+        for i in 0..16 {
+            set_bit(&mut s, i, 1, u32::from((crc >> (15 - i)) & 1));
+        }
+        s
+    }
+
+    fn frame(channels: &[&[i32]], speakers: &[usize]) -> RDecodedFrame {
+        let n = channels[0].len();
+        let mut pcm = RVec::with_capacity(n * channels.len());
+        for s in 0..n {
+            for c in channels {
+                pcm.push(c[s]);
+            }
+        }
+        RDecodedFrame {
+            sampling_frequency: 48_000,
+            sample_count: n as u32,
+            channel_count: channels.len() as u32,
+            pcm,
+            channel_labels: speakers
+                .iter()
+                .map(|&s| crate::dts_pipeline::speaker_to_label(s))
+                .collect(),
+            metadata: RVec::new(),
+            drc_gain: 1.0,
+            drc_ramp_duration: 0,
+            dialogue_level: None.into(),
+            is_new_segment: false,
+        }
+    }
+
+    #[test]
+    fn a_carrier_announcing_a_height_plays_it_on_the_height_channel() {
+        // Carrier 4.0 (config 20: 4.0_4H): DCA speakers L=1, R=2, Ls=3, Rs=4.
+        let speakers = [1usize, 2, 3, 4];
+        let blocks = 6;
+        let mut carrier: Vec<Vec<i32>> = Vec::new();
+        for (c, &id) in [9u8, 1, 4, 5].iter().enumerate() {
+            let mut ch = Vec::new();
+            for b in 0..blocks {
+                let audio: Vec<i32> = (0..BLOCK)
+                    .map(|i| (((i + b * BLOCK) as i32 * 37 + c as i32 * 1000) % 20000 - 10000) * 8)
+                    .collect();
+                ch.extend(block(&audio, 20, id));
+            }
+            carrier.push(ch);
+        }
+        let total = blocks * BLOCK;
+        let mut state = DtsAuroState::default();
+        let mut out = RVec::new();
+        let step = 512;
+        for start in (0..total).step_by(step) {
+            let chans: Vec<&[i32]> = carrier.iter().map(|c| &c[start..start + step]).collect();
+            let f = frame(&chans, &speakers);
+            let lossless = speakers.iter().copied().zip(chans.iter().copied());
+            state.route(f, &speakers, lossless, &mut out);
+        }
+        assert!(state.is_unfolding());
+        let emitted: usize = out.iter().map(|f| f.sample_count as usize).sum();
+        // Everything but one block of latency is out, and none of it as the
+        // carrier: every frame has the eight unfolded channels.
+        assert_eq!(emitted, total - BLOCK);
+        assert!(out.iter().all(|f| f.channel_count == 8));
+        let labels = &out[0].channel_labels;
+        assert_eq!(
+            labels.as_slice(),
+            &[
+                RChannelLabel::L,
+                RChannelLabel::R,
+                RChannelLabel::Ls,
+                RChannelLabel::Rs,
+                RChannelLabel::Tfl,
+                RChannelLabel::Tfr,
+                RChannelLabel::Tbl,
+                RChannelLabel::Tbr,
+            ]
+        );
+        // Sample 100: the L carrier announced HL, so L is silent and Tfl
+        // carries the carrier with its borrowed bits cleared; R plays as R.
+        let f = &out[0];
+        let row = |s: usize| &f.pcm[s * 8..(s + 1) * 8];
+        let s = 100;
+        assert_eq!(row(s)[0], 0, "L is not part of the fold");
+        assert_eq!(
+            row(s)[4],
+            carrier[0][s] & !0b111,
+            "HL comes off the L carrier"
+        );
+        assert_eq!(row(s)[1], carrier[1][s] & !0b111, "R plays as R");
+        assert_eq!(row(s)[5], 0, "HR was never announced");
+    }
+
+    #[test]
+    fn plain_pcm_is_released_unchanged_once_the_stage_gives_up() {
+        let speakers = [1usize, 2];
+        let mut state = DtsAuroState::default();
+        let mut out = RVec::new();
+        let n = 512;
+        let mut pushed = 0usize;
+        while pushed < 3 * auro::block::MAX_BLOCK {
+            let l: Vec<i32> = (0..n).map(|i| (pushed + i) as i32 * 3).collect();
+            let r: Vec<i32> = (0..n).map(|i| -((pushed + i) as i32) * 3).collect();
+            let chans: Vec<&[i32]> = vec![&l, &r];
+            let f = frame(&chans, &speakers);
+            let lossless = speakers.iter().copied().zip(chans.iter().copied());
+            state.route(f, &speakers, lossless, &mut out);
+            pushed += n;
+        }
+        assert!(!state.is_unfolding());
+        let emitted: usize = out.iter().map(|f| f.sample_count as usize).sum();
+        assert_eq!(emitted, pushed, "every held frame came out");
+        assert!(out.iter().all(|f| f.channel_count == 2));
+        assert_eq!(out[1].pcm[0], 512 * 3, "frames came out in order");
+    }
+}

--- a/bridge/src/bridge.rs
+++ b/bridge/src/bridge.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 use truehd::process::{MAX_PRESENTATIONS, decode::Decoder, extract::Extractor, parse::Parser};
 
 use crate::ac3_native::NativeAc3Decoder;
+use crate::auro_pipeline::DtsAuroState;
 use crate::dts_pipeline::{DtsFoldConfig, DtsXState};
 use crate::eac3_pipeline::{
     diagnose_eac3_frame, is_dependent_eac3_frame, is_legacy_ac3_frame,
@@ -164,6 +165,9 @@ pub(crate) struct AtmosBridge {
     /// from what the frame presented rather than from its profile, so every
     /// object-bearing presentation reaches it by the same route.
     pub(crate) dts_objects_active: bool,
+    /// Auro-3D detection and unfolding over the lossless DTS-HD output.
+    /// Holds the first frames back until the carrier question is settled.
+    pub(crate) dts_auro: DtsAuroState,
     // ── Shared ───────────────────────────────────────────────────────
     pub(crate) presentation: u8,
     pub(crate) strict: bool,
@@ -244,6 +248,7 @@ impl AtmosBridge {
             dts_active: false,
             dts_fold_config: DtsFoldConfig::from_env(),
             dts_objects_active: false,
+            dts_auro: DtsAuroState::default(),
             presentation,
             strict,
             total_samples: 0,
@@ -303,6 +308,7 @@ impl AtmosBridge {
         self.dts_x = DtsXState::default();
         self.dts_active = false;
         self.dts_objects_active = false;
+        self.dts_auro.reset();
         // Re-sniff after reset, but keep any host-declared codec.
         self.raw_codec = None;
 
@@ -978,6 +984,38 @@ mod raw_transport_tests {
     // End-to-end: feed a raw DTS core stream through the FormatBridge and check
     // it emits 5.1 bed frames with the expected channel labels. Skips when the
     // (uncommitted) corpus is absent.
+    #[test]
+    fn dts_hd_auro_carrier_unfolds_into_its_layout() {
+        let Some(dts) = corpus_path("HARLETTY_AURO_DTS_CORPUS") else {
+            eprintln!("skipping: HARLETTY_AURO_DTS_CORPUS is not set to a readable file");
+            return;
+        };
+        let bytes = std::fs::read(dts).unwrap();
+        let mut bridge = AtmosBridge::new(false);
+        let mut frames = Vec::new();
+        for chunk in bytes.chunks(16 * 1024) {
+            let result = bridge.push_packet(RSlice::from_slice(chunk), RInputTransport::Raw, 0);
+            assert!(result.error_message.is_empty(), "{}", result.error_message);
+            frames.extend(result.frames.into_iter());
+        }
+        assert!(bridge.dts_auro.is_unfolding(), "the carrier was not confirmed");
+        assert!(!bridge.has_objects(), "Auro is fixed channels, not objects");
+        // Every frame that came out is the unfolded layout: the carrier was
+        // held back until the verdict, never emitted as 7.1.
+        let channels = frames[0].channel_count;
+        assert!(channels > 8, "expected more than the carrier's channels, got {channels}");
+        assert!(frames.iter().all(|f| f.channel_count == channels));
+        let labels = &frames[0].channel_labels;
+        assert!(
+            labels.contains(&bridge_api::RChannelLabel::Tfl)
+                && labels.contains(&bridge_api::RChannelLabel::Tbr)
+        );
+        // Output is one block behind input, and no more.
+        let emitted: u64 = frames.iter().map(|f| u64::from(f.sample_count)).sum();
+        assert!(bridge.total_samples - emitted <= 4096, "{} held back", bridge.total_samples - emitted);
+        eprintln!("{} frames, {} channels, {emitted}/{} samples out", frames.len(), channels, bridge.total_samples);
+    }
+
     #[test]
     fn dts_raw_transport_emits_bed_frames() {
         let Some(dts) = corpus_path("HARLETTY_DTS_CORE_CORPUS") else {

--- a/bridge/src/dts_pipeline.rs
+++ b/bridge/src/dts_pipeline.rs
@@ -196,7 +196,19 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
                             &mut bridge.declared_object_channels,
                         ) {
                             bridge.dts_objects_active = emitted_objects;
-                            result.frames.push(frame);
+                            // The Auro side channel lives in the low bits of
+                            // the lossless integers, read off the decoder's
+                            // integer tap. The stage decides whether the
+                            // frame goes out as it is or unfolded.
+                            let active: Vec<usize> = (0..hd.samples.len())
+                                .filter(|&s| hd.samples[s].is_some())
+                                .collect();
+                            bridge.dts_auro.route(
+                                frame,
+                                &active,
+                                bridge.dts_hd_decoder.lossless_samples(),
+                                &mut result.frames,
+                            );
                         }
                         bridge.total_samples += n as u64;
                         bridge.dts_frame_count += 1;
@@ -221,6 +233,7 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
                 match bridge.dts_decoder.push_access_unit(&rest[..fs]) {
                     Ok(push) => {
                         bridge.dts_objects_active = false;
+                        bridge.dts_auro.not_a_carrier(&mut result.frames);
                         result.frames.push(build_core_frame(&push.pcm));
                         bridge.total_samples += push.pcm.samples_per_channel() as u64;
                         bridge.dts_frame_count += 1;
@@ -243,6 +256,7 @@ pub(crate) fn drain_dts(bridge: &mut AtmosBridge, result: &mut RPushResult) {
                 Ok(push) => {
                     let frame = build_core_frame(&push.pcm);
                     bridge.dts_objects_active = false;
+                    bridge.dts_auro.not_a_carrier(&mut result.frames);
                     bridge.total_samples += push.pcm.samples_per_channel() as u64;
                     bridge.dts_frame_count += 1;
                     result.frames.push(frame);
@@ -276,7 +290,7 @@ fn hd_samples(hd: &HdFrame) -> usize {
 }
 
 /// DCA speaker index -> renderer channel label, for the DTS-HD bed.
-fn speaker_to_label(spkr: usize) -> RChannelLabel {
+pub(crate) fn speaker_to_label(spkr: usize) -> RChannelLabel {
     match spkr {
         0 => RChannelLabel::C,
         1 => RChannelLabel::L,

--- a/bridge/src/labels.rs
+++ b/bridge/src/labels.rs
@@ -119,3 +119,28 @@ pub(crate) fn oamd_speaker_to_label(speaker_index: usize) -> RChannelLabel {
         _ => RChannelLabel::Unknown,
     }
 }
+
+/// Map an Auro stream to the renderer's channel label. Auro's height layer
+/// sits at about 30 degrees of elevation rather than overhead, and its
+/// centre height and top have no closer labels than the top-front-centre
+/// and top-centre ones; the renderer's channel mode places them.
+pub(crate) fn auro_stream_to_r(stream: auro::StreamId) -> RChannelLabel {
+    match stream.0 {
+        0 => RChannelLabel::L,
+        1 => RChannelLabel::R,
+        2 => RChannelLabel::C,
+        3 => RChannelLabel::LFE,
+        4 => RChannelLabel::Ls,
+        5 => RChannelLabel::Rs,
+        6 => RChannelLabel::Cb,
+        7 => RChannelLabel::Lb,
+        8 => RChannelLabel::Rb,
+        9 => RChannelLabel::Tfl,
+        10 => RChannelLabel::Tfr,
+        11 => RChannelLabel::Tfc,
+        12 => RChannelLabel::Tc,
+        13 => RChannelLabel::Tbl,
+        14 => RChannelLabel::Tbr,
+        _ => RChannelLabel::Unknown,
+    }
+}

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -1,4 +1,5 @@
 mod ac3_native;
+mod auro_pipeline;
 mod bridge;
 mod dts_pipeline;
 mod dts_spdif;

--- a/damf/src/damf.rs
+++ b/damf/src/damf.rs
@@ -153,6 +153,19 @@ pub enum SourceCodec {
     /// quartet (the D0 marker with a 5.1 reference layout).
     #[serde(rename = "DTS:X-5.1+1")]
     DtsX51Plus1,
+    // Auro-3D, by the channel count of the layout the carrier unfolds to:
+    // bed plus heights plus top. Layouts with no common name fall back to
+    // the bare label.
+    #[serde(rename = "Auro-3D-9.1")]
+    Auro3d91,
+    #[serde(rename = "Auro-3D-10.1")]
+    Auro3d101,
+    #[serde(rename = "Auro-3D-11.1")]
+    Auro3d111,
+    #[serde(rename = "Auro-3D-13.1")]
+    Auro3d131,
+    #[serde(rename = "Auro-3D")]
+    Auro3d,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/dca/src/hd.rs
+++ b/dca/src/hd.rs
@@ -130,6 +130,19 @@ impl HdDecoder {
         self.xll.reset();
     }
 
+    /// The lossless 24-bit samples of the last decoded frame, by DCA speaker
+    /// index, as integers — before the float conversion `decode` hands out.
+    /// Active speakers only. This is the tap for anything that reads the low
+    /// bits of the PCM (an Auro-Codec carrier keeps its side channel there),
+    /// which a float round trip would not preserve.
+    pub fn lossless_samples(&self) -> impl Iterator<Item = (usize, &[i32])> {
+        self.xll
+            .output
+            .iter()
+            .enumerate()
+            .filter_map(|(speaker, channel)| channel.as_deref().map(|v| (speaker, v)))
+    }
+
     /// Decode one DTS-HD frame from its core access unit + EXSS substream bytes.
     pub fn decode(&mut self, core_au: &[u8], exss: &[u8]) -> Result<HdFrame, HdError> {
         // 1) Core bitstream decode (the residual base).

--- a/docs/harletty-cli.md
+++ b/docs/harletty-cli.md
@@ -244,13 +244,16 @@ of drift.
   extension block that this decoder does not read. A DTS:X master set is
   therefore fine for layout inspection and useless for anything that
   measures movement.
-- **Auro-3D height channels are not reconstructed.** A DTS-HD MA track
+- **Auro-3D is unfolded, not decoded bit-exactly.** A DTS-HD MA track
   that carries an Auro-Codec side channel in its low bits is recognised
-  (the log names the original layout, `7.1_5H_1T` say, and the carrier it
-  was folded into) but decoded as its carrier bed only: the folded height
-  layer stays in the mix, as it does on any player without an Auro
-  decoder. Only the layout part of the side channel is publicly
-  described; the residual layer that undoes the fold is not.
+  and unfolded into the layout it was encoded from: a `7.1_5H_1T` carrier
+  becomes a 13.1 master set (bed plus four corner heights, with the centre
+  height and the top as static objects, since OAMD has no names for
+  them). The unfold follows the codec's own arithmetic, whose outputs
+  are "virtually lossless" by design: expect the restored channels to sit
+  about 50 dB below the signal in error, not to match a master bit for
+  bit. The label is `Auro-3D-<count>` (`Auro-3D-13.1`, `-11.1`, `-10.1`,
+  `-9.1`, or `Auro-3D` for other layouts).
 - **ffmpeg cannot open the 6-channel CAF files this writer produces.**
   12-channel files are fine. This predates the rename and is not a
   regression — the reference implementation emits byte-identical headers

--- a/docs/harletty-cli.md
+++ b/docs/harletty-cli.md
@@ -244,6 +244,13 @@ of drift.
   extension block that this decoder does not read. A DTS:X master set is
   therefore fine for layout inspection and useless for anything that
   measures movement.
+- **Auro-3D height channels are not reconstructed.** A DTS-HD MA track
+  that carries an Auro-Codec side channel in its low bits is recognised
+  (the log names the original layout, `7.1_5H_1T` say, and the carrier it
+  was folded into) but decoded as its carrier bed only: the folded height
+  layer stays in the mix, as it does on any player without an Auro
+  decoder. Only the layout part of the side channel is publicly
+  described; the residual layer that undoes the fold is not.
 - **ffmpeg cannot open the 6-channel CAF files this writer produces.**
   12-channel files are fine. This predates the rename and is not a
   regression — the reference implementation emits byte-identical headers

--- a/docs/pcm-aux-layer-research.md
+++ b/docs/pcm-aux-layer-research.md
@@ -1,159 +1,84 @@
-# PCM auxiliary-layer / Auro-Codec research
+# Auro-Codec: the side channel in 24-bit PCM
 
-Status: exploratory notes, last updated 2026-07-23. This is not yet an
-implementation specification. The commercial bitstream may differ from the
-public patent examples, so a real bit-perfect Auro-Codec carrier remains the
-required oracle.
+Status: detection implemented (`auro` crate, 2026-09-12). This note records
+what the format is, what is known publicly, and where the line to a full
+decoder lies. It replaces an earlier draft (2026-07-23) that reasoned from a
+patent example the shipped streams do not follow.
 
-## Main finding
+## What it is
 
-The height channels should not be treated as raw PCM serialized directly into
-the least-significant bits. The public Aurophonic carrier patent describes a
-different construction:
+Auro-3D delivers its height layer inside an ordinary lossless 5.1 or 7.1
+track. The encoder mixes the height channels into the carrier channels with
+its own gains, then borrows the `m` least-significant bits of every carrier
+sample for a serial side channel. Without a decoder the track plays as the
+carrier mix; a decoder reads the side channel and separates bed and height
+again. On disc the carrier is a DTS-HD MA track, so the side channel
+survives only a bit-exact lossless decode: any gain, dither or float round
+trip ahead of the reader destroys it. In harletty it is read off
+`dca::HdDecoder::lossless_samples`, the integer XLL output, before the
+conversion to `f32`.
 
-- two audio signals are alternately sample-rate-reduced and added into the
-  significant PCM portion of one backwards-compatible carrier channel;
-- the freed LSBs carry the information required to undo that mix: sync, block
-  length, PCM offset, seed samples, attenuation, optional error/index tables,
-  and a CRC;
-- the decoder reconstructs two channel waveforms from the significant carrier
-  PCM plus this auxiliary information, then interpolates the missing samples
-  and applies the transmitted correction/gain data.
+`m` is chosen per block and per channel. On the demo material at hand it
+runs from 3 (metadata only: the LFE and rear channels of a 7.1 carrier
+never carry more) to 10 on loud front channels.
 
-The patent gives common 24-bit divisions of 20+4 and 18+6 bits, also mentions
-2/4/6 auxiliary bits per sample, and allows the width to be selected
-dynamically. The width therefore must be detected from valid framing, not from
-LSB entropy alone.
+## Block layout
 
-Primary public description:
-
-- <https://patents.google.com/patent/WO2008043858A1/en>
-- <https://www.auro-3d.com/consumer_2024/>
-- <https://www.auro-3d.com/content/>
-
-## Proposed detector
-
-The detector must receive the exact decoded integer PCM. No volume operation,
-dither, resampling, or float round trip may occur before detection. Harletty
-currently converts the XLL output from 24-bit integers to `f32` in
-`dca/src/hd.rs`, and later converts it back to `i32` in `src/dts_pipeline.rs`.
-An implementation must tap or retain the integer XLL output before that
-conversion.
-
-For each carrier channel and each candidate auxiliary width `q` (initially
-2, 4, and 6; 1 through 8 in the research tool):
+The side channel is framed in blocks of `block_size` samples, 1000 on every
+stream seen so far. The first sixteen samples of a block are its header:
 
 ```text
-mask      = (1 << q) - 1
-symbol[n] = unsigned(sample[n]) & mask
-audio[n]  = signed(sample[n] & ~mask)
+bit 0 of samples 0..16   sync: all ones
+bit 1 of samples 0..16   CRC-16/CCITT of the block, MSB first
+bit 2 of samples 0..8    block-size code (size = code * 16 + 16; 0x3D means 1000)
+bit 2 of samples 8..12   four flag bits
+bit 2 of samples 12..16  14 - m
 ```
 
-Build one symbol stream per carrier channel first. Also test interleaved
-channel order as a secondary hypothesis, plus both possible bit orders inside
-each `q`-bit symbol.
+The CRC covers the three bytes of every sample of the block, low byte
+first, with bit 1 of the header samples masked out, and is inverted at the
+end. Bits 3..m of the header samples and the low `m` bits of every later
+sample, MSB first, form the payload; one bit every `16 * m` payload
+positions is reserved and must be zero. The first reserved bit is bit 0 of
+sample 16, which is what stops the sync run at exactly sixteen ones.
 
-Score a candidate only from structure across multiple consecutive blocks:
+The payload opens with a fixed set of fields (widths known, meanings not
+public), four stream-id slots, an optional small table, then one or more
+ADOL blocks: a bytecode of one-byte opcodes with 0-, 8-, 16-, 24- or
+32-bit operands, terminated by opcode 0. Opcode `0x1E` names the
+channel-input configuration, which maps to an original layout (what a full
+decode restores) and a carrier layout (what is physically in the PCM). The
+crate's `layout.rs` carries both tables.
 
-1. Find repeated sync candidates. The patent example is a rotating one-hot
-   sequence, e.g. `1, 2, 4, 8` for `q=4`.
-2. Parse the following 12-bit block length and signed 12-bit PCM offset.
-3. Require plausible bounds and a repeatable block cadence.
-4. Parse the seed samples and verify that they reproduce the next stored seed
-   under the unmix recurrence.
-5. Determine the CRC width/polynomial and require repeated CRC success over
-   both the significant PCM and auxiliary data.
+The rest of the payload is the residual layer: predictor seeds,
+Golomb-Rice coded residuals and the parameters of the unmix (two outputs
+from one carrier, or three for the heavier layouts). Its coding is not
+publicly described.
 
-Marginal entropy is only a diagnostic. Dithered PCM and compressed auxiliary
-data can both have nearly perfect one/zero balance.
+## Sources
 
-## Two-channel reconstruction described by the patent
+- almirus, *Auro-3D: how height channels are hidden in ordinary PCM*,
+  Habr, August 2026 — <https://habr.com/ru/articles/1068212/>.
+- almirus/Orua-D3 on GitHub (MIT): the Python detector these tables come
+  from, and the archived Auro white papers.
+- MediaArea/MediaInfoLib pull request 2531: the same detector in C++.
+- The commercial decoder `orua3d-decode` (closed, Windows, non-commercial
+  licence) is the only public implementation of the residual layer. It can
+  serve as an oracle for testing a clean-room decoder; nothing in it may be
+  copied.
 
-Let `C[n]` be the carrier sample with the auxiliary LSBs cleared. Given seed
-samples `A[0]` and `B[1]` at the block's declared PCM offset:
+## What harletty does with it
 
-```text
-B[0] = C[0] - A[0]
-A[1] = C[1] - B[1]
+`harletty decode` runs the detector over every lossless DTS-HD frame and,
+once three consecutive blocks agree, logs the original and carrier layouts.
+The output is the carrier bed. Reconstructing the height layer is a
+separate piece of work; see the crate documentation for the boundary.
 
-even n >= 2: B[n] = B[n-1]; A[n] = C[n] - B[n]
-odd  n >= 3: A[n] = A[n-1]; B[n] = C[n] - A[n]
-```
+## Corpus
 
-This yields the alternating exact samples of the two reduced streams. Fill the
-missing samples with interpolation, then apply any error-approximation table
-and undo the declared attenuation. Channel identity and layout must come from
-validated stream information; fixed Auro presentations must be emitted as
-labeled fixed channels, never fabricated objects.
-
-## Harletty implementation outline
-
-1. Add an offline integer-PCM probe before touching the realtime bridge.
-2. Preserve the lossless XLL output as integer PCM through `dca::HdFrame` (or
-   provide an integer analysis tap without doubling steady-state buffers).
-3. Implement a bounded streaming synchronizer/parser with fixed reusable
-   storage and checked lengths/offset arithmetic.
-4. Latch the detected format only after several valid blocks and CRCs.
-5. Add the unmix/interpolation stage, then emit stable labeled-channel frames.
-6. Keep all research logging and corpus dumping outside the shipped ABI hot
-   path.
-
-## Local corpus comparison
-
-The official content page was compared on 2026-07-23 against:
-
-- 351 MKV files under the local `Films`/`atmos` directories;
-- 89 MKV files under `/mnt/nas/backup/Videos`;
-- 440 MKV files total.
-
-The official page has two materially different categories:
-
-- **Cinema** means the film had an Auro theatrical mix. It does not prove that
-  an arbitrary Blu-ray/UHD edition contains an Auro carrier.
-- **Movies (Blu-ray/Digital)** identifies home releases, but territory and
-  edition still matter.
-
-### Matching home-release titles
-
-| Official title | Local/NAS edition | Observed audio | Assessment |
-|---|---|---|---|
-| Ballerina (2025) | `/mnt/local/HDD_F/Films/Ballerina.2025.Multi.Truefrench.2160p.Bluray.Remux.DV.HDR10.HEVC-BDHD.mkv` | French and English TrueHD Atmos 7.1/24-bit | Matching title, but this remux contains Atmos rather than an identifiable Auro carrier. The official entry is territory-specific. |
-| Blade Runner 2049 | `/mnt/nas/backup/Videos/TrueHD_Atmos/Blade.Runner.2049.2017.Multi.2160p.BluRay.REMUX.HEVC.HYBRID.DoVi.TrueHD.Atmos.7.1-ONLY.mkv` | English TrueHD Atmos 7.1/24-bit; French DTS-HD MA 5.1/16-bit | No plausible 24-bit Auro carrier in this remux. |
-| Borderlands (2024) | `/mnt/nas/backup/Videos/TrueHD_Atmos/Borderlands.2024.MULTi.TRUEFRENCH.2160p.UHD.BluRay.REMUX.DV.HDR10.TrueHD.7.1.HEVC-REBiRTH.mkv` | French and English TrueHD 7.1/24-bit, no Atmos profile reported | Initially promising, but both tracks have their low four bits almost entirely zero over a 20-second probe and no patent sync signature. This is not the listed Benelux Auro carrier, or its auxiliary layer is absent. |
-| Everything Everywhere All at Once (2022) | `/mnt/nas/backup/Videos/TrueHD_Atmos/Everything.Everywhere.All.at.Once.2022.MULTI.VFF.2160p.UHD.BLURAY.REMUX.DV.HDR.TrueHD.7.1.x265-OPTIMUM.mkv` | French and English TrueHD Atmos 7.1/24-bit | Correct title/4K class, but not the specific Auro edition. |
-| Everything Everywhere All at Once (2022) | `/mnt/local/SSD_A-CT4000/Films/[ Torrent911.cc ] Everything.Everywhere.All.at.Once.2022.MULTi.1080p.BluRay.DTS.x264-EXTREME.mkv` | French and English lossy DTS 5.1 | Lossy transport cannot preserve the auxiliary LSB layer. |
-| Salyut 7 (2017) | `/mnt/local/HDD_D/Films/Salyut.7.2017.2160p.UHD.BLURAY.REMUX.HDR.HEVC.MULTI.DTS-HDMA.mkv` | Russian DTS-HD MA 7.1/48 kHz/16-bit; French lossy DTS 5.1 | Not the Russian 3D Blu-ray Auro edition. The 16-bit Russian LSBs show no structured auxiliary signature. |
-| Salyut 7 (2017) | `/mnt/nas/backup/Videos/Salyut.7.-.La.storia.di.un.impresa.(2017).1080p.BluRay.DTS.ITA.AC3.RUS.Subs.x264.mkv` | Italian lossy DTS 5.1; Russian AC-3 5.1 | Cannot carry the bit-perfect auxiliary layer. |
-
-The local `Jumanji.1995` is not a match: the official table links to IMDb
-`tt2283362` (the 2017 film). `Ford v Ferrari`, `Guardians of the Galaxy`,
-`Twisters`, `Despicable Me 4`, and `John Wick 3/4` were also rejected as title
-matcher false positives for different films or sequels.
-
-### Matching cinema-only titles
-
-These local files match films in the official Cinema list, but their local
-home editions do not thereby inherit the theatrical Auro mix:
-
-| Film | Local file / relevant audio | Result |
-|---|---|---|
-| American Sniper (2014) | `/mnt/local/HDD_B/Films/American.Sniper.2014.UHD.MULTi.VFi.2160p.UHD.BluRay.REMUX.HDR.HEVC.TrueHD.7.1.Atmos-ONLY.mkv` — TrueHD Atmos | Not an Auro test carrier. |
-| Everest (2015) | `/mnt/local/HDD_D/Films/Everest.2015.MULTi.VFF.VFQ.Hybrid.2160p.UHD.BluRay.REMUX.CUSTOM.DV.HDR10Plus.HEVC.TrueHD.7.1.Atmos-ONLY.mkv` — TrueHD Atmos | Not an Auro test carrier. |
-| First Man (2018) | `/mnt/local/HDD_A/Films/TrueHD Atmos/First.Man.2018.MULTI.VFF.2160p.UHD.BLURAY.REMUX.DV.HDR10.TrueHD.7.1.HEVC-BREMBO.mkv` — English TrueHD Atmos, French E-AC-3 | Not an Auro test carrier. |
-| In the Heart of the Sea (2015) | `/mnt/local/HDD_D/Films/Au.cœur.de.l.Océan.2015.mkv` — French and English TrueHD Atmos | Not an Auro test carrier. |
-| Lucy (2014) | `/mnt/local/HDD_A/Films/TrueHD Atmos/Lucy.2014.2160p.UHD.BLURAY.REMUX.HDR.HEVC.MULTI.VFF.DTS-HDMA.x265-EXTREME.mkv` — French DTS-HD MA 5.1/24-bit, English TrueHD Atmos | The French DTS-HD track was probed. Its low bits are uniformly dither-like; the patent `q=4` hits occur at chance rate and no `q=6` sync is present. Not currently promising. |
-| Minions (2015) | `/mnt/local/HDD_D/Films/Minions.2015.MULTI.VFF.2160p.UHD.BluRay.Remux.HDR.EAC3.7.1.Atmos.HEVC-D5T0.mkv` — E-AC-3/TrueHD Atmos | Not an Auro test carrier. |
-| Sing (2016) | `/mnt/local/HDD_D/Films/Tous.En.Scene.2016.MULTI.VF2.2160p.UHD.BluRay.Remux.HDR.EAC3.7.1.Atmos-tlub.mkv` — TrueHD/E-AC-3 Atmos | Not an Auro test carrier. |
-| The Legend of Tarzan (2016) | `/mnt/local/HDD_A/Films/The.Legend.of.Tarzan.2016.MULTi.VFF.VFQ.2160p.UHD.BluRay.REMUX.CUSTOM.HEVC.HDR.DV.TrueHD.Atmos.7.1-HDForever.mkv` — TrueHD Atmos | Not an Auro test carrier. |
-| The Mummy (2017) | `/mnt/nas/backup/Videos/EAC3_Atmos/La.Momie.2017.mkv` — E-AC-3/TrueHD Atmos | Correct film (IMDb `tt2345759`), wrong home audio carrier. |
-| The Secret Life of Pets (2016) | `/mnt/local/HDD_D/Films/Comme.Des.Betes.2016.MULTI.VF2.2160p.UHD.BluRay.Remux.HDR.EAC3.TrueHD.7.1.Atmos.HEVC-TSC.mkv` — includes English DTS-HD MA 7.1/24-bit | The DTS-HD track has zero/padded low bits rather than an auxiliary stream. |
-| Warcraft (2016) | `/mnt/local/HDD_F/Films/Warcraft.Le.Commencement.2016..mkv` — French and English TrueHD Atmos | Not an Auro test carrier. |
-
-## Current conclusion and required sample
-
-No scanned MKV is currently confirmed as an Auro-Codec carrier. The highest
-value next sample remains the Russian 3D Blu-ray edition of *Salyut 7*, expected
-to expose a 5.1, 48 kHz, 24-bit lossless carrier. A 30-60 second bit-perfect
-DTS-HD MA extract from that exact edition should be sufficient to establish the
-auxiliary width, sync ordering, and initial block grammar before implementing
-the realtime decoder.
+The Trinnov Auro demo clips (DTS-HD MA 7.1 and 5.1, 48 kHz, 24-bit): every
+clip without a DTS:X extension is a carrier, configuration 62
+(`7.1_5H_1T` on a 7.1 carrier) for the 7.1 clips and 50 (`5.1_5H_1T` on
+5.1) for the 5.1 ones. The two clips flagged DTS:X carry no side channel.
+`auro/tests/corpus.rs` checks one such extract when
+`HARLETTY_AURO_CORPUS` points at it.

--- a/docs/pcm-aux-layer-research.md
+++ b/docs/pcm-aux-layer-research.md
@@ -115,6 +115,16 @@ bed channels, the centre height and the top as static objects. Samples no
 block claims (before the first block, after the last) play as the carrier.
 A track that turns out not to be a carrier is written as before.
 
+The realtime bridge does the same on its DTS-HD path (`bridge/src/
+auro_pipeline.rs`): frames are held back until the verdict — at most two
+of the largest blocks when no block validates, four when blocks validate
+but the layout has not latched — then replayed into the unfolder, and
+every frame from then on is the unfolded layout as labelled fixed
+channels (the corner heights as Tfl/Tfr/Tbl/Tbr, the centre height as
+Tfc, the top as Tc). Output lags input by one block (21 ms at 48 kHz for
+1000-sample blocks); the last block of a stream stays in the unfolder,
+as the bridge has no end-of-stream flush.
+
 ## Corpus
 
 The Trinnov Auro demo clips (DTS-HD MA 7.1 and 5.1, 48 kHz, 24-bit): every

--- a/docs/pcm-aux-layer-research.md
+++ b/docs/pcm-aux-layer-research.md
@@ -1,9 +1,10 @@
 # Auro-Codec: the side channel in 24-bit PCM
 
-Status: detection implemented (`auro` crate, 2026-09-12). This note records
-what the format is, what is known publicly, and where the line to a full
-decoder lies. It replaces an earlier draft (2026-07-23) that reasoned from a
-patent example the shipped streams do not follow.
+Status: decoded (`auro` crate, 2026-09-12): detection, the stream layer and
+the unfold, checked against a published original/encoded pair. This note
+records what the format is and where each part of the knowledge comes
+from. It replaces an earlier draft (2026-07-23) that reasoned from a patent
+example the shipped streams do not follow.
 
 ## What it is
 
@@ -50,10 +51,47 @@ channel-input configuration, which maps to an original layout (what a full
 decode restores) and a carrier layout (what is physically in the PCM). The
 crate's `layout.rs` carries both tables.
 
-The rest of the payload is the residual layer: predictor seeds,
-Golomb-Rice coded residuals and the parameters of the unmix (two outputs
-from one carrier, or three for the heavier layouts). Its coding is not
-publicly described.
+## The stream layer
+
+Everything after the layout bytecode was worked out here by analysis of the
+carriers and confirmed on the published original/encoded pair
+(`auro/tests/pair.rs`: correlation 0.99999 per channel, gain within
+0.01 dB). Per block and per carrier:
+
+- A 112-bit header: a 16-bit field (`0x010A` on every stream seen), a
+  32-bit word holding the Rice parameter (bits 27..24), an adaptive-Rice
+  flag (bit 30), the codebook count code (bits 23..16), the ADOL block
+  count (bits 15..8) and the codebook entry width (bits 7..0); then the
+  four stream-id slots (`0xFF` = empty) and four unused bytes.
+- Predictor seeds: two 32-bit words when two streams are folded, five for
+  three, none for one.
+- The ADOL blocks. Besides `0x1E` (layout), `0x40` carries a per-stream
+  gain code (channel, scaler) in tenths of a dB and `0x41` an offset added
+  to every code.
+- The codebook: `count` entries of `width` bits, sign and magnitude; twice
+  for a three-stream fold. `count` is `2c + 8` for codes below 5, `4c` up
+  to 15, `8c - 64` up to `0x53`.
+- The Golomb-Rice stream: one index per sample (unary prefix, then `k`
+  suffix bits least-significant first), selecting a codebook entry — the
+  same index selects from both codebooks in a three-stream fold.
+
+The stream ids: 0 L, 1 R, 2 C, 3 LFE, 4 Ls, 5 Rs, 7 Lb, 8 Rb, 9 HL, 10 HR,
+11 HC, 12 T, 13 HLs, 14 HRs, read off the channel-identification material.
+
+## The unfold
+
+With its borrowed bits dropped, the carrier is the exact sum of the folded
+streams. Each sample one stream is extrapolated from its recent history —
+`2a - b` for two streams, a three-phase `(b + 3(4a - 3b)) / 4` for three —
+and the others are derived from the sum; the residual corrects the derived
+value before it feeds the next prediction. Outputs are then scaled by
+their gain codes (`10^(code/200)`, with exact powers of two pinned every
+60 codes) and clamped to 24 bits. Blocks are independent (state resets at
+each), so output lags input by one block.
+
+The outputs sum back to the carrier exactly; each one carries the other's
+extrapolation error, which is what "virtually lossless" means here: about
+50 dB below the signal on real material.
 
 ## Sources
 
@@ -69,10 +107,13 @@ publicly described.
 
 ## What harletty does with it
 
-`harletty decode` runs the detector over every lossless DTS-HD frame and,
-once three consecutive blocks agree, logs the original and carrier layouts.
-The output is the carrier bed. Reconstructing the height layer is a
-separate piece of work; see the crate documentation for the boundary.
+`harletty decode` runs the detector over every lossless DTS-HD frame,
+holding the frames back until three consecutive blocks agree. Then it
+unfolds every carrier, joins the streams (`auro::Unfolder`) and writes a
+master set of the original layout: the bed and the four corner heights as
+bed channels, the centre height and the top as static objects. Samples no
+block claims (before the first block, after the last) play as the carrier.
+A track that turns out not to be a carrier is written as before.
 
 ## Corpus
 

--- a/harletty/Cargo.toml
+++ b/harletty/Cargo.toml
@@ -24,6 +24,7 @@ truehdd-macros = "0.1.1"
 truehd = { version = "0.7.1" }
 eac3 = { version = "0.7.4", path = "../eac3" }
 dca = { version = "0.7.4", path = "../dca" }
+auro = { version = "0.7.4", path = "../auro" }
 damf = { version = "0.7.4", path = "../damf" }
 
 anyhow = "1.0.99"

--- a/harletty/src/cli/decode/auro_stage.rs
+++ b/harletty/src/cli/decode/auro_stage.rs
@@ -214,6 +214,7 @@ impl AuroStage {
         };
         let sample_rate = first.frame.sample_rate;
         let mut unfolder = Unfolder::new(&carrier_ids, &outputs);
+        unfolder.set_latency(usize::from(detection.block_size));
         let mut scratch = Vec::new();
         // Replay what was held: the floats are the 24-bit integers exactly.
         for h in held {

--- a/harletty/src/cli/decode/auro_stage.rs
+++ b/harletty/src/cli/decode/auro_stage.rs
@@ -1,0 +1,284 @@
+//! The Auro-3D stage of the DTS decode thread.
+//!
+//! A lossless DTS-HD track may be an Auro-Codec carrier: the low bits of
+//! its PCM then hold the fold of a larger layout. Whether it is one is only
+//! known a few blocks in, and unfolding lags input by a block, so the
+//! frames decoded so far are held back until the question is settled. If
+//! the carrier is confirmed, the held frames are replayed into the
+//! unfolder and the output switches to unfolded frames; if it is not, they
+//! go out as they are and the stage steps aside.
+
+use super::dts_handler::{AuroFrame, DtsFrameMessage};
+use anyhow::Result;
+use auro::{Detector, StreamId, Unfolder};
+use dca::HdFrame;
+use std::collections::VecDeque;
+use std::sync::mpsc;
+
+/// Samples to hold back while waiting for a verdict: three of the largest
+/// blocks, which is what the detector needs to latch.
+const HOLD_LIMIT: usize = 3 * auro::block::MAX_BLOCK + 4096;
+
+const PCM_SCALE: f32 = 8_388_608.0;
+
+/// The bed stream a DCA speaker index plays as.
+fn speaker_stream(speaker: usize) -> StreamId {
+    StreamId(match speaker {
+        0 => 2,
+        1 => 0,
+        2 => 1,
+        3 => 4,
+        4 => 5,
+        5 => 3,
+        6 => 6,
+        7 => 7,
+        8 => 8,
+        _ => 0xff,
+    })
+}
+
+enum Phase {
+    /// Detecting; `held` accumulates the frames not yet sent.
+    Undecided {
+        detector: Detector,
+        held: VecDeque<HeldFrame>,
+        held_samples: usize,
+    },
+    /// Confirmed: everything flows through the unfolder.
+    Unfolding {
+        unfolder: Unfolder,
+        /// DCA speaker index of each carrier channel, in unfolder order.
+        speakers: Vec<usize>,
+        outputs: Vec<StreamId>,
+        sample_rate: u32,
+        scratch: Vec<i32>,
+    },
+    /// Not a carrier (or given up): frames pass straight through.
+    Plain,
+}
+
+struct HeldFrame {
+    frame: Box<HdFrame>,
+    presentation: Option<dca::XPresentation>,
+    metadata: Option<dca::XMetadata>,
+}
+
+pub struct AuroStage {
+    phase: Phase,
+}
+
+impl AuroStage {
+    pub fn new() -> Self {
+        Self {
+            phase: Phase::Undecided {
+                detector: Detector::new(0),
+                held: VecDeque::new(),
+                held_samples: 0,
+            },
+        }
+    }
+
+    /// One decoded HD frame, with the decoder's integer output for it.
+    /// Sends whatever can go out now.
+    pub fn frame(
+        &mut self,
+        frame: Box<HdFrame>,
+        presentation: Option<dca::XPresentation>,
+        metadata: Option<dca::XMetadata>,
+        lossless: impl Iterator<Item = (usize, Vec<i32>)>,
+        tx: &mpsc::Sender<Result<DtsFrameMessage>>,
+    ) {
+        match &mut self.phase {
+            Phase::Plain => {
+                let _ = tx.send(Ok(DtsFrameMessage::Hd {
+                    frame,
+                    presentation,
+                    metadata,
+                }));
+            }
+            Phase::Unfolding {
+                unfolder,
+                speakers,
+                outputs,
+                sample_rate,
+                scratch,
+            } => {
+                for (speaker, samples) in lossless {
+                    if let Some(index) = speakers.iter().position(|&s| s == speaker) {
+                        for chunk in samples.chunks(auro::unfold::MAX_PUSH) {
+                            unfolder.push(index, chunk);
+                        }
+                    }
+                }
+                Self::drain(unfolder, outputs, *sample_rate, scratch, tx);
+            }
+            Phase::Undecided {
+                detector,
+                held,
+                held_samples,
+            } => {
+                if detector.channel_count() == 0 {
+                    *detector = Detector::new(frame.samples.len());
+                }
+                let n = frame.bed_sample_count();
+                let mut latched = None;
+                for (speaker, samples) in lossless {
+                    if let Some(d) = detector.push(speaker, &samples) {
+                        latched = Some(d);
+                    }
+                }
+                held.push_back(HeldFrame {
+                    frame,
+                    presentation,
+                    metadata,
+                });
+                *held_samples += n;
+                if let Some(detection) = latched {
+                    let _ = tx.send(Ok(DtsFrameMessage::Auro(detection)));
+                    self.start_unfolding(detection, tx);
+                } else if *held_samples > HOLD_LIMIT {
+                    self.give_up(tx);
+                }
+            }
+        }
+    }
+
+    /// A frame without lossless output (core only): not a carrier.
+    pub fn not_a_carrier(&mut self, tx: &mpsc::Sender<Result<DtsFrameMessage>>) {
+        if matches!(self.phase, Phase::Undecided { .. }) {
+            self.give_up(tx);
+        }
+    }
+
+    /// Input is over: release what the latency held back.
+    pub fn finish(&mut self, tx: &mpsc::Sender<Result<DtsFrameMessage>>) {
+        match &mut self.phase {
+            Phase::Unfolding {
+                unfolder,
+                outputs,
+                sample_rate,
+                scratch,
+                ..
+            } => {
+                unfolder.finish();
+                Self::drain(unfolder, outputs, *sample_rate, scratch, tx);
+                log::info!(
+                    "Auro-3D unfold complete: {} blocks failed to decode",
+                    unfolder.decode_errors()
+                );
+            }
+            Phase::Undecided { .. } => self.give_up(tx),
+            Phase::Plain => {}
+        }
+    }
+
+    fn give_up(&mut self, tx: &mpsc::Sender<Result<DtsFrameMessage>>) {
+        let phase = std::mem::replace(&mut self.phase, Phase::Plain);
+        if let Phase::Undecided { held, .. } = phase {
+            for h in held {
+                let _ = tx.send(Ok(DtsFrameMessage::Hd {
+                    frame: h.frame,
+                    presentation: h.presentation,
+                    metadata: h.metadata,
+                }));
+            }
+        }
+    }
+
+    fn start_unfolding(
+        &mut self,
+        detection: auro::Detection,
+        tx: &mpsc::Sender<Result<DtsFrameMessage>>,
+    ) {
+        let phase = std::mem::replace(&mut self.phase, Phase::Plain);
+        let Phase::Undecided { held, .. } = phase else {
+            return;
+        };
+        let Some(first) = held.front() else {
+            return;
+        };
+        let speakers: Vec<usize> = (0..first.frame.samples.len())
+            .filter(|&s| first.frame.samples[s].is_some())
+            .collect();
+        let carrier_ids: Vec<StreamId> = speakers.iter().map(|&s| speaker_stream(s)).collect();
+        let outputs: Vec<StreamId> = match detection.original.streams() {
+            Some(streams) => streams.as_slice().iter().map(|&id| StreamId(id)).collect(),
+            None => {
+                log::warn!(
+                    "Auro-3D layout {:?} has no known stream list; keeping the carrier as is",
+                    detection.original
+                );
+                self.give_up_with(held, tx);
+                return;
+            }
+        };
+        let sample_rate = first.frame.sample_rate;
+        let mut unfolder = Unfolder::new(&carrier_ids, &outputs);
+        let mut scratch = Vec::new();
+        // Replay what was held: the floats are the 24-bit integers exactly.
+        for h in held {
+            for (index, &speaker) in speakers.iter().enumerate() {
+                if let Some(channel) = h.frame.samples.get(speaker).and_then(|c| c.as_ref()) {
+                    let ints: Vec<i32> = channel
+                        .iter()
+                        .map(|&v| (v * PCM_SCALE).round() as i32)
+                        .collect();
+                    for chunk in ints.chunks(auro::unfold::MAX_PUSH) {
+                        unfolder.push(index, chunk);
+                    }
+                }
+            }
+            Self::drain(&mut unfolder, &outputs, sample_rate, &mut scratch, tx);
+        }
+        self.phase = Phase::Unfolding {
+            unfolder,
+            speakers,
+            outputs,
+            sample_rate,
+            scratch,
+        };
+    }
+
+    fn give_up_with(
+        &mut self,
+        held: VecDeque<HeldFrame>,
+        tx: &mpsc::Sender<Result<DtsFrameMessage>>,
+    ) {
+        self.phase = Phase::Plain;
+        for h in held {
+            let _ = tx.send(Ok(DtsFrameMessage::Hd {
+                frame: h.frame,
+                presentation: h.presentation,
+                metadata: h.metadata,
+            }));
+        }
+    }
+
+    fn drain(
+        unfolder: &mut Unfolder,
+        outputs: &[StreamId],
+        sample_rate: u32,
+        scratch: &mut Vec<i32>,
+        tx: &mpsc::Sender<Result<DtsFrameMessage>>,
+    ) {
+        let ready = unfolder.ready();
+        if ready == 0 {
+            return;
+        }
+        scratch.clear();
+        scratch.resize(ready * outputs.len(), 0);
+        let frames = unfolder.take(outputs, scratch);
+        scratch.truncate(frames * outputs.len());
+        let _ = tx.send(Ok(DtsFrameMessage::AuroFrame(Box::new(AuroFrame {
+            sample_rate,
+            streams: outputs.to_vec(),
+            samples: std::mem::take(scratch),
+        }))));
+    }
+}
+
+impl Default for AuroStage {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -27,6 +27,9 @@ pub enum DtsFrameMessage {
     },
     /// A plain DTS core frame (5.1 lossy bed, no extension).
     Core(Box<PcmPushResult>),
+    /// The lossless PCM turned out to be an Auro-Codec carrier. Sent once,
+    /// when the side channel's configuration is confirmed.
+    Auro(auro::Detection),
 }
 
 pub struct DtsDecodeHandler {
@@ -60,6 +63,8 @@ pub struct DtsDecodeHandler {
     /// Label for the master set, chosen from the presentation of the first
     /// spatial frame.
     source_codec: SourceCodec,
+    /// The Auro-Codec carrier the lossless PCM was found to be, if any.
+    pub auro: Option<auro::Detection>,
 }
 
 /// Which DAMF codec label a spatial presentation is stored under.
@@ -96,6 +101,7 @@ impl Default for DtsDecodeHandler {
             warned_dropped_channels: false,
             warned_unreadable_metadata: false,
             source_codec: SourceCodec::DtsX714,
+            auro: None,
         }
     }
 }
@@ -117,7 +123,28 @@ impl DtsDecodeHandler {
             DtsFrameMessage::Core(push) => {
                 self.handle_core_frame(&push.pcm, base_path, format, no_audio)
             }
+            DtsFrameMessage::Auro(detection) => {
+                self.note_auro(detection);
+                Ok(())
+            }
         }
+    }
+
+    /// Say what the carrier holds. The height layer is not reconstructed:
+    /// the output stays the carrier bed, which is what the disc plays as on
+    /// anything without an Auro decoder.
+    fn note_auro(&mut self, detection: auro::Detection) {
+        let name = |layout: auro::Layout| layout.name().unwrap_or("unknown layout");
+        log::info!(
+            "Auro-3D carrier: {} folded into {} ({}-sample blocks, channel configuration {}). \
+             Height channels are not reconstructed; the output is the {} carrier.",
+            name(detection.original),
+            name(detection.carrier),
+            detection.block_size,
+            detection.config.0,
+            name(detection.carrier),
+        );
+        self.auro = Some(detection);
     }
 
     fn handle_hd_frame(

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -30,6 +30,18 @@ pub enum DtsFrameMessage {
     /// The lossless PCM turned out to be an Auro-Codec carrier. Sent once,
     /// when the side channel's configuration is confirmed.
     Auro(auro::Detection),
+    /// Unfolded Auro-3D audio: the streams of the original layout,
+    /// interleaved. Replaces the `Hd` frames from the moment the carrier
+    /// is confirmed.
+    AuroFrame(Box<AuroFrame>),
+}
+
+pub struct AuroFrame {
+    pub sample_rate: u32,
+    /// The streams, in interleaving order.
+    pub streams: Vec<auro::StreamId>,
+    /// `frames * streams.len()` samples, 24-bit in `i32`.
+    pub samples: Vec<i32>,
 }
 
 pub struct DtsDecodeHandler {
@@ -65,6 +77,21 @@ pub struct DtsDecodeHandler {
     source_codec: SourceCodec,
     /// The Auro-Codec carrier the lossless PCM was found to be, if any.
     pub auro: Option<auro::Detection>,
+}
+
+/// Which DAMF codec label an unfolded Auro-3D layout is stored under: its
+/// channel count when it is one of the common ones.
+fn auro_source_codec(original: auro::Layout) -> SourceCodec {
+    let Some(streams) = original.streams() else {
+        return SourceCodec::Auro3d;
+    };
+    match streams.len {
+        10 => SourceCodec::Auro3d91,
+        11 => SourceCodec::Auro3d101,
+        12 => SourceCodec::Auro3d111,
+        14 => SourceCodec::Auro3d131,
+        _ => SourceCodec::Auro3d,
+    }
 }
 
 /// Which DAMF codec label a spatial presentation is stored under.
@@ -127,22 +154,82 @@ impl DtsDecodeHandler {
                 self.note_auro(detection);
                 Ok(())
             }
+            DtsFrameMessage::AuroFrame(frame) => {
+                self.handle_auro_frame(&frame, base_path, no_audio)
+            }
         }
     }
 
-    /// Say what the carrier holds. The height layer is not reconstructed:
-    /// the output stays the carrier bed, which is what the disc plays as on
-    /// anything without an Auro decoder.
+    /// Write one unfolded Auro-3D frame. The output is always a master
+    /// set: the bed the layout resolved plus the centre height and top as
+    /// static objects.
+    fn handle_auro_frame(
+        &mut self,
+        frame: &AuroFrame,
+        base_path: &Option<PathBuf>,
+        no_audio: bool,
+    ) -> Result<()> {
+        let ns = frame.streams.len();
+        if ns == 0 || frame.samples.len() < ns {
+            return Ok(());
+        }
+        let sample_count = frame.samples.len() / ns;
+        let layout = DtsLayout::from_auro(&frame.streams);
+        let total_channels = layout.bed.len() + layout.objects.len();
+        if total_channels < ns {
+            self.warn_dropped_channels(ns - total_channels);
+        }
+        if !self.has_spatial {
+            self.source_codec = self
+                .auro
+                .map(|d| auro_source_codec(d.original))
+                .unwrap_or(SourceCodec::Auro3d);
+        }
+        self.note_frame(frame.sample_rate, total_channels, &layout, true, base_path)?;
+        if let Some(base_path) = base_path {
+            let oamd = convert_dts(&layout);
+            self.write_metadata_event(&oamd, frame.sample_rate, base_path)?;
+        }
+        if !no_audio {
+            self.ensure_audio_writer(
+                base_path,
+                AudioFormat::Caf,
+                frame.sample_rate,
+                total_channels,
+            )?;
+            if let Some(ref mut writer) = self.audio_writer {
+                let mut interleaved: Vec<i32> = Vec::with_capacity(sample_count * total_channels);
+                for sample_idx in 0..sample_count {
+                    let row = &frame.samples[sample_idx * ns..(sample_idx + 1) * ns];
+                    for &source in &layout.bed_sources {
+                        let BedSource::Speaker(index) = source else {
+                            continue;
+                        };
+                        interleaved.push(row[index]);
+                    }
+                    for &index in &layout.object_sources {
+                        interleaved.push(row[index]);
+                    }
+                }
+                writer.write_pcm_samples(&interleaved, total_channels)?;
+            }
+        }
+        self.decoded_samples += sample_count as u64;
+        self.decoded_frames += 1;
+        Ok(())
+    }
+
+    /// Say what the carrier holds and what the output will be.
     fn note_auro(&mut self, detection: auro::Detection) {
         let name = |layout: auro::Layout| layout.name().unwrap_or("unknown layout");
         log::info!(
-            "Auro-3D carrier: {} folded into {} ({}-sample blocks, channel configuration {}). \
-             Height channels are not reconstructed; the output is the {} carrier.",
+            "Auro-3D carrier: {} folded into {} ({}-sample blocks, channel configuration {}); \
+             unfolding to a {} master set",
             name(detection.original),
             name(detection.carrier),
             detection.block_size,
             detection.config.0,
-            name(detection.carrier),
+            name(detection.original),
         );
         self.auro = Some(detection);
     }

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -82,14 +82,11 @@ pub struct DtsDecodeHandler {
 /// Which DAMF codec label an unfolded Auro-3D layout is stored under: its
 /// channel count when it is one of the common ones.
 fn auro_source_codec(original: auro::Layout) -> SourceCodec {
-    let Some(streams) = original.streams() else {
-        return SourceCodec::Auro3d;
-    };
-    match streams.len {
-        10 => SourceCodec::Auro3d91,
-        11 => SourceCodec::Auro3d101,
-        12 => SourceCodec::Auro3d111,
-        14 => SourceCodec::Auro3d131,
+    match original.source_codec_label() {
+        "Auro-3D-9.1" => SourceCodec::Auro3d91,
+        "Auro-3D-10.1" => SourceCodec::Auro3d101,
+        "Auro-3D-11.1" => SourceCodec::Auro3d111,
+        "Auro-3D-13.1" => SourceCodec::Auro3d131,
         _ => SourceCodec::Auro3d,
     }
 }

--- a/harletty/src/cli/decode/dts_thread.rs
+++ b/harletty/src/cli/decode/dts_thread.rs
@@ -37,6 +37,9 @@ struct DtsDecodeState {
     buffer: Vec<u8>,
     core: PcmDecoder,
     hd: HdDecoder,
+    /// Auro-Codec side-channel detector over the lossless output. Built on
+    /// the first HD frame, once the speaker count is known.
+    auro: Option<auro::Detector>,
     frame_count: u64,
     strict_mode: bool,
 }
@@ -55,6 +58,7 @@ pub fn spawn_dts_decoder_thread(config: DtsDecoderThreadConfig) -> thread::JoinH
             buffer: prefix,
             core: PcmDecoder::new(),
             hd: HdDecoder::new(),
+            auro: None,
             frame_count: 0,
             strict_mode,
         };
@@ -133,6 +137,7 @@ fn drain_frames(
         let DtsDecodeState {
             core: core_decoder,
             hd: hd_decoder,
+            auro,
             frame_count,
             strict_mode,
             ..
@@ -141,6 +146,7 @@ fn drain_frames(
             DecodeTargets {
                 core_decoder,
                 hd_decoder,
+                auro,
                 frame_count,
                 strict_mode: *strict_mode,
             },
@@ -161,6 +167,7 @@ fn drain_frames(
 struct DecodeTargets<'a> {
     core_decoder: &'a mut PcmDecoder,
     hd_decoder: &'a mut HdDecoder,
+    auro: &'a mut Option<auro::Detector>,
     frame_count: &'a mut u64,
     strict_mode: bool,
 }
@@ -175,12 +182,22 @@ fn decode_one(
     let DecodeTargets {
         core_decoder,
         hd_decoder,
+        auro,
         frame_count,
         strict_mode,
     } = targets;
     if let Some(exss) = exss {
         match hd_decoder.decode(core, exss) {
             Ok(frame) => {
+                // The side channel lives in the low bits of the lossless
+                // integers, so it is read off the decoder's integer tap, not
+                // off the float frame.
+                let detector = auro.get_or_insert_with(|| auro::Detector::new(frame.samples.len()));
+                for (speaker, samples) in hd_decoder.lossless_samples() {
+                    if let Some(detection) = detector.push(speaker, samples) {
+                        let _ = tx.send(Ok(DtsFrameMessage::Auro(detection)));
+                    }
+                }
                 let presentation = XPresentation::detect(&frame);
                 // Unreadable metadata is reported by the handler once; the
                 // frame still plays with its bed as authored.

--- a/harletty/src/cli/decode/dts_thread.rs
+++ b/harletty/src/cli/decode/dts_thread.rs
@@ -10,6 +10,7 @@
 //! the realtime path. Kept separate on purpose: that one is a streaming
 //! push-model driven by an audio callback, this one owns a file and can block.
 
+use super::auro_stage::AuroStage;
 use super::dts_handler::DtsFrameMessage;
 use crate::input::InputReader;
 use anyhow::Result;
@@ -37,9 +38,9 @@ struct DtsDecodeState {
     buffer: Vec<u8>,
     core: PcmDecoder,
     hd: HdDecoder,
-    /// Auro-Codec side-channel detector over the lossless output. Built on
-    /// the first HD frame, once the speaker count is known.
-    auro: Option<auro::Detector>,
+    /// Auro-Codec detection and unfolding over the lossless output; owns
+    /// the frames it holds back while deciding.
+    auro: AuroStage,
     frame_count: u64,
     strict_mode: bool,
 }
@@ -58,7 +59,7 @@ pub fn spawn_dts_decoder_thread(config: DtsDecoderThreadConfig) -> thread::JoinH
             buffer: prefix,
             core: PcmDecoder::new(),
             hd: HdDecoder::new(),
-            auro: None,
+            auro: AuroStage::new(),
             frame_count: 0,
             strict_mode,
         };
@@ -72,6 +73,7 @@ pub fn spawn_dts_decoder_thread(config: DtsDecoderThreadConfig) -> thread::JoinH
 
         // A trailing frame can still be complete after EOF.
         drain_frames(&mut state, &pb_clone, &tx)?;
+        state.auro.finish(&tx);
 
         log::info!("DTS decode complete: {} frames", state.frame_count);
         Ok(())
@@ -167,7 +169,7 @@ fn drain_frames(
 struct DecodeTargets<'a> {
     core_decoder: &'a mut PcmDecoder,
     hd_decoder: &'a mut HdDecoder,
-    auro: &'a mut Option<auro::Detector>,
+    auro: &'a mut AuroStage,
     frame_count: &'a mut u64,
     strict_mode: bool,
 }
@@ -189,15 +191,6 @@ fn decode_one(
     if let Some(exss) = exss {
         match hd_decoder.decode(core, exss) {
             Ok(frame) => {
-                // The side channel lives in the low bits of the lossless
-                // integers, so it is read off the decoder's integer tap, not
-                // off the float frame.
-                let detector = auro.get_or_insert_with(|| auro::Detector::new(frame.samples.len()));
-                for (speaker, samples) in hd_decoder.lossless_samples() {
-                    if let Some(detection) = detector.push(speaker, samples) {
-                        let _ = tx.send(Ok(DtsFrameMessage::Auro(detection)));
-                    }
-                }
                 let presentation = XPresentation::detect(&frame);
                 // Unreadable metadata is reported by the handler once; the
                 // frame still plays with its bed as authored.
@@ -205,11 +198,21 @@ fn decode_one(
                     .and_then(|p| XMetadata::parse(&frame.x_payload, p.feed_count()).ok());
                 *frame_count += 1;
                 tick(pb);
-                let _ = tx.send(Ok(DtsFrameMessage::Hd {
-                    frame: Box::new(frame),
+                // The Auro side channel lives in the low bits of the lossless
+                // integers, so it is read off the decoder's integer tap, not
+                // off the float frame. The stage decides whether the frame
+                // goes out as it is or unfolded.
+                let lossless: Vec<(usize, Vec<i32>)> = hd_decoder
+                    .lossless_samples()
+                    .map(|(speaker, samples)| (speaker, samples.to_vec()))
+                    .collect();
+                auro.frame(
+                    Box::new(frame),
                     presentation,
                     metadata,
-                }));
+                    lossless.into_iter(),
+                    tx,
+                );
                 return Ok(());
             }
             // Peak-bitrate buffering: this packet yields no frame, which is
@@ -228,6 +231,8 @@ fn decode_one(
         Ok(push) => {
             *frame_count += 1;
             tick(pb);
+            // A lossy core frame cannot carry the side channel.
+            auro.not_a_carrier(tx);
             let _ = tx.send(Ok(DtsFrameMessage::Core(Box::new(push))));
         }
         Err(err) => {

--- a/harletty/src/cli/decode/mod.rs
+++ b/harletty/src/cli/decode/mod.rs
@@ -1,4 +1,5 @@
 pub mod atmos;
+pub mod auro_stage;
 mod decode_impl;
 pub mod decoder_thread;
 pub mod dts_handler;

--- a/harletty/src/dts_to_oamd.rs
+++ b/harletty/src/dts_to_oamd.rs
@@ -194,6 +194,64 @@ impl DtsLayout {
     }
 }
 
+/// Map an Auro stream to its OAMD speaker. The bed and the four corner
+/// heights have names; the centre height and the top do not and become
+/// static objects instead (see [`DtsLayout::from_auro`]).
+pub fn auro_stream_to_speaker(stream: auro::StreamId) -> Option<SpeakerLabels> {
+    Some(match stream.0 {
+        0 => SpeakerLabels::L,
+        1 => SpeakerLabels::R,
+        2 => SpeakerLabels::C,
+        3 => SpeakerLabels::LFE,
+        4 => SpeakerLabels::Lss,
+        5 => SpeakerLabels::Rss,
+        7 => SpeakerLabels::Lrs,
+        8 => SpeakerLabels::Rrs,
+        9 => SpeakerLabels::Lfh,
+        10 => SpeakerLabels::Rfh,
+        13 => SpeakerLabels::Lrh,
+        14 => SpeakerLabels::Rrh,
+        _ => return None,
+    })
+}
+
+/// Where an Auro stream with no OAMD speaker sits, in DAMF space: the
+/// centre height on the front wall at the ceiling, the top overhead.
+pub fn auro_stream_object_position(stream: auro::StreamId) -> Option<[f64; 3]> {
+    Some(match stream.0 {
+        11 => [0.0, 1.0, 1.0],
+        12 => [0.0, 0.0, 1.0],
+        _ => return None,
+    })
+}
+
+impl DtsLayout {
+    /// Layout of an unfolded Auro-3D stream: `streams` in the order the
+    /// unfolder interleaves them. Streams with a speaker name join the bed;
+    /// the centre height and the top become objects at fixed positions;
+    /// anything else (a rear centre) is dropped.
+    pub fn from_auro(streams: &[auro::StreamId]) -> Self {
+        let mut pairs = Vec::new();
+        let mut objects = Vec::new();
+        let mut object_sources = Vec::new();
+        for (index, stream) in streams.iter().enumerate() {
+            if let Some(speaker) = auro_stream_to_speaker(*stream) {
+                pairs.push((speaker, BedSource::Speaker(index)));
+            } else if let Some(position) = auro_stream_object_position(*stream) {
+                objects.push(position);
+                object_sources.push(index);
+            }
+        }
+        let (bed, bed_sources) = Self::from_pairs(pairs);
+        Self {
+            bed,
+            bed_sources,
+            objects,
+            object_sources,
+        }
+    }
+}
+
 /// Convert a DAMF-space coordinate (`-1.0..=1.0`) to the OAMD `pos3d` encoding.
 ///
 /// OAMD stores x and y in `0.0..=1.0` and z in `-1.0..=1.0`, and its y axis runs
@@ -529,6 +587,29 @@ mod tests {
                 assert!((read_back[index][0][axis] - expected[axis]).abs() < 1e-9);
             }
         }
+    }
+
+    #[test]
+    fn an_unfolded_thirteen_one_is_a_twelve_channel_bed_plus_two_objects() {
+        let streams: Vec<auro::StreamId> = auro::Layout(32703)
+            .streams()
+            .unwrap()
+            .as_slice()
+            .iter()
+            .map(|&id| auro::StreamId(id))
+            .collect();
+        let layout = DtsLayout::from_auro(&streams);
+        assert_eq!(layout.bed.len(), 12);
+        assert_eq!(layout.objects.len(), 2);
+        // HC (index 10 in the stream order) then T (index 13).
+        assert_eq!(layout.object_sources, vec![10, 13]);
+        assert_eq!(layout.objects[0], [0.0, 1.0, 1.0]);
+        assert_eq!(layout.objects[1], [0.0, 0.0, 1.0]);
+        // The bed is declared in DAMF order with matching sources.
+        assert_eq!(layout.bed[0], SpeakerLabels::L);
+        assert_eq!(layout.bed_sources[0], BedSource::Speaker(0));
+        assert_eq!(layout.bed[3], SpeakerLabels::LFE);
+        assert_eq!(layout.bed_sources[3], BedSource::Speaker(7));
     }
 
     #[test]


### PR DESCRIPTION
## What

Auro-3D ships its height layer inside an ordinary 24-bit 5.1/7.1 carrier: the low bits of every carrier sample hold a serial side channel that names the fold and carries the residuals a decoder needs to undo it. This PR reads that side channel in full and unfolds the carrier back into the layout it was encoded from, offline and in realtime.

Three commits:

1. **Detection** — a dependency-free `auro` crate: block sync, CRC-16/CCITT, the ADOL bytecode that announces the channel-input configuration, the public layout tables, and a streaming `Detector` with fixed per-channel storage. `dca::HdDecoder::lossless_samples` exposes the integer XLL output the side channel needs.
2. **Unfold** — the stream layer (header, seeds, gains, codebook, Golomb-Rice residuals) and the unfold arithmetic (two-stream linear and three-stream three-phase extrapolation, gain scaling, clamping), an `Unfolder` that joins the carriers with the one-block latency the scheme imposes, and the CLI: `harletty decode` holds DTS-HD frames back until the carrier is confirmed, then writes a master set of the original layout — bed and corner heights as bed channels, centre height and top as static objects — labelled `Auro-3D-13.1` / `-11.1` / `-10.1` / `-9.1`.
3. **Bridge** — the realtime DTS-HD path does the same: frames held back until the verdict (two of the largest blocks when no block validates, four when blocks validate but the layout has not latched), replayed into the unfolder from their own PCM, then every frame is the unfolded layout as labelled fixed channels (Tfl/Tfr/Tbl/Tbr, Tfc for the centre height, Tc for the top). Output lags input by one block, 21 ms at 48 kHz for 1000-sample blocks. A track that is not a carrier, or a DTS:X one, gets its held frames back unchanged.

`docs/pcm-aux-layer-research.md` documents the format as found; the earlier draft reasoned from a patent example the streams do not follow.

## Verification

- `cargo test -p auro`: a synthetic writer mirrors the reader's bit map; an encoder round trip checks the two-stream unfold; the three-stream sum invariant; Rice/codebook decoding on hand-built bit strings.
- `auro/tests/pair.rs` against the published original/encoded pair (`HARLETTY_AURO_PAIR_*`): 1880 blocks, 0 decode errors, correlation 0.999996–0.999998 and gain −0.002 dB on L, R, C, Ls, Rs.
- `auro/tests/corpus.rs` on real 13.1 and 11.1 extracts: every block of every channel validates.
- CLI on 13.1 and 11.1 carriers (30 s extracts and a full 100 s demo): 14- and 12-channel master sets, 0 failed blocks, output length equal to the input, ~2.5 s for 100 s of audio; a DTS:X track still decodes as before.
- Bridge: a synthetic carrier whose L blocks announce a height stream comes out on Tfl with L silent and the other channels as themselves; plain PCM is released unchanged once the stage gives up; a real 13.1 extract through `push_packet` (`HARLETTY_AURO_DTS_CORPUS`) yields 2923 frames of 14 channels with exactly one block held back at the end.
- `cargo test --workspace` green; `scripts/check-crate-isolation.sh` ok.

## Not in this PR

- The bridge has no end-of-stream flush, so the last block of a stream stays in the unfolder (as the PBR pending frames already do).
- The unfold is the codec's own arithmetic: outputs are "virtually lossless" (about −50 dB relative error on real material), not bit-exact masters.
- Not yet listened to through mpv.

Sources for the layout layer: almirus, Habr (2026-08); `almirus/Orua-D3` (MIT); MediaArea/MediaInfoLib#2531. The stream layer was worked out here by analysis of the carriers and is checked against the published pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
