### PR TITLE
feat(dts): estimate the bed fold of a waveform the stream does not state

### DIFF
--- a/bridge/dts-fold.yaml
+++ b/bridge/dts-fold.yaml
@@ -2,8 +2,14 @@
 # could not be read: the four height feeds' contribution to the compatible
 # 7.1 bed. Every stream examined states code 55 (Q15 23170/32768) here. A
 # `dts-fold.yaml` in the working directory overrides this bundled default.
-# Alternate profiles carry their folds in per-frame metadata and ignore this
-# file.
+# Alternate profiles carry their folds in per-frame metadata and ignore the
+# `sources` list.
+#
+# `estimate_unknown`: a waveform whose fold the stream does not state (an
+# object record without reference rows) has its fold measured from the bed's
+# own audio, frame by frame, so it plays at its position and leaves the bed.
+# Set to false to keep such a waveform in the bed and mute its own channel.
+estimate_unknown: true
 sources:
   - source: TFL
     routes: [{target: L, gain_db: -3.0104780234}]

--- a/bridge/src/dts_pipeline.rs
+++ b/bridge/src/dts_pipeline.rs
@@ -13,7 +13,9 @@
 // gains the stream's private metadata states; that contribution is removed
 // from the bed before the waveform is emitted at its own position, so nothing
 // plays twice. A waveform whose fold is not stated (an object record without
-// reference rows) stays in the bed and its own channel is silent.
+// reference rows) has its fold estimated from the audio (`dca::FoldEstimator`)
+// and is treated the same; with estimation off it stays in the bed and its
+// own channel is silent.
 
 use abi_stable::std_types::{RString, RVec};
 use bridge_api::RPushResult;
@@ -21,8 +23,8 @@ use bridge_api::{
     RChannelLabel, RDecodedFrame, REvent, RMetadataFrame, RNameUpdate, RObjectChannel,
 };
 use dca::{
-    CorePcmFrame, FoldPlan, HdError, HdFrame, MAX_SOURCES, SourceRole, SphericalPosition,
-    XMetadata, XPresentation, exss_has_xll, exss_substream_size, parse_header,
+    CorePcmFrame, FoldEstimator, FoldPlan, HdError, HdFrame, MAX_SOURCES, SourceRole,
+    SphericalPosition, XMetadata, XPresentation, exss_has_xll, exss_substream_size, parse_header,
 };
 use serde::Deserialize;
 
@@ -62,6 +64,15 @@ pub(crate) struct FoldSource {
 pub(crate) struct DtsFoldConfig {
     #[serde(default)]
     pub sources: Vec<FoldSource>,
+    /// Estimate the fold of a waveform the stream does not state one for,
+    /// from the bed's own audio, so the waveform plays at its position and
+    /// leaves the bed. Off, such a waveform stays in the bed and is muted.
+    #[serde(default = "default_true")]
+    pub estimate_unknown: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for DtsFoldConfig {
@@ -114,6 +125,10 @@ pub(crate) struct DtsXState {
     pub(crate) last_metadata: Option<XMetadata>,
     /// Position last announced per object feed, for sparse events.
     emitted_positions: [Option<SphericalPosition>; MAX_SOURCES],
+    /// Running fold estimates for the waveforms whose fold is not stated.
+    estimator: FoldEstimator,
+    /// Whether the estimation has been announced for this stream.
+    estimation_noted: bool,
     parse_failures: u64,
     feed_dropouts: u64,
 }
@@ -371,6 +386,7 @@ fn build_hd_frame_with_extensions(
                     "dts: extension presentation changed {:?} -> {detected:?}; channel shape changes",
                     state.locked
                 );
+                state.estimator.reset();
             }
             state.locked = Some(detected);
             detected
@@ -388,11 +404,21 @@ fn build_hd_frame_with_extensions(
     } else {
         &[]
     };
-    let plan = if detected.is_some() {
+    let mut plan = if detected.is_some() {
         resolve_plan(hd, presentation, state, fold_config)
     } else {
         FoldPlan::all_unknown(presentation.feed_count())
     };
+    if detected.is_some() && fold_config.estimate_unknown && plan.has_unknown() {
+        if !state.estimation_noted {
+            state.estimation_noted = true;
+            log::info!(
+                "dts: {:?} carries waveform(s) without a stated bed fold; estimating their fold from the bed",
+                presentation
+            );
+        }
+        state.estimator.refine(&mut plan, &hd.samples, feeds);
+    }
     let metadata = detected.and(state.last_metadata);
 
     let fixed_feeds = presentation.fixed_feeds();
@@ -698,6 +724,30 @@ mod tests {
         let mut declared = None;
         build_hd_frame_with_extensions(hd, state, &DtsFoldConfig::default(), 0, &mut declared)
             .expect("valid frame")
+    }
+
+    fn build_without_estimation(hd: &HdFrame, state: &mut DtsXState) -> (RDecodedFrame, bool) {
+        let mut declared = None;
+        let config = DtsFoldConfig {
+            estimate_unknown: false,
+            ..DtsFoldConfig::default()
+        };
+        build_hd_frame_with_extensions(hd, state, &config, 0, &mut declared).expect("valid frame")
+    }
+
+    /// Deterministic pseudo-noise in [-1, 1] (splitmix64).
+    fn noise(seed: u64, length: usize) -> Vec<f32> {
+        let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        (0..length)
+            .map(|_| {
+                state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                let mut z = state;
+                z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+                z ^= z >> 31;
+                ((z >> 33) as f32 / (1u64 << 31) as f32) * 2.0 - 1.0
+            })
+            .collect()
     }
 
     fn folded(dry: &[f32], sources: &[(&[f32], f32)]) -> Vec<f32> {
@@ -1073,7 +1123,66 @@ mod tests {
     }
 
     #[test]
-    fn d1_objects_without_a_stated_fold_stay_in_the_bed_and_are_muted() {
+    fn d1_objects_without_a_stated_fold_are_estimated_out_of_the_bed_and_played() {
+        let n = 2048;
+        let extension: Vec<Vec<f32>> = (0..6).map(|i| noise(100 + i, n)).collect();
+        let dry: Vec<Vec<f32>> = (0..9)
+            .map(|i| noise(200 + i, n).iter().map(|v| v * 0.3).collect())
+            .collect();
+        let mut samples: Vec<Option<Vec<f32>>> = (0..9).map(|_| None).collect();
+        for idx in [0usize, 2, 3, 5, 7, 8] {
+            samples[idx] = Some(dry[idx].clone());
+        }
+        // L holds object 0 at 0.92 plus TFL (feed 2) at the stated Q55; Rs
+        // holds object 1 at 0.34.
+        samples[1] = Some(folded(
+            &dry[1],
+            &[(&extension[0], 0.9152), (&extension[2], Q55)],
+        ));
+        samples[4] = Some(folded(&dry[4], &[(&extension[1], 0.34)]));
+        let mut hd = hd_frame(samples, extension);
+        hd.xll_segment_samples = n;
+        hd.x_present = false;
+        hd.x_imax = true;
+
+        let mut sources = vec![
+            object(-69, 24, BedFold::Unknown),
+            object(69, 24, BedFold::Unknown),
+        ];
+        sources.extend(heights(Q55));
+        let mut state = state_with(XMetadata::from_sources(&sources));
+        let (frame, emitted) = build(&hd, &mut state);
+
+        assert!(emitted);
+        assert_eq!(frame.channel_count, 8 + 6);
+        let mut l_residual = 0.0f64;
+        let mut rs_residual = 0.0f64;
+        for sample in 0..n {
+            let row = &frame.pcm[sample * 14..(sample + 1) * 14];
+            l_residual += f64::from(row[1] as f32 / 8_388_608.0 - dry[1][sample]).powi(2);
+            rs_residual += f64::from(row[4] as f32 / 8_388_608.0 - dry[4][sample]).powi(2);
+            // Both objects now play on their own channels.
+            assert_pcm_close(row[12], hd.x_samples[0][sample]);
+            assert_pcm_close(row[13], hd.x_samples[1][sample]);
+        }
+        // What is left in L and Rs is the dry content: the objects are gone to
+        // within the fit's noise (-30 dB of the dry level at least).
+        let dry_l: f64 = dry[1].iter().map(|v| f64::from(*v).powi(2)).sum();
+        let dry_rs: f64 = dry[4].iter().map(|v| f64::from(*v).powi(2)).sum();
+        assert!(
+            l_residual / dry_l < 5e-3,
+            "L residual {}",
+            l_residual / dry_l
+        );
+        assert!(
+            rs_residual / dry_rs < 5e-3,
+            "Rs residual {}",
+            rs_residual / dry_rs
+        );
+    }
+
+    #[test]
+    fn d1_objects_without_a_stated_fold_stay_in_the_bed_and_are_muted_without_estimation() {
         let extension: Vec<Vec<f32>> = (0..6)
             .map(|index| vec![0.01 * (index + 1) as f32, -0.01 * (index + 1) as f32])
             .collect();
@@ -1094,7 +1203,7 @@ mod tests {
         ];
         sources.extend(heights(Q55));
         let mut state = state_with(XMetadata::from_sources(&sources));
-        let (frame, emitted) = build(&hd, &mut state);
+        let (frame, emitted) = build_without_estimation(&hd, &mut state);
 
         assert!(emitted, "D1 declares object channels");
         assert_eq!(state.locked, Some(XPresentation::ObjectsD1));
@@ -1199,7 +1308,7 @@ mod tests {
         hd.x_imax = true;
 
         let mut state = DtsXState::default();
-        let (frame, emitted) = build(&hd, &mut state);
+        let (frame, emitted) = build_without_estimation(&hd, &mut state);
         assert!(emitted);
         assert_eq!(frame.channel_count, 16);
         assert_eq!(state.parse_failures, 1);

--- a/dca/src/dcadec/xmeta.rs
+++ b/dca/src/dcadec/xmeta.rs
@@ -316,9 +316,7 @@ impl XMetadata {
             DCA_SYNCWORD_XLL_X_ALT_D0
             | DCA_SYNCWORD_XLL_X_ALT_D1
             | DCA_SYNCWORD_XLL_X_ALT_D3
-            | DCA_SYNCWORD_XLL_X_ALT_D4 => {
-                parse_alternate(payload, source_count)
-            }
+            | DCA_SYNCWORD_XLL_X_ALT_D4 => parse_alternate(payload, source_count),
             _ => Err(XMetadataError::Unsupported("extension profile")),
         }
     }
@@ -372,6 +370,10 @@ impl XMetadata {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FoldPlan {
     gains: [[f32; MAX_SOURCES]; FOLD_SPEAKERS],
+    /// Per-sample change of each gain across the frame, so a gain that was
+    /// estimated rather than stated can ramp from the previous frame's value
+    /// to this frame's without a step. Zero for every stated fold.
+    slope: [[f32; MAX_SOURCES]; FOLD_SPEAKERS],
     /// Bit `k` set when waveform `k` contributes to that speaker. Sixteen bits
     /// because the widest profile carries nine waveforms, one more than a byte.
     used: [u16; FOLD_SPEAKERS],
@@ -387,6 +389,7 @@ impl FoldPlan {
         let count = source_count.min(MAX_SOURCES);
         Self {
             gains: [[0.0; MAX_SOURCES]; FOLD_SPEAKERS],
+            slope: [[0.0; MAX_SOURCES]; FOLD_SPEAKERS],
             used: [0; FOLD_SPEAKERS],
             unknown: (1u16 << count) - 1,
             count,
@@ -435,6 +438,21 @@ impl FoldPlan {
         feed < self.count && self.unknown & (1 << feed) == 0
     }
 
+    /// Whether any waveform of this frame has no stated fold.
+    pub fn has_unknown(&self) -> bool {
+        self.unknown != 0
+    }
+
+    /// The gain of waveform `feed` in `speaker` at the start of the frame
+    /// (zero when it contributes nothing there).
+    pub fn gain(&self, speaker: usize, feed: usize) -> f32 {
+        if speaker < FOLD_SPEAKERS && feed < self.count && self.used[speaker] & (1 << feed) != 0 {
+            self.gains[speaker][feed]
+        } else {
+            0.0
+        }
+    }
+
     /// Whether any subtraction applies to `speaker`.
     pub fn touches(&self, speaker: usize) -> bool {
         self.used.get(speaker).is_some_and(|&used| used != 0)
@@ -452,13 +470,232 @@ impl FoldPlan {
             return bed;
         }
         let gains = &self.gains[speaker];
+        let slope = &self.slope[speaker];
+        let position = sample as f32;
         let mut value = bed;
         for (feed, source) in sources.iter().enumerate().take(self.count) {
             if used & (1 << feed) != 0 {
-                value -= gains[feed] * source.get(sample).copied().unwrap_or(0.0);
+                value -= (gains[feed] + slope[feed] * position)
+                    * source.get(sample).copied().unwrap_or(0.0);
             }
         }
         value
+    }
+}
+
+/// Estimates, from the audio itself, the fold of every waveform whose fold
+/// the stream does not state.
+///
+/// Every extension waveform was mixed into the compatible bed by the encoder;
+/// a record without reference rows only withholds the gains. Measured on such
+/// streams, the waveform is present in the bed sample-aligned, at gains that
+/// are constant (a wide channel) or follow the transmitted position (an object
+/// panned into the bed by the encoder's own renderer, whose law differs from
+/// one encoder generation to the next). Rather than guess the law, this solves
+/// for the gains directly: per frame and per bed speaker, the least-squares
+/// fit of the bed on the unstated waveforms, jointly so that two waveforms
+/// sharing content are not both credited with it. The fit never adds energy
+/// to a speaker within the frame; what it removes is what the waveforms
+/// explain. A waveform silent in the frame keeps its last gains. Gains ramp
+/// across the frame from the previous frame's estimate, so a moving object
+/// leaves no steps in the bed.
+///
+/// Fixed-size state, no allocation per frame: a K×K normal system with K the
+/// number of unstated waveforms (at most [`MAX_SOURCES`]), solved by Cholesky.
+#[derive(Clone, Copy, Debug)]
+pub struct FoldEstimator {
+    gains: [[f32; MAX_SOURCES]; FOLD_SPEAKERS],
+    /// Bit `k` set once waveform `k` has an estimate to ramp from.
+    primed: u16,
+}
+
+impl Default for FoldEstimator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FoldEstimator {
+    /// Squared-sample floor under which a waveform counts as silent in the
+    /// frame (about -100 dBFS RMS for full-scale 1.0): its gains cannot be
+    /// measured and its last ones stand.
+    const SILENCE_ENERGY_PER_SAMPLE: f64 = 1e-10;
+    /// Ridge added to the normal matrix, relative to its largest diagonal:
+    /// keeps two nearly identical waveforms from cancelling each other with
+    /// huge opposite gains.
+    const RIDGE: f64 = 1e-4;
+    /// Gains beyond this are not a fold; the estimate is discarded and the
+    /// previous one stands.
+    const MAX_GAIN: f32 = 4.0;
+    /// Share of each frame's measurement taken into the running gain. One
+    /// frame's fit carries noise from whatever else the speaker plays (about
+    /// 0.04 for content at the waveform's own level); averaging two frames
+    /// halves its power at the cost of one frame of lag on a moving object.
+    const SMOOTHING: f32 = 0.5;
+
+    pub const fn new() -> Self {
+        Self {
+            gains: [[0.0; MAX_SOURCES]; FOLD_SPEAKERS],
+            primed: 0,
+        }
+    }
+
+    /// Forget every estimate (a new stream, or a presentation change).
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
+
+    /// Fill in the unstated folds of `plan` from this frame's audio: `bed` is
+    /// indexed by DCA speaker like `HdFrame::samples`, `sources` are the
+    /// extension waveforms. Afterwards every waveform is known to the plan,
+    /// so it is rendered on its own channel and removed from the bed.
+    pub fn refine(&mut self, plan: &mut FoldPlan, bed: &[Option<Vec<f32>>], sources: &[Vec<f32>]) {
+        if plan.unknown == 0 {
+            return;
+        }
+        let count = plan.count.min(sources.len());
+        let length = sources.iter().take(count).map(Vec::len).min().unwrap_or(0);
+        if length == 0 {
+            return;
+        }
+        // The unstated waveforms with something to measure this frame.
+        let mut feeds = [0usize; MAX_SOURCES];
+        let mut k = 0usize;
+        for feed in 0..count {
+            if plan.unknown & (1 << feed) == 0 {
+                continue;
+            }
+            let energy: f64 = sources[feed][..length]
+                .iter()
+                .map(|&v| f64::from(v) * f64::from(v))
+                .sum();
+            if energy >= Self::SILENCE_ENERGY_PER_SAMPLE * length as f64 {
+                feeds[k] = feed;
+                k += 1;
+            }
+        }
+
+        // Normal matrix over the active waveforms, once per frame.
+        let mut gram = [[0.0f64; MAX_SOURCES]; MAX_SOURCES];
+        let mut max_diagonal = 0.0f64;
+        for i in 0..k {
+            for j in 0..=i {
+                let dot: f64 = sources[feeds[i]][..length]
+                    .iter()
+                    .zip(&sources[feeds[j]][..length])
+                    .map(|(&a, &b)| f64::from(a) * f64::from(b))
+                    .sum();
+                gram[i][j] = dot;
+                gram[j][i] = dot;
+            }
+            max_diagonal = max_diagonal.max(gram[i][i]);
+        }
+        let ridge = Self::RIDGE * max_diagonal;
+        for (i, row) in gram.iter_mut().enumerate().take(k) {
+            row[i] += ridge;
+        }
+        let cholesky = cholesky(&gram, k);
+
+        for (speaker, channel) in bed.iter().enumerate().take(FOLD_SPEAKERS) {
+            let Some(channel) = channel.as_deref() else {
+                continue;
+            };
+            if channel.len() < length {
+                continue;
+            }
+            let mut estimate = [0.0f64; MAX_SOURCES];
+            if let Some(factor) = cholesky.as_ref() {
+                let mut rhs = [0.0f64; MAX_SOURCES];
+                for (i, &feed) in feeds.iter().enumerate().take(k) {
+                    rhs[i] = sources[feed][..length]
+                        .iter()
+                        .zip(&channel[..length])
+                        .map(|(&a, &b)| f64::from(a) * f64::from(b))
+                        .sum();
+                }
+                solve(factor, k, &mut rhs);
+                estimate[..k].copy_from_slice(&rhs[..k]);
+            }
+            for feed in 0..count {
+                if plan.unknown & (1 << feed) == 0 {
+                    continue;
+                }
+                let bit = 1u16 << feed;
+                let previous = self.gains[speaker][feed];
+                let measured = feeds[..k]
+                    .iter()
+                    .position(|&f| f == feed)
+                    .map(|i| estimate[i] as f32)
+                    .filter(|g| g.is_finite() && g.abs() <= Self::MAX_GAIN);
+                let target = match measured {
+                    Some(measured) if self.primed & bit != 0 => {
+                        previous + Self::SMOOTHING * (measured - previous)
+                    }
+                    Some(measured) => measured,
+                    None => previous,
+                };
+                let start = if self.primed & bit != 0 {
+                    previous
+                } else {
+                    target
+                };
+                plan.gains[speaker][feed] = start;
+                plan.slope[speaker][feed] = (target - start) / length as f32;
+                plan.used[speaker] |= bit;
+                self.gains[speaker][feed] = target;
+            }
+        }
+        // Every measured waveform is now accounted for and may be rendered.
+        let unknown = plan.unknown & ((1u16 << count) - 1);
+        self.primed |= unknown;
+        plan.unknown &= !unknown;
+    }
+}
+
+/// Lower-triangular Cholesky factor of the leading `k`×`k` block, or `None`
+/// when the matrix is not positive definite (all waveforms silent).
+fn cholesky(
+    matrix: &[[f64; MAX_SOURCES]; MAX_SOURCES],
+    k: usize,
+) -> Option<[[f64; MAX_SOURCES]; MAX_SOURCES]> {
+    if k == 0 {
+        return None;
+    }
+    let mut l = [[0.0f64; MAX_SOURCES]; MAX_SOURCES];
+    for i in 0..k {
+        for j in 0..=i {
+            let mut sum = matrix[i][j];
+            for p in 0..j {
+                sum -= l[i][p] * l[j][p];
+            }
+            if i == j {
+                if sum <= 0.0 {
+                    return None;
+                }
+                l[i][i] = sum.sqrt();
+            } else {
+                l[i][j] = sum / l[j][j];
+            }
+        }
+    }
+    Some(l)
+}
+
+/// Solve L Lᵀ x = b in place, for the leading `k` unknowns.
+fn solve(l: &[[f64; MAX_SOURCES]; MAX_SOURCES], k: usize, b: &mut [f64; MAX_SOURCES]) {
+    for i in 0..k {
+        let mut sum = b[i];
+        for p in 0..i {
+            sum -= l[i][p] * b[p];
+        }
+        b[i] = sum / l[i][i];
+    }
+    for i in (0..k).rev() {
+        let mut sum = b[i];
+        for p in i + 1..k {
+            sum -= l[p][i] * b[p];
+        }
+        b[i] = sum / l[i][i];
     }
 }
 
@@ -1480,6 +1717,176 @@ mod tests {
         for end in 0..payload.len() - 8 {
             assert!(XMetadata::parse(&payload[..end], 1).is_err(), "end {end}");
         }
+    }
+
+    /// Deterministic pseudo-noise in [-1, 1].
+    fn noise(seed: u64, length: usize) -> Vec<f32> {
+        // splitmix64: streams from neighbouring seeds are uncorrelated,
+        // which a linear congruential generator would not give.
+        let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        (0..length)
+            .map(|_| {
+                state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                let mut z = state;
+                z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+                z ^= z >> 31;
+                ((z >> 33) as f32 / (1u64 << 31) as f32) * 2.0 - 1.0
+            })
+            .collect()
+    }
+
+    fn quiet(signal: &[f32]) -> Vec<f32> {
+        signal.iter().map(|v| v * 0.3).collect()
+    }
+
+    fn mixed(dry: &[f32], parts: &[(&[f32], f32)]) -> Vec<f32> {
+        dry.iter()
+            .enumerate()
+            .map(|(s, &v)| v + parts.iter().map(|(x, g)| x[s] * g).sum::<f32>())
+            .collect()
+    }
+
+    fn unknown_objects(count: usize) -> XMetadata {
+        let sources: Vec<SourceMetadata> = (0..count)
+            .map(|i| SourceMetadata {
+                role: SourceRole::Object {
+                    position: SphericalPosition {
+                        azimuth_half_degrees: (i as i16) * 60,
+                        elevation_half_degrees: 0,
+                        distance_64ths: 64,
+                    },
+                    centre_height_alternative: false,
+                },
+                fold: BedFold::Unknown,
+            })
+            .collect();
+        XMetadata::from_sources(&sources).expect("metadata")
+    }
+
+    #[test]
+    fn estimator_recovers_an_unstated_fold_from_the_bed() {
+        let n = 2048;
+        let x = [noise(1, n), noise(2, n)];
+        let dry = [quiet(&noise(3, n)), quiet(&noise(4, n))];
+        let mut bed: Vec<Option<Vec<f32>>> = vec![None; 9];
+        // L carries feed 0 at 0.92 and feed 1 at 0.10; Rs carries feed 1 at 0.34.
+        bed[1] = Some(mixed(&dry[0], &[(&x[0], 0.92), (&x[1], 0.10)]));
+        bed[4] = Some(mixed(&dry[1], &[(&x[1], 0.34)]));
+        bed[0] = Some(dry[0].clone());
+
+        let mut plan = FoldPlan::from_metadata(&unknown_objects(2));
+        assert!(plan.has_unknown());
+        let mut estimator = FoldEstimator::new();
+        estimator.refine(&mut plan, &bed, &x);
+
+        assert!(!plan.has_unknown());
+        assert!(plan.source_is_known(0) && plan.source_is_known(1));
+        assert!(
+            (plan.gain(1, 0) - 0.92).abs() < 0.03,
+            "L/feed0 {}",
+            plan.gain(1, 0)
+        );
+        assert!(
+            (plan.gain(1, 1) - 0.10).abs() < 0.03,
+            "L/feed1 {}",
+            plan.gain(1, 1)
+        );
+        assert!(
+            (plan.gain(4, 1) - 0.34).abs() < 0.03,
+            "Rs/feed1 {}",
+            plan.gain(4, 1)
+        );
+        assert!(plan.gain(4, 0).abs() < 0.03, "Rs/feed0 {}", plan.gain(4, 0));
+        assert!(plan.gain(0, 0).abs() < 0.03, "C carries nothing");
+        // The cleaned L is the dry signal, within the fit's noise.
+        let residual: f32 = (0..n)
+            .map(|s| (plan.clean(1, bed[1].as_ref().unwrap()[s], s, &x) - dry[0][s]).powi(2))
+            .sum::<f32>()
+            / n as f32;
+        assert!(residual < 1e-4, "residual {residual}");
+        // Untouched speakers pass through.
+        assert_eq!(plan.clean(7, 0.25, 3, &x), 0.25);
+    }
+
+    #[test]
+    fn estimator_separates_waveforms_that_share_content() {
+        let n = 2048;
+        let a = noise(11, n);
+        let b: Vec<f32> = noise(12, n)
+            .iter()
+            .zip(&a)
+            .map(|(&y, &x)| 0.6 * x + 0.5 * y)
+            .collect();
+        let x = [a.clone(), b];
+        let mut bed: Vec<Option<Vec<f32>>> = vec![None; 9];
+        // Only feed 0 is in L; a one-at-a-time fit would credit feed 1 too.
+        bed[1] = Some(mixed(&quiet(&noise(13, n)), &[(&x[0], 1.0)]));
+
+        let mut plan = FoldPlan::from_metadata(&unknown_objects(2));
+        FoldEstimator::new().refine(&mut plan, &bed, &x);
+        assert!((plan.gain(1, 0) - 1.0).abs() < 0.05, "{}", plan.gain(1, 0));
+        assert!(plan.gain(1, 1).abs() < 0.05, "{}", plan.gain(1, 1));
+    }
+
+    #[test]
+    fn estimator_ramps_from_the_previous_frame_and_holds_through_silence() {
+        let n = 2048;
+        let x = [noise(21, n)];
+        let mut bed: Vec<Option<Vec<f32>>> = vec![None; 9];
+        bed[2] = Some(mixed(&quiet(&noise(22, n)), &[(&x[0], 0.5)]));
+        let mut estimator = FoldEstimator::new();
+
+        // First frame: no history, the estimate applies flat.
+        let mut plan = FoldPlan::from_metadata(&unknown_objects(1));
+        estimator.refine(&mut plan, &bed, &x);
+        assert!((plan.gain(2, 0) - 0.5).abs() < 0.05);
+        assert_eq!(plan.slope[2][0], 0.0);
+
+        // Second frame at a new gain: starts at the old one and ramps halfway
+        // to the new measurement.
+        bed[2] = Some(mixed(&quiet(&noise(23, n)), &[(&x[0], 0.9)]));
+        let mut plan = FoldPlan::from_metadata(&unknown_objects(1));
+        estimator.refine(&mut plan, &bed, &x);
+        let start = plan.gain(2, 0);
+        let end = start + plan.slope[2][0] * n as f32;
+        assert!((start - 0.5).abs() < 0.05, "start {start}");
+        assert!((end - 0.7).abs() < 0.05, "end {end}");
+        let first = plan.clean(2, bed[2].as_ref().unwrap()[0], 0, &x);
+        assert!((first - (bed[2].as_ref().unwrap()[0] - start * x[0][0])).abs() < 1e-6);
+
+        // Third frame, the waveform silent: the last gains stand, flat, and the
+        // waveform is still rendered (as silence).
+        let silent = [vec![0.0f32; n]];
+        let mut plan = FoldPlan::from_metadata(&unknown_objects(1));
+        estimator.refine(&mut plan, &bed, &silent);
+        assert!(plan.source_is_known(0));
+        assert!((plan.gain(2, 0) - end).abs() < 1e-6);
+        assert_eq!(plan.slope[2][0], 0.0);
+    }
+
+    #[test]
+    fn estimator_leaves_stated_folds_alone() {
+        let n = 2048;
+        let x = [noise(31, n), noise(32, n)];
+        let mut bed: Vec<Option<Vec<f32>>> = vec![None; 9];
+        bed[1] = Some(mixed(&quiet(&noise(33, n)), &[(&x[0], 0.7), (&x[1], 0.7)]));
+        let mut known = [0.0f32; REFERENCE_CHANNELS];
+        known[1] = 0.25; // states feed 0 in L at 0.25, whatever the audio says
+        let sources = [
+            SourceMetadata {
+                role: SourceRole::Height(SpatialChannel::TopFrontLeft),
+                fold: BedFold::Known(known),
+            },
+            unknown_objects(1).source(0).copied().unwrap(),
+        ];
+        let mut plan = FoldPlan::from_metadata(&XMetadata::from_sources(&sources).unwrap());
+        FoldEstimator::new().refine(&mut plan, &bed, &x);
+        assert_eq!(plan.gain(1, 0), 0.25, "a stated gain is not re-estimated");
+        assert!(plan.source_is_known(1));
+        // Feed 1's estimate absorbs what feed 0's stated gain under-removes only
+        // insofar as the two are correlated; independent noise leaves it at 0.7.
+        assert!((plan.gain(1, 1) - 0.7).abs() < 0.1, "{}", plan.gain(1, 1));
     }
 
     #[test]

--- a/dca/src/lib.rs
+++ b/dca/src/lib.rs
@@ -28,7 +28,8 @@ pub use hd::{exss_has_xll, exss_substream_size, HdDecoder, HdError, HdFrame};
 pub use pcm::{CorePcmFrame, DecodeError, PcmDecoder, PcmPushResult, bed_layout};
 pub use spatial::{SpatialChannel, XPresentation};
 pub use dcadec::xmeta::{
-    BedFold, FoldPlan, MAX_SOURCES, REFERENCE_CHANNELS, REFERENCE_MASK_5_1, REFERENCE_MASK_7_1,
+    BedFold, FoldEstimator, FoldPlan, MAX_SOURCES, REFERENCE_CHANNELS, REFERENCE_MASK_5_1,
+    REFERENCE_MASK_7_1,
     REFERENCE_SPEAKERS, SourceMetadata, SourceRole, SphericalPosition, XMetadata, XMetadataError,
     gain_code_linear,
 };

--- a/docs/harletty-cli.md
+++ b/docs/harletty-cli.md
@@ -103,6 +103,7 @@ harletty decode [OPTIONS] <INPUT>
 | `--no-audio` | flag | off | Skip the audio file; still write `.atmos` and `.atmos.metadata`. Much faster when you only want the object automation. |
 | `--presentation <0-3>` | index | `3` | Which TrueHD presentation to decode. `3` is the 16-channel Atmos presentation; `0`–`2` are the stereo/5.1/7.1 downmixes carried in the same stream. **TrueHD only** — silently ignored for E-AC-3 and DTS, which have no equivalent. |
 | `--bed-conform` | flag | off | Force the Atmos bed to a conformant 7.1.2 layout. |
+| `--no-fold-estimate` | flag | off | DTS:X only. A waveform whose bed fold the stream does not state is normally given a fold estimated from the bed's audio, so it plays at its position and leaves the bed. With this flag it stays in the bed and its own channel is muted. |
 | `--warp-mode` | `normal`, `warping`, `prologiciix`, `loro` | *(from stream)* | Downmix warp mode to declare when the metadata does not carry one. |
 | `--no-estimate-progress` | flag | off | Skip the pre-pass that counts frames for the progress bar. Automatic for stdin, which cannot be pre-scanned. |
 

--- a/harletty/src/cli/command.rs
+++ b/harletty/src/cli/command.rs
@@ -83,6 +83,12 @@ pub struct DecodeArgs {
     #[arg(long)]
     pub bed_conform: bool,
 
+    /// Keep a DTS:X waveform whose bed fold the stream does not state in the
+    /// bed, muted on its own channel, instead of estimating its fold from
+    /// the bed and playing it at its position.
+    #[arg(long)]
+    pub no_fold_estimate: bool,
+
     /// Specify warp mode when not present in metadata
     #[arg(long, value_enum)]
     pub warp_mode: Option<WarpMode>,

--- a/harletty/src/cli/decode/decode_impl.rs
+++ b/harletty/src/cli/decode/decode_impl.rs
@@ -7,9 +7,9 @@ use super::handler::{DecodeHandler, FrameHandlerContext, WriterState};
 use super::progress::{create_progress_bar, estimate_total_frames};
 use crate::cli::command::{AudioFormat, Cli, DecodeArgs};
 use crate::codec_probe::{Codec, probe_codec};
-use damf::SourceCodec;
 use crate::input::InputReader;
 use anyhow::Result;
+use damf::SourceCodec;
 use indicatif::{MultiProgress, ProgressStyle};
 use log::Level;
 use std::sync::mpsc;
@@ -315,6 +315,7 @@ fn cmd_decode_dts(
 
     let mut handler = DtsDecodeHandler::default();
     handler.warp_mode = args.warp_mode;
+    handler.estimate_folds = !args.no_fold_estimate;
     let start_time = std::time::Instant::now();
 
     while let Ok(result) = rx.recv() {

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -11,7 +11,9 @@ use crate::cli::command::{AudioFormat, WarpMode};
 use crate::dts_to_oamd::{BedSource, DtsLayout, convert_dts};
 use anyhow::Result;
 use damf::{Configuration, Event, SourceCodec};
-use dca::{CorePcmFrame, FoldPlan, HdFrame, PcmPushResult, XMetadata, XPresentation};
+use dca::{
+    CorePcmFrame, FoldEstimator, FoldPlan, HdFrame, PcmPushResult, XMetadata, XPresentation,
+};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
@@ -72,6 +74,12 @@ pub struct DtsDecodeHandler {
     warned_dropped_channels: bool,
     /// Whether the unreadable-metadata warning has already been emitted.
     warned_unreadable_metadata: bool,
+    /// Estimate the fold of a waveform the stream states none for, from the
+    /// bed's audio, rather than keeping it in the bed muted.
+    pub estimate_folds: bool,
+    estimator: FoldEstimator,
+    /// Whether the estimation has been announced.
+    noted_estimation: bool,
     /// Label for the master set, chosen from the presentation of the first
     /// spatial frame.
     source_codec: SourceCodec,
@@ -124,6 +132,9 @@ impl Default for DtsDecodeHandler {
             metadata_header_written: false,
             warned_dropped_channels: false,
             warned_unreadable_metadata: false,
+            estimate_folds: true,
+            estimator: FoldEstimator::new(),
+            noted_estimation: false,
             source_codec: SourceCodec::DtsX714,
             auro: None,
         }
@@ -251,7 +262,18 @@ impl DtsDecodeHandler {
             .collect();
 
         let layout = DtsLayout::from_hd(&active, presentation, metadata.as_ref());
-        let plan = self.fold_plan(presentation, metadata.as_ref());
+        let mut plan = self.fold_plan(presentation, metadata.as_ref());
+        if presentation.is_some() && self.estimate_folds && plan.has_unknown() {
+            if !self.noted_estimation {
+                self.noted_estimation = true;
+                log::info!(
+                    "DTS:X {:?} carries waveform(s) without a stated bed fold; estimating their fold from the bed",
+                    presentation.expect("checked")
+                );
+            }
+            self.estimator
+                .refine(&mut plan, &frame.samples, &frame.x_samples);
+        }
         // The output carries exactly what the master set declares: the bed the
         // layout resolved (speakers with no OAMD name, i.e. rear centre, are
         // dropped from both) plus one channel per object.
@@ -416,6 +438,8 @@ impl DtsDecodeHandler {
                         "DTS:X {presentation:?} metadata unreadable: {}",
                         if presentation == XPresentation::Height {
                             "assuming the standard -3 dB height fold"
+                        } else if self.estimate_folds {
+                            "estimating the extension feeds' fold from the bed"
                         } else {
                             "keeping the bed as authored and muting the extension feeds"
                         }


### PR DESCRIPTION
## What

A DTS:X extension waveform whose object record carries no reference rows stayed in the bed and its own channel was muted: with the fold gains unstated nothing could be removed, and rendering the waveform on top would have played it twice.

This estimates the fold from the audio instead, in both hosts:

- `dca::FoldEstimator`: per frame and per bed speaker, the least-squares fit of the bed on the unstated waveforms, solved jointly (Cholesky on a K×K normal matrix, K ≤ 9) so two waveforms sharing content are not both credited with it. The fit never adds energy to a speaker within the frame. A silent waveform keeps its last gains; each frame's measurement is averaged with the running gain (halves the fit noise, one frame of lag); `FoldPlan` gained a per-sample slope so gains ramp from the previous frame's value. Fixed-size state, no allocation per frame.
- Bridge: `dts-fold.yaml` → `estimate_unknown: true` (default). Announced once per stream in the log; the estimator resets on a presentation change.
- CLI: on by default, `--no-fold-estimate` keeps the previous behaviour. Documented in `docs/harletty-cli.md`.

## Why the audio, not a law

Two titles without rows were measured end to end (the only two in the local catalogue):

- **Independence Day (D1)**: two static objects at ±34.5°/12°, in the bed at L 0.92 + Ls 0.34 (mirror for the right one), identical at two points ten minutes apart.
- **Ip Man 3 (D4)**: one object sweeping 57° → 180° → −12° at 55–69° elevation; the bed gains follow the transmitted position frame by frame (metadata every 2 frames), as a smooth function of the object-to-speaker angle spread over all seven channels.

Both differ from each other and from the explicit rows the 2018 DTS:X Pro trailer writes (pairwise constant-power over 0/±30/±90/±150°, elevation ignored). Three encoders, three laws, nothing in the stream to pick one by. Every one is deterministic and recoverable from the audio, which is what this does.

## Verification

- `cargo test --workspace` green; new tests: recovery of a two-source fold with independent dry content, separation of two correlated waveforms, ramp from the previous frame and hold through silence, stated folds left alone, and the bridge frame builder with estimation on and off.
- Offline decode of the two excerpts, estimation on vs off:
  - Ip Man 3 burst: rear bed channels −23.7 → −35.5 dBFS, the object plays on its own channel at −15 dBFS; the rest of the excerpt is unchanged.
  - Independence Day: L/R −22.7 → −25.6 dBFS, the two wides play on their channels at −25/−26 dBFS.
- Not yet listened to on the realtime path: the bridge library builds, the integration tree was not rebuilt (it carries another session's uncommitted work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)