### PR TITLE
fix(damf): number the events after the objects the header declares

### DIFF
--- a/damf/src/damf.rs
+++ b/damf/src/damf.rs
@@ -559,6 +559,13 @@ impl Configuration {
             Vec::new()
         };
 
+        // Dynamic objects take the IDs 10, 11, … in the order they appear,
+        // matching the `objects:` list of the header. Counting them as they
+        // come, rather than subtracting the bed size from the index, keeps
+        // the IDs right whether or not the bed objects precede them in
+        // `object_data`: a TrueHD payload lists the bed first, a payload
+        // synthesised for a DTS:X or Auro-3D track lists no bed at all.
+        let mut dynamic_rank = 0usize;
         for i in 0..object_count {
             let object_data = &object_element.object_data[i][0];
             let id = if object_data.b_object_in_bed_or_isf {
@@ -572,7 +579,8 @@ impl Configuration {
                     _ => index + 120,
                 }
             } else {
-                i + 10 - bed_index_vec.len()
+                dynamic_rank += 1;
+                dynamic_rank + 9
             };
 
             let mut event: Event = Event::with_id(id as u32);

--- a/docs/harletty-cli.md
+++ b/docs/harletty-cli.md
@@ -239,12 +239,14 @@ of drift.
 
 ## Known limitations
 
-- **DTS:X object positions are not decoded.** Spatial presentations are
-  exported with their channel layout and labels, but objects sit at
-  static positions; the per-frame trajectories live in a proprietary
-  extension block that this decoder does not read. A DTS:X master set is
-  therefore fine for layout inspection and useless for anything that
-  measures movement.
+- **DTS:X objects are positioned from the stream's own metadata**, frame
+  by frame, so an object that moves in the mix moves in the master set;
+  the fixed heights become bed channels. The private metadata is read
+  from corpus evidence rather than a specification, so the alternate
+  profiles (D0, D1, D3, D4, 5.1+1) are reported as experimental. A
+  waveform whose bed fold the stream does not state has that fold
+  estimated from the bed's audio (see `--no-fold-estimate`), so it plays
+  on its own track and leaves the bed.
 - **Auro-3D is unfolded, not decoded bit-exactly.** A DTS-HD MA track
   that carries an Auro-Codec side channel in its low bits is recognised
   and unfolded into the layout it was encoded from: a `7.1_5H_1T` carrier

--- a/harletty/src/dts_to_oamd.rs
+++ b/harletty/src/dts_to_oamd.rs
@@ -366,6 +366,53 @@ mod tests {
 
     /// Guards the y inversion specifically — a mirrored mapping would still
     /// round-trip if it were applied symmetrically, so pin the encoding too.
+    /// The metadata events must carry the IDs the header declares for the
+    /// objects (10, 11, …), or a DAMF reader cannot pair them with their
+    /// tracks. A synthesised payload lists no bed objects, which once made
+    /// the IDs wrap below zero.
+    #[test]
+    fn event_ids_match_the_declared_objects() {
+        use damf::{Configuration, CreationTool, Data, SourceCodec};
+
+        let layout = DtsLayout {
+            bed: vec![SpeakerLabels::L, SpeakerLabels::R, SpeakerLabels::C],
+            bed_sources: vec![
+                BedSource::Speaker(1),
+                BedSource::Speaker(2),
+                BedSource::Speaker(0),
+            ],
+            objects: vec![[-0.5, 0.75, 0.25], [0.5, -0.75, 0.0], [0.0, 0.0, 1.0]],
+            object_sources: vec![0, 1, 2],
+        };
+        let oamd = convert_dts(&layout);
+        let tool = CreationTool {
+            name: "test",
+            version: "0",
+        };
+        let header = Data::with_oamd_payload(
+            &oamd,
+            std::path::Path::new("test"),
+            SourceCodec::DtsX714Plus4,
+            tool,
+        );
+        // Read the IDs back from the serialised YAML, the form a reader sees.
+        let ids_in = |yaml: &str| -> Vec<u32> {
+            yaml.lines()
+                .filter_map(|line| line.trim().strip_prefix("- ID: "))
+                .filter_map(|id| id.trim().parse().ok())
+                .collect()
+        };
+        let declared: Vec<u32> = ids_in(&header.serialize_damf())
+            .into_iter()
+            .filter(|id| *id >= 10)
+            .collect();
+        assert_eq!(declared, vec![10, 11, 12]);
+
+        let mut events = Configuration::with_oamd_payload(&oamd, 48_000, 0).expect("payload");
+        let ids = ids_in(&events.serialize_events(false));
+        assert_eq!(ids, declared, "events name the declared objects");
+    }
+
     #[test]
     fn oamd_y_axis_is_inverted_relative_to_damf() {
         let front = damf_pos_to_oamd([0.0, 1.0, 0.0]);


### PR DESCRIPTION
## What

The metadata events of a DTS:X or Auro-3D master set carried the IDs `4294967294, 4294967295, 0, 1, …` while the header declared the objects as `10, 11, …`. The event ID was `index + 10 - bed_size`, which assumes the TrueHD payload shape (bed objects first in `object_data`); the payloads synthesised for DTS:X and Auro-3D list no bed objects, so the first dynamic object wrapped below zero. A DAMF reader could not pair events with tracks.

Dynamic objects are now numbered as they come (`10 + rank`), the same value for TrueHD and the right one for the synthesised payloads. Round-trip test added on a synthesised payload: the event IDs equal the header's object list.

Also rewrites the stale "DTS:X object positions are not decoded" limitation in `docs/harletty-cli.md`: positions are read per frame from the stream's metadata, and unstated folds are estimated (#57).

## Verification

- `cargo test -p damf -p harletty` green, TrueHD golden test included.
- Real decodes: Ip Man 3 (D4) events now `10..14` with the moving object on 13; an Auro-3D 13.1 unfold's two static objects on `10, 11`; both match their headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)