### PR TITLE
feat(dts): report what a DTS stream carries, and conform its bed for Atmos

### DIFF
--- a/docs/harletty-cli.md
+++ b/docs/harletty-cli.md
@@ -102,7 +102,7 @@ harletty decode [OPTIONS] <INPUT>
 | `--format` | `caf`, `pcm`, `w64` | `caf` | Audio container. **Ignored for Atmos output**, which is always CAF; see [Output files](#output-files). `pcm` is raw 24-bit little-endian, `w64` is Wave64 with a `.wav` extension. |
 | `--no-audio` | flag | off | Skip the audio file; still write `.atmos` and `.atmos.metadata`. Much faster when you only want the object automation. |
 | `--presentation <0-3>` | index | `3` | Which TrueHD presentation to decode. `3` is the 16-channel Atmos presentation; `0`–`2` are the stereo/5.1/7.1 downmixes carried in the same stream. **TrueHD only** — silently ignored for E-AC-3 and DTS, which have no equivalent. |
-| `--bed-conform` | flag | off | Force the Atmos bed to a conformant 7.1.2 layout. |
+| `--bed-conform` | flag | off | Keep the bed to what an Atmos bed can hold. TrueHD: declare a 7.1.2 bed. DTS:X and Auro-3D: the corner heights (and wides) leave the bed for static objects at their speaker positions, so the master set can feed an Atmos encoder. |
 | `--no-fold-estimate` | flag | off | DTS:X only. A waveform whose bed fold the stream does not state is normally given a fold estimated from the bed's audio, so it plays at its position and leaves the bed. With this flag it stays in the bed and its own channel is muted. |
 | `--warp-mode` | `normal`, `warping`, `prologiciix`, `loro` | *(from stream)* | Downmix warp mode to declare when the metadata does not carry one. |
 | `--no-estimate-progress` | flag | off | Skip the pre-pass that counts frames for the progress bar. Automatic for stdin, which cannot be pre-scanned. |
@@ -149,6 +149,21 @@ OAMD         : yes
 JOC          : yes
 Frames seen  : 47
 ```
+
+DTS (a file or a pipe: `ffmpeg … -c copy -f dts - | harletty info -`),
+read for at most twenty seconds, usually far less:
+
+```
+Codec        : DTS-HD MA
+Channels     : 8
+Sample rate  : 48000 Hz
+Spatial      : DTS:X-7.1.4+5 (ObjectsD4: 5 objects, 4 fixed heights)
+Frames seen  : 33 (0.4 s)
+```
+
+`Spatial` names the presentation the way `decode` labels the master set
+(`DTS:X-7.1.4`, `DTS:X-7.1.4+2`, `Auro-3D-13.1 (7.1_5H_1T carried in
+7.1)`, …), or `none` for a track that carries neither.
 
 ## Output files
 

--- a/harletty/src/cli/command.rs
+++ b/harletty/src/cli/command.rs
@@ -79,7 +79,9 @@ pub struct DecodeArgs {
     #[arg(long)]
     pub no_estimate_progress: bool,
 
-    /// Enable bed conformance for Atmos content
+    /// Keep the bed to what an Atmos bed can hold. TrueHD: declare a 7.1.2
+    /// bed. DTS:X and Auro-3D: the corner heights and wides leave the bed for
+    /// static objects at their speaker positions.
     #[arg(long)]
     pub bed_conform: bool,
 

--- a/harletty/src/cli/decode/decode_impl.rs
+++ b/harletty/src/cli/decode/decode_impl.rs
@@ -316,6 +316,7 @@ fn cmd_decode_dts(
     let mut handler = DtsDecodeHandler::default();
     handler.warp_mode = args.warp_mode;
     handler.estimate_folds = !args.no_fold_estimate;
+    handler.bed_conform = args.bed_conform;
     let start_time = std::time::Instant::now();
 
     while let Ok(result) = rx.recv() {

--- a/harletty/src/cli/decode/dts_handler.rs
+++ b/harletty/src/cli/decode/dts_handler.rs
@@ -77,6 +77,9 @@ pub struct DtsDecodeHandler {
     /// Estimate the fold of a waveform the stream states none for, from the
     /// bed's audio, rather than keeping it in the bed muted.
     pub estimate_folds: bool,
+    /// Keep the bed to what an Atmos bed can hold (7.1.2 at most): a DTS:X
+    /// or Auro-3D layout's corner heights and wides become static objects.
+    pub bed_conform: bool,
     estimator: FoldEstimator,
     /// Whether the estimation has been announced.
     noted_estimation: bool,
@@ -96,6 +99,18 @@ fn auro_source_codec(original: auro::Layout) -> SourceCodec {
         "Auro-3D-11.1" => SourceCodec::Auro3d111,
         "Auro-3D-13.1" => SourceCodec::Auro3d131,
         _ => SourceCodec::Auro3d,
+    }
+}
+
+/// The DAMF codec label of a spatial presentation, as the header writes it.
+pub(crate) fn presentation_label(presentation: XPresentation) -> &'static str {
+    match presentation {
+        XPresentation::Height => "DTS:X-7.1.4",
+        XPresentation::FixedD0 => "DTS:X-7.1.5",
+        XPresentation::ObjectsD1 => "DTS:X-7.1.4+2",
+        XPresentation::ObjectsD3 => "DTS:X-7.1.4+4",
+        XPresentation::ObjectsD4 => "DTS:X-7.1.4+5",
+        XPresentation::ObjectOnly => "DTS:X-5.1+1",
     }
 }
 
@@ -133,6 +148,7 @@ impl Default for DtsDecodeHandler {
             warned_dropped_channels: false,
             warned_unreadable_metadata: false,
             estimate_folds: true,
+            bed_conform: false,
             estimator: FoldEstimator::new(),
             noted_estimation: false,
             source_codec: SourceCodec::DtsX714,
@@ -182,7 +198,7 @@ impl DtsDecodeHandler {
             return Ok(());
         }
         let sample_count = frame.samples.len() / ns;
-        let layout = DtsLayout::from_auro(&frame.streams);
+        let layout = DtsLayout::from_auro(&frame.streams, self.bed_conform);
         let total_channels = layout.bed.len() + layout.objects.len();
         if total_channels < ns {
             self.warn_dropped_channels(ns - total_channels);
@@ -261,7 +277,7 @@ impl DtsDecodeHandler {
             .filter(|&s| frame.samples[s].is_some())
             .collect();
 
-        let layout = DtsLayout::from_hd(&active, presentation, metadata.as_ref());
+        let layout = DtsLayout::from_hd(&active, presentation, metadata.as_ref(), self.bed_conform);
         let mut plan = self.fold_plan(presentation, metadata.as_ref());
         if presentation.is_some() && self.estimate_folds && plan.has_unknown() {
             if !self.noted_estimation {

--- a/harletty/src/cli/dts_info.rs
+++ b/harletty/src/cli/dts_info.rs
@@ -1,0 +1,219 @@
+// `harletty info` on a DTS stream: what the first seconds establish about
+// it, without decoding the rest. Reads a pipe as well as a file, so a
+// player or a front end can ask `ffmpeg … -f dts - | harletty info -` what
+// a track carries before committing to a full extraction.
+//
+// Reported: the codec (core only, or DTS-HD MA when an XLL substream
+// follows), the bed, the spatial presentation the extension declares (the
+// DTS:X profile, or an Auro-3D carrier found in the low bits), and how many
+// frames were needed to say so.
+
+use anyhow::Result;
+use dca::{
+    HdDecoder, HdError, PcmDecoder, XPresentation, exss_has_xll, exss_substream_size, parse_header,
+};
+
+use super::command::InfoArgs;
+use super::decode::dts_handler::presentation_label;
+use crate::input::InputReader;
+
+const CORE_SYNC: [u8; 4] = dca::SYNCWORD_CORE_BE.to_be_bytes();
+const SUBSTREAM_SYNC: [u8; 4] = dca::SYNCWORD_SUBSTREAM.to_be_bytes();
+/// Seconds of audio inspected at most, for a stream whose lossless frames
+/// are slow to come (peak-bitrate buffering).
+const MAX_SECONDS: u64 = 20;
+/// Bytes read at most, whatever the sample rate says.
+const MAX_BYTES: usize = 96 * 1024 * 1024;
+
+#[derive(Default)]
+struct Survey {
+    frames: u64,
+    samples: u64,
+    sample_rate: u32,
+    lossless: bool,
+    bed_channels: usize,
+    presentation: Option<XPresentation>,
+    auro: Option<auro::Detection>,
+    auro_decided: bool,
+    detector: Option<auro::detect::Detector>,
+}
+
+impl Survey {
+    /// A DTS:X presentation shows on the first lossless frame and an Auro-3D
+    /// carrier declares itself within its first blocks, and a stream is one
+    /// or the other; a plain track is called plain once the carrier verdict
+    /// is in and two seconds went by without a presentation.
+    fn done(&self) -> bool {
+        let seconds = self.samples / u64::from(self.sample_rate.max(1));
+        self.presentation.is_some()
+            || self.auro.is_some()
+            || (self.auro_decided && seconds >= 2)
+            || seconds >= MAX_SECONDS
+    }
+
+    fn hd_frame(&mut self, frame: &dca::HdFrame, decoder: &HdDecoder) {
+        self.frames += 1;
+        self.lossless = true;
+        self.sample_rate = frame.sample_rate;
+        self.bed_channels = frame.samples.iter().filter(|s| s.is_some()).count();
+        let n = frame.bed_sample_count() as u64;
+        if let Some(presentation) = XPresentation::detect(frame) {
+            self.presentation = Some(presentation);
+        }
+        if !self.auro_decided {
+            let detector = self
+                .detector
+                .get_or_insert_with(|| auro::detect::Detector::new(frame.samples.len()));
+            for (speaker, samples) in decoder.lossless_samples() {
+                if let Some(detection) = detector.push(speaker, samples) {
+                    self.auro = Some(detection);
+                    self.auro_decided = true;
+                }
+            }
+            // The stage that unfolds gives a carrier this long to declare
+            // itself; past that it is played as it is.
+            if self.samples + n > (3 * auro::block::MAX_BLOCK + 4096) as u64 {
+                self.auro_decided = true;
+            }
+        }
+        self.samples += n;
+    }
+
+    fn core_frame(&mut self, push: &dca::PcmPushResult) {
+        self.frames += 1;
+        self.auro_decided = true;
+        if self.sample_rate == 0 {
+            self.sample_rate = push.pcm.sample_rate;
+        }
+        if self.bed_channels == 0 {
+            self.bed_channels =
+                push.pcm.fullband_channels.len() + usize::from(push.pcm.lfe_channel.is_some());
+        }
+        self.samples += push
+            .pcm
+            .fullband_channels
+            .first()
+            .map_or(0, |channel| channel.len() as u64);
+    }
+
+    fn print(&self) {
+        println!(
+            "Codec        : {}",
+            if self.lossless { "DTS-HD MA" } else { "DTS" }
+        );
+        println!("Channels     : {}", self.bed_channels);
+        println!("Sample rate  : {} Hz", self.sample_rate);
+        let spatial = if let Some(presentation) = self.presentation {
+            let objects = presentation.object_feeds().len();
+            let fixed = presentation.fixed_feeds().len();
+            format!(
+                "{} ({presentation:?}: {objects} object{}, {fixed} fixed height{})",
+                presentation_label(presentation),
+                if objects == 1 { "" } else { "s" },
+                if fixed == 1 { "" } else { "s" }
+            )
+        } else if let Some(detection) = &self.auro {
+            format!(
+                "{} ({} carried in {})",
+                detection.original.source_codec_label(),
+                detection.original.name().unwrap_or("?"),
+                detection.carrier.name().unwrap_or("?")
+            )
+        } else {
+            "none".to_string()
+        };
+        println!("Spatial      : {spatial}");
+        println!(
+            "Frames seen  : {} ({:.1} s)",
+            self.frames,
+            self.samples as f64 / f64::from(self.sample_rate.max(1))
+        );
+    }
+}
+
+pub fn cmd_info_dts(reader: &mut InputReader, prefix: Vec<u8>, args: &InfoArgs) -> Result<()> {
+    log::info!("Analyzing DTS stream: {}", args.input.display());
+    let mut buffer = prefix;
+    let mut core = PcmDecoder::new();
+    let mut hd = HdDecoder::new();
+    let mut survey = Survey::default();
+    let mut total = buffer.len();
+    let mut chunk = vec![0u8; 256 * 1024];
+    loop {
+        drain(&mut buffer, &mut core, &mut hd, &mut survey);
+        if survey.done() || total >= MAX_BYTES {
+            break;
+        }
+        let read = reader.read_chunk(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        total += read;
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+    if survey.frames == 0 {
+        println!("No DTS frame found in the input.");
+        return Ok(());
+    }
+    survey.print();
+    Ok(())
+}
+
+/// Decode every complete frame in `buffer`, then drop the consumed bytes.
+fn drain(buffer: &mut Vec<u8>, core: &mut PcmDecoder, hd: &mut HdDecoder, survey: &mut Survey) {
+    let mut consumed = 0usize;
+    loop {
+        let rest = &buffer[consumed..];
+        let Some(offset) = rest.windows(4).position(|w| w == CORE_SYNC) else {
+            consumed += rest.len().saturating_sub(3);
+            break;
+        };
+        consumed += offset;
+        let rest = &buffer[consumed..];
+        let info = match parse_header(rest) {
+            Ok(info) => info,
+            Err(dca::HeaderParseError::InsufficientData) => break,
+            Err(_) => {
+                consumed += 4;
+                continue;
+            }
+        };
+        let core_size = info.frame_size;
+        if rest.len() < core_size + 4 {
+            break;
+        }
+        let mut frame_size = core_size;
+        let mut exss = None;
+        if rest[core_size..core_size + 4] == SUBSTREAM_SYNC {
+            let Some(exss_size) = exss_substream_size(&rest[core_size..]) else {
+                break;
+            };
+            if rest.len() < core_size + exss_size {
+                break;
+            }
+            frame_size = core_size + exss_size;
+            let candidate = &rest[core_size..frame_size];
+            if exss_has_xll(candidate) {
+                exss = Some(candidate);
+            }
+        }
+        let decoded_lossless = match exss.map(|exss| hd.decode(&rest[..core_size], exss)) {
+            Some(Ok(frame)) => {
+                survey.hd_frame(&frame, hd);
+                true
+            }
+            Some(Err(HdError::Pending)) => true,
+            Some(Err(_)) | None => false,
+        };
+        if !decoded_lossless {
+            if let Ok(push) = core.push_access_unit(&rest[..core_size]) {
+                survey.core_frame(&push);
+            }
+        }
+        consumed += frame_size;
+        if survey.done() {
+            break;
+        }
+    }
+    buffer.drain(..consumed);
+}

--- a/harletty/src/cli/info.rs
+++ b/harletty/src/cli/info.rs
@@ -16,7 +16,12 @@ use truehd::structs::channel::{ChannelGroup, ChannelLabel};
 
 pub fn cmd_info(args: &InfoArgs, cli: &Cli, multi: Option<&MultiProgress>) -> Result<()> {
     let mut probe_reader = InputReader::new(&args.input)?;
-    let (codec, _prefix) = probe_codec(&mut probe_reader, cli.codec)?;
+    let (codec, prefix) = probe_codec(&mut probe_reader, cli.codec)?;
+
+    if codec == Codec::Dts {
+        // Keeps reading the same handle: the input may be a pipe.
+        return super::dts_info::cmd_info_dts(&mut probe_reader, prefix, args);
+    }
     drop(probe_reader);
 
     if codec == Codec::Eac3 {

--- a/harletty/src/cli/mod.rs
+++ b/harletty/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod command;
 pub(crate) mod decode;
+pub(crate) mod dts_info;
 pub(crate) mod info;
 pub(crate) mod inspect;

--- a/harletty/src/dts_to_oamd.rs
+++ b/harletty/src/dts_to_oamd.rs
@@ -115,7 +115,71 @@ pub fn spatial_channel_to_speaker(channel: SpatialChannel) -> Option<SpeakerLabe
     })
 }
 
+/// Whether an OAMD speaker belongs to the Atmos bed (up to 7.1.2). Anything
+/// else a DTS:X or Auro-3D layout puts in the bed — the four corner heights,
+/// the wides — has no place in a bed an Atmos encoder accepts.
+fn is_atmos_bed_speaker(speaker: SpeakerLabels) -> bool {
+    matches!(
+        speaker,
+        SpeakerLabels::L
+            | SpeakerLabels::R
+            | SpeakerLabels::C
+            | SpeakerLabels::LFE
+            | SpeakerLabels::Lss
+            | SpeakerLabels::Rss
+            | SpeakerLabels::Lrs
+            | SpeakerLabels::Rrs
+            | SpeakerLabels::Lts
+            | SpeakerLabels::Rts
+    )
+}
+
+/// Where a bed speaker sits as a static object, in DAMF space (x right,
+/// y front, z up, each -1..=1): the heights at the ceiling corners, the
+/// wides on the side walls ahead of the listener.
+fn static_speaker_position(speaker: SpeakerLabels) -> [f64; 3] {
+    match speaker {
+        SpeakerLabels::Lfh => [-1.0, 1.0, 1.0],
+        SpeakerLabels::Rfh => [1.0, 1.0, 1.0],
+        SpeakerLabels::Lrh => [-1.0, -1.0, 1.0],
+        SpeakerLabels::Rrh => [1.0, -1.0, 1.0],
+        SpeakerLabels::Lw => [-1.0, 0.5, 0.0],
+        SpeakerLabels::Rw => [1.0, 0.5, 0.0],
+        SpeakerLabels::Lts => [-1.0, 0.0, 1.0],
+        SpeakerLabels::Rts => [1.0, 0.0, 1.0],
+        SpeakerLabels::L => [-1.0, 1.0, 0.0],
+        SpeakerLabels::R => [1.0, 1.0, 0.0],
+        SpeakerLabels::C | SpeakerLabels::LFE | SpeakerLabels::LFE2 => [0.0, 1.0, 0.0],
+        SpeakerLabels::Lss => [-1.0, 0.0, 0.0],
+        SpeakerLabels::Rss => [1.0, 0.0, 0.0],
+        SpeakerLabels::Lrs => [-1.0, -1.0, 0.0],
+        SpeakerLabels::Rrs => [1.0, -1.0, 0.0],
+    }
+}
+
 impl DtsLayout {
+    /// Move every bed speaker an Atmos bed cannot hold out of `pairs` and
+    /// into the objects, as a static object at the speaker's position. The
+    /// object's source is the pair's source index, whichever kind it was.
+    fn conform_bed(
+        pairs: &mut Vec<(SpeakerLabels, BedSource)>,
+        objects: &mut Vec<[f64; 3]>,
+        object_sources: &mut Vec<usize>,
+    ) {
+        let mut kept = Vec::with_capacity(pairs.len());
+        for (speaker, source) in pairs.drain(..) {
+            if is_atmos_bed_speaker(speaker) {
+                kept.push((speaker, source));
+            } else {
+                objects.push(static_speaker_position(speaker));
+                object_sources.push(match source {
+                    BedSource::Speaker(index) | BedSource::Feed(index) => index,
+                });
+            }
+        }
+        *pairs = kept;
+    }
+
     /// Layout of a plain DTS core frame: a bed, no objects.
     ///
     /// The decoder hands back fullband channels then LFE; this reorders them
@@ -147,10 +211,15 @@ impl DtsLayout {
     /// `active_speakers` are the DCA speaker indices present in the frame, in
     /// ascending order — the same order the realtime pipeline emits channels
     /// in, so the ADM channel order matches the audio it describes.
+    ///
+    /// `conform`: keep only what an Atmos bed can hold (up to 7.1.2) in the
+    /// bed; the corner heights and wides become static objects at their
+    /// speaker positions, so the master set can feed an Atmos encoder.
     pub fn from_hd(
         active_speakers: &[usize],
         presentation: Option<XPresentation>,
         metadata: Option<&XMetadata>,
+        conform: bool,
     ) -> Self {
         let mut pairs: Vec<(SpeakerLabels, BedSource)> = active_speakers
             .iter()
@@ -182,6 +251,9 @@ impl DtsLayout {
                 objects.push(position);
                 object_sources.push(feed);
             }
+        }
+        if conform {
+            Self::conform_bed(&mut pairs, &mut objects, &mut object_sources);
         }
 
         let (bed, bed_sources) = Self::from_pairs(pairs);
@@ -230,7 +302,10 @@ impl DtsLayout {
     /// unfolder interleaves them. Streams with a speaker name join the bed;
     /// the centre height and the top become objects at fixed positions;
     /// anything else (a rear centre) is dropped.
-    pub fn from_auro(streams: &[auro::StreamId]) -> Self {
+    ///
+    /// `conform` as in [`DtsLayout::from_hd`]: the corner heights leave the
+    /// bed for static objects too.
+    pub fn from_auro(streams: &[auro::StreamId], conform: bool) -> Self {
         let mut pairs = Vec::new();
         let mut objects = Vec::new();
         let mut object_sources = Vec::new();
@@ -241,6 +316,9 @@ impl DtsLayout {
                 objects.push(position);
                 object_sources.push(index);
             }
+        }
+        if conform {
+            Self::conform_bed(&mut pairs, &mut objects, &mut object_sources);
         }
         let (bed, bed_sources) = Self::from_pairs(pairs);
         Self {
@@ -413,6 +491,71 @@ mod tests {
         assert_eq!(ids, declared, "events name the declared objects");
     }
 
+    /// With `conform`, a 7.1.4 DTS:X layout keeps a 7.1 bed and carries the
+    /// four heights as static objects at the ceiling corners, so an Atmos
+    /// encoder can take the master set.
+    #[test]
+    fn conform_moves_the_heights_out_of_the_bed_into_static_objects() {
+        let free = DtsLayout::from_hd(
+            &[0, 1, 2, 3, 4, 5, 7, 8],
+            Some(XPresentation::Height),
+            None,
+            false,
+        );
+        assert_eq!(free.bed.len(), 12);
+        assert!(free.objects.is_empty());
+
+        let layout = DtsLayout::from_hd(
+            &[0, 1, 2, 3, 4, 5, 7, 8],
+            Some(XPresentation::Height),
+            None,
+            true,
+        );
+        assert_eq!(layout.bed.len(), 8, "7.1 stays");
+        assert!(!layout.bed.contains(&SpeakerLabels::Lfh));
+        assert_eq!(layout.objects.len(), 4);
+        assert_eq!(
+            layout.object_sources,
+            vec![0, 1, 2, 3],
+            "the height feeds, in feed order"
+        );
+        assert_eq!(
+            layout.objects[0],
+            [-1.0, 1.0, 1.0],
+            "TFL at the front-left corner"
+        );
+        assert_eq!(
+            layout.objects[3],
+            [1.0, -1.0, 1.0],
+            "TBR at the back-right corner"
+        );
+
+        // Objects declared by the stream come first, then the heights.
+        let d4 = DtsLayout::from_hd(
+            &[0, 1, 2, 3, 4, 5, 7, 8],
+            Some(XPresentation::ObjectsD4),
+            None,
+            true,
+        );
+        assert_eq!(d4.bed.len(), 8);
+        assert_eq!(d4.object_sources, vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(d4.objects[5], [-1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn conform_keeps_an_unfolded_auro_bed_to_seven_one() {
+        let streams: Vec<auro::StreamId> = (0..=14).map(auro::StreamId).collect();
+        let layout = DtsLayout::from_auro(&streams, true);
+        assert_eq!(layout.bed.len(), 8);
+        assert!(layout.bed.iter().all(|s| !matches!(
+            s,
+            SpeakerLabels::Lfh | SpeakerLabels::Rfh | SpeakerLabels::Lrh | SpeakerLabels::Rrh
+        )));
+        // Centre height, top, then the four corner heights.
+        assert_eq!(layout.object_sources, vec![11, 12, 9, 10, 13, 14]);
+        assert_eq!(layout.objects[2], [-1.0, 1.0, 1.0]);
+    }
+
     #[test]
     fn oamd_y_axis_is_inverted_relative_to_damf() {
         let front = damf_pos_to_oamd([0.0, 1.0, 0.0]);
@@ -472,8 +615,12 @@ mod tests {
     #[test]
     fn standard_height_extends_the_bed_to_7_1_4() {
         // A full 7.1 lossless bed: every DCA speaker except rear centre.
-        let layout =
-            DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::Height), None);
+        let layout = DtsLayout::from_hd(
+            &[0, 1, 2, 3, 4, 5, 7, 8],
+            Some(XPresentation::Height),
+            None,
+            false,
+        );
         assert_eq!(
             layout.bed,
             vec![
@@ -506,6 +653,7 @@ mod tests {
             &[0, 1, 2, 3, 4, 5, 7, 8],
             Some(XPresentation::FixedD0),
             None,
+            false,
         );
         assert_eq!(
             XPresentation::FixedD0.feed_count(),
@@ -523,11 +671,12 @@ mod tests {
 
     #[test]
     fn d1_is_two_objects_and_four_heights() {
-        let bed_only = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], None, None);
+        let bed_only = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], None, None, false);
         let layout = DtsLayout::from_hd(
             &[0, 1, 2, 3, 4, 5, 7, 8],
             Some(XPresentation::ObjectsD1),
             None,
+            false,
         );
         assert_eq!(
             layout.bed.len(),
@@ -597,11 +746,12 @@ mod tests {
         ])
         .unwrap();
 
-        let bed_only = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], None, None);
+        let bed_only = DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], None, None, false);
         let layout = DtsLayout::from_hd(
             &[0, 1, 2, 3, 4, 5, 7, 8],
             Some(XPresentation::ObjectsD3),
             Some(&metadata),
+            false,
         );
         assert_eq!(layout.bed.len(), bed_only.bed.len() + 4);
         assert_eq!(layout.object_sources, vec![0, 1, 2, 3]);
@@ -645,7 +795,7 @@ mod tests {
             .iter()
             .map(|&id| auro::StreamId(id))
             .collect();
-        let layout = DtsLayout::from_auro(&streams);
+        let layout = DtsLayout::from_auro(&streams, false);
         assert_eq!(layout.bed.len(), 12);
         assert_eq!(layout.objects.len(), 2);
         // HC (index 10 in the stream order) then T (index 13).
@@ -661,7 +811,7 @@ mod tests {
 
     #[test]
     fn a_frame_with_no_presentation_is_just_its_bed() {
-        let layout = DtsLayout::from_hd(&[1, 2], None, None);
+        let layout = DtsLayout::from_hd(&[1, 2], None, None, false);
         assert_eq!(layout.bed, vec![SpeakerLabels::L, SpeakerLabels::R]);
         assert!(layout.objects.is_empty());
     }
@@ -718,8 +868,12 @@ mod tests {
     /// sorted in among the speakers, not appended.
     #[test]
     fn height_feeds_sort_into_the_bed_rather_than_trailing_it() {
-        let layout =
-            DtsLayout::from_hd(&[0, 1, 2, 3, 4, 5, 7, 8], Some(XPresentation::Height), None);
+        let layout = DtsLayout::from_hd(
+            &[0, 1, 2, 3, 4, 5, 7, 8],
+            Some(XPresentation::Height),
+            None,
+            false,
+        );
         assert_eq!(layout.bed.len(), layout.bed_sources.len());
 
         let mut sorted = layout.bed.clone();


### PR DESCRIPTION
## What

Two things a front end (AtmosFer) needs before it can take a DTS:X or Auro-3D track as the spatial source of a master set.

- **`harletty info` on DTS**, file or pipe (`ffmpeg … -c copy -f dts - | harletty info -`). Reads at most twenty seconds, usually far less, and prints the codec, bed, sample rate and the spatial presentation named the way `decode` labels the master set: the DTS:X profile (first lossless frame), an Auro-3D carrier (low bits, within its first blocks), or `none` once the carrier verdict is in and two seconds passed without a presentation. MediaInfo and ffprobe cannot tell: alternate DTS:X profiles read as plain DTS-HD MA there, and Auro-3D hides in the PCM.
- **`--bed-conform` for DTS:X and Auro-3D**: the corner heights and wides leave the bed for static objects at their speaker positions; the bed stays 7.1 and the objects are numbered after the stream's own. Without it the master set declares a 7.1.4 bed (IDs 130-133) that no Atmos encoder accepts. Off by default.

## Verification

- `cargo test -p harletty` green; tests added for the conformed layouts (DTS:X Height and D4, Auro 13.1).
- `info` on real streams: DTS:X Pro trailer → `DTS:X-7.1.4+5` in 0.4 s; Independence Day → `DTS:X-7.1.4+2`; an Auro-3D demo → `Auro-3D-13.1 (7.1_5H_1T carried in 7.1)`, also through a pipe; a plain 5.1 DTS-HD MA → `none` after 2 s.
- `decode --bed-conform` on the trailer: 7.1 bed + 9 objects (IDs 10-18); on the Auro demo: 7.1 bed + 6 objects, 14-channel CAF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)